### PR TITLE
Activity parameter for manager messages

### DIFF
--- a/base/io/src/main/java/org/almostrealism/io/Console.java
+++ b/base/io/src/main/java/org/almostrealism/io/Console.java
@@ -131,14 +131,14 @@ public class Console {
 	 *
 	 * @param s the string to print
 	 */
-	public void print(String s) {
+	public synchronized void print(String s) {
 		String orig = s;
 		s = prep(s);
 		if (s == null) return;
-		
+
 		append(s);
 		lastLine.append(s);
-		
+
 		if (parent == null) {
 			if (systemOutEnabled) System.out.print(s);
 		} else {
@@ -152,35 +152,35 @@ public class Console {
 	 *
 	 * @param s the string to print
 	 */
-	public void println(String s) {
+	public synchronized void println(String s) {
 		String orig = s;
 		s = prep(s);
 		if (s == null) return;
 
 		append(s);
 		append("\n");
-		
+
 		lastLine.append(s);
 		resetLastLine = true;
-		
+
 		if (parent == null) {
 			if (systemOutEnabled) System.out.println(s);
 		} else {
 			parent.println(orig);
 		}
 	}
-	
+
 	/**
 	 * Prints a newline to the console.
 	 */
-	public void println() {
+	public synchronized void println() {
 		if (resetLastLine) {
 			lastLine = new StringBuilder();
 		}
-		
+
 		append("\n");
 		resetLastLine = true;
-		
+
 		if (parent == null) {
 			if (systemOutEnabled) System.out.println();
 		} else {
@@ -193,7 +193,7 @@ public class Console {
 	 *
 	 * @return the last line, without timestamp prefix
 	 */
-	public String lastLine() { return lastLine.toString(); }
+	public synchronized String lastLine() { return lastLine.toString(); }
 
 	/** Appends text to the console output and notifies all listeners. */
 	protected void append(String s) {

--- a/flowtree/src/main/java/io/flowtree/jobs/ClaudeCodeJob.java
+++ b/flowtree/src/main/java/io/flowtree/jobs/ClaudeCodeJob.java
@@ -133,6 +133,8 @@ public class ClaudeCodeJob extends GitManagedJob {
     private boolean enforceChanges;
     /** Number of times enforcement has been re-attempted after an empty commit. */
     private int enforcementAttempt;
+    /** Enforcement rule name for the current correction session; {@code null} during primary runs. */
+    private String currentActivity;
     /** Description of a git-tampering rule violation detected during this job. */
     private String gitTamperingViolation;
     /**
@@ -730,7 +732,7 @@ public class ClaudeCodeJob extends GitManagedJob {
                             + "': correction attempt " + attempts);
                     String correctionPrompt = rule.buildCorrectionPrompt(this);
                     if (correctionPrompt != null) {
-                        runCorrectionSession(correctionPrompt);
+                        runCorrectionSession(correctionPrompt, rule.getName());
                     } else {
                         // Re-run with the existing prompt; the job's built-in instruction
                         // context (e.g., enforceChanges) already provides correction guidance.
@@ -758,21 +760,17 @@ public class ClaudeCodeJob extends GitManagedJob {
     }
 
     /**
-     * Runs a correction session inline with the specified prompt replacing the
-     * primary job's prompt for the duration of the session.
+     * Runs a correction session tagged with {@code activity} (the rule name)
+     * via {@code AR_AGENT_ACTIVITY} so {@code send_message} calls are labelled.
      *
-     * <p>The original prompt is always restored in a {@code finally} block.
-     * Any commit message written by the primary agent is also saved and
-     * restored, preventing correction sessions from overwriting it.</p>
-     *
-     * @param correctionPrompt the prompt to use for the correction session
+     * @param correctionPrompt prompt for this session
+     * @param activity         rule name used as the activity tag
      */
-    private void runCorrectionSession(String correctionPrompt) {
+    private void runCorrectionSession(String correctionPrompt, String activity) {
         String originalPrompt = this.prompt;
-
-        // Preserve the primary agent's commit.txt so the correction session cannot
-        // overwrite it.  executeSingleRun() deletes any stale commit.txt at startup,
-        // so we read the content now and write it back in finally.
+        String previousActivity = this.currentActivity;
+        this.currentActivity = activity;
+        // Preserve commit.txt so the correction session cannot overwrite it.
         Path commitFile = resolveWorkingPath("commit.txt");
         String savedCommitMessage = null;
         if (commitFile != null && Files.exists(commitFile)) {
@@ -788,7 +786,7 @@ public class ClaudeCodeJob extends GitManagedJob {
             executeSingleRun();
         } finally {
             this.prompt = originalPrompt;
-
+            this.currentActivity = previousActivity;
             if (commitFile != null) {
                 try {
                     if (savedCommitMessage != null) {
@@ -935,6 +933,11 @@ public class ClaudeCodeJob extends GitManagedJob {
                 log("AR_WORKSTREAM_URL: " + wsUrl);
             }
 
+            if (currentActivity != null && !currentActivity.isEmpty()) {
+                pb.environment().put("AR_AGENT_ACTIVITY", currentActivity);
+            } else {
+                pb.environment().remove("AR_AGENT_ACTIVITY");
+            }
             GitOperations.augmentPath(pb);
 
             log("Command: " + String.join(" ", command));

--- a/flowtree/src/main/java/io/flowtree/jobs/ClaudeCodeJob.java
+++ b/flowtree/src/main/java/io/flowtree/jobs/ClaudeCodeJob.java
@@ -710,7 +710,7 @@ public class ClaudeCodeJob extends GitManagedJob {
      * <p>Exits early if the agent commits during a correction session — the
      * tampering-detection path in {@link GitManagedJob} handles that case.</p>
      */
-    private void runEnforcementRules() {
+    void runEnforcementRules() {
         List<EnforcementRule> rules = buildActiveRules();
         boolean anyRuleCorrectionRan;
         do {
@@ -766,7 +766,7 @@ public class ClaudeCodeJob extends GitManagedJob {
      * @param correctionPrompt prompt for this session
      * @param activity         rule name used as the activity tag
      */
-    private void runCorrectionSession(String correctionPrompt, String activity) {
+    protected void runCorrectionSession(String correctionPrompt, String activity) {
         String originalPrompt = this.prompt;
         String previousActivity = this.currentActivity;
         this.currentActivity = activity;

--- a/flowtree/src/main/java/io/flowtree/node/Node.java
+++ b/flowtree/src/main/java/io/flowtree/node/Node.java
@@ -1490,7 +1490,14 @@ public class Node implements Runnable, ThreadFactory, ConsoleFeatures {
 			this.relaySum += r;
 			this.relayDiv++;
 
-			r: if ((isRelay ? js > 0 : js > this.minJobs) && Math.random() < r) {
+			// Worker nodes should only relay when currently executing a job
+			// (so they have a genuine backlog) or when the queue has more
+			// jobs than a single worker thread can immediately absorb (> 1).
+			// This prevents eager relay-back to the controller by idle workers
+			// that received a job before their worker thread had a chance to run.
+			boolean shouldRelay = isRelay ? js > 0
+					: (js > this.minJobs && (this.working || js > 1));
+			r: if (shouldRelay && Math.random() < r) {
 				Connection c;
 
 				if (Math.random() < this.parentalRelayP ||

--- a/flowtree/src/main/java/io/flowtree/slack/FlowTreeApiEndpoint.java
+++ b/flowtree/src/main/java/io/flowtree/slack/FlowTreeApiEndpoint.java
@@ -512,7 +512,7 @@ public class FlowTreeApiEndpoint extends NanoHTTPD implements ConsoleFeatures {
             return "workstream missing repoUrl or defaultBranch";
         }
         String tagsJson = (activity != null && !activity.isEmpty())
-            ? "[\"message\",\"activity:" + activity.replace("\"", "\\\"") + "\"]"
+            ? "[\"message\"," + escapeJsonValue("activity:" + activity) + "]"
             : "[\"message\"]";
 
         String url = memoryServerUrl.replaceAll("/+$", "") + "/api/memory/store";

--- a/flowtree/src/main/java/io/flowtree/slack/FlowTreeApiEndpoint.java
+++ b/flowtree/src/main/java/io/flowtree/slack/FlowTreeApiEndpoint.java
@@ -437,10 +437,8 @@ public class FlowTreeApiEndpoint extends NanoHTTPD implements ConsoleFeatures {
     /**
      * Handles POST to {@code /api/workstreams/{id}/messages} or
      * {@code /api/workstreams/{id}/jobs/{jobId}/messages}.
-     *
-     * <p>Posts a message to the workstream's channel. When a
-     * {@code jobId} is present, the controller can optionally thread the
-     * message under that job's thread.</p>
+     * An optional {@code activity} field in the body is stored as an
+     * {@code activity:<value>} tag for enforcement-phase filtering.
      */
     private Response handleMessage(IHTTPSession session, String workstreamId, String jobId) {
         String body = readBody(session);
@@ -453,6 +451,7 @@ public class FlowTreeApiEndpoint extends NanoHTTPD implements ConsoleFeatures {
             return errorResponse("Missing required field: text");
         }
 
+        String activity = extractJsonField(body, "activity");
         SlackNotifier targetNotifier = notifiers.notifierFor(workstreamId);
         Workstream workstream = targetNotifier != null
                 ? targetNotifier.getWorkstream(workstreamId) : null;
@@ -466,7 +465,7 @@ public class FlowTreeApiEndpoint extends NanoHTTPD implements ConsoleFeatures {
         // warning if memory server is not configured at all (minimal deployment)
         String repoUrl = workstream.getRepoUrl();
         String branch = workstream.getDefaultBranch();
-        String storeError = storeMessageAsMemory(text, repoUrl, branch);
+        String storeError = storeMessageAsMemory(text, repoUrl, branch, activity);
         if (storeError != null) {
             if (memoryServerUrl != null && !memoryServerUrl.isEmpty()) {
                 // Memory server is configured but storage failed — hard error
@@ -500,28 +499,29 @@ public class FlowTreeApiEndpoint extends NanoHTTPD implements ConsoleFeatures {
 
     /**
      * Stores a message in the ar-memory server's "messages" namespace.
+     * A non-empty {@code activity} is appended as an {@code activity:<value>} tag.
      *
-     * @param text    the message content
-     * @param repoUrl the repository URL for the memory entry
-     * @param branch  the branch name for the memory entry
+     * @param activity enforcement phase name, or null/empty for primary work
      * @return null on success, or an error description on failure
      */
-    private String storeMessageAsMemory(String text, String repoUrl, String branch) {
+    private String storeMessageAsMemory(String text, String repoUrl, String branch, String activity) {
         if (memoryServerUrl == null || memoryServerUrl.isEmpty()) {
             return "memory server URL not configured";
         }
         if (repoUrl == null || repoUrl.isEmpty() || branch == null || branch.isEmpty()) {
             return "workstream missing repoUrl or defaultBranch";
         }
+        String tagsJson = (activity != null && !activity.isEmpty())
+            ? "[\"message\",\"activity:" + activity.replace("\"", "\\\"") + "\"]"
+            : "[\"message\"]";
 
         String url = memoryServerUrl.replaceAll("/+$", "") + "/api/memory/store";
         String payload = "{\"content\":" + escapeJsonValue(text)
             + ",\"repo_url\":" + escapeJsonValue(repoUrl)
             + ",\"branch\":" + escapeJsonValue(branch)
             + ",\"namespace\":\"messages\""
-            + ",\"tags\":[\"message\"]"
+            + ",\"tags\":" + tagsJson
             + ",\"source\":\"ar-messages\"}";
-
         try {
             HttpURLConnection conn = (HttpURLConnection) URI.create(url).toURL().openConnection();
             conn.setRequestMethod("POST");

--- a/flowtree/src/test/java/io/flowtree/jobs/ClaudeCodeJobEnforcementTest.java
+++ b/flowtree/src/test/java/io/flowtree/jobs/ClaudeCodeJobEnforcementTest.java
@@ -375,19 +375,19 @@ public class ClaudeCodeJobEnforcementTest extends TestSuiteBase {
 	}
 
 	/**
-	 * Verifies that correction sessions are tagged with the enforcement rule's
-	 * name as the activity.  The rule's {@link EnforcementRule#getName()} return
-	 * value is the activity identifier propagated to {@code AR_AGENT_ACTIVITY}
-	 * in the subprocess environment so that {@code send_message} calls made by
-	 * the correction-session agent are automatically tagged with the rule name.
+	 * Verifies that {@link ClaudeCodeJob#runEnforcementRules()} passes
+	 * {@link EnforcementRule#getName()} as the {@code activity} parameter to
+	 * {@code runCorrectionSession}, which propagates it to {@code AR_AGENT_ACTIVITY}
+	 * in the subprocess environment.
 	 *
-	 * <p>This test verifies that the activity value captured at the
-	 * {@code runEnforcementRules} call site equals {@code rule.getName()},
-	 * using a spy rule that records the name at correction time.</p>
+	 * <p>A spy subclass overrides {@code runCorrectionSession} to capture the
+	 * {@code activity} argument without launching a real subprocess.  The test
+	 * calls {@code runEnforcementRules()} directly (package-private access) so
+	 * the full enforcement loop is exercised.</p>
 	 */
 	@Test(timeout = 30000)
 	public void correctionSessionActivityMatchesRuleName() {
-		AtomicReference<String> capturedRuleName = new AtomicReference<>();
+		AtomicReference<String> capturedActivity = new AtomicReference<>();
 
 		EnforcementRule rule = new EnforcementRule() {
 			private boolean done = false;
@@ -400,25 +400,27 @@ public class ClaudeCodeJobEnforcementTest extends TestSuiteBase {
 
 			@Override
 			public String buildCorrectionPrompt(ClaudeCodeJob job) {
-				// Record the name that runEnforcementRules() would use as activity
-				capturedRuleName.set(getName());
 				done = true;
-				// Return null so the enforcement loop skips the subprocess launch
-				return null;
+				return "correct the dependency violation";
 			}
 		};
 
-		ClaudeCodeJob job = new ClaudeCodeJob("t1", "test");
+		// Spy subclass: capture the activity argument without launching a subprocess.
+		ClaudeCodeJob job = new ClaudeCodeJob("t1", "test") {
+			@Override
+			protected void runCorrectionSession(String correctionPrompt, String activity) {
+				capturedActivity.set(activity);
+			}
+		};
 
-		// Simulate the enforcement loop: isViolated triggers buildCorrectionPrompt,
-		// which records getName() — the value later passed as activity.
-		if (rule.isViolated(job)) {
-			rule.buildCorrectionPrompt(job);
-			assertNotNull("rule.getName() must return a non-null activity string",
-					capturedRuleName.get());
-		}
+		// Disable built-in rules so only the spy rule fires.
+		job.setEnforceOrganizationalPlacement(false);
+		job.addEnforcementRule(rule);
 
-		assertEquals("maven_dependency_protection", capturedRuleName.get());
+		// Exercise the real enforcement path.
+		job.runEnforcementRules();
+
+		assertEquals("maven_dependency_protection", capturedActivity.get());
 	}
 
 	// ── Backward compatibility ───────────────────────────────────────────────

--- a/flowtree/src/test/java/io/flowtree/jobs/ClaudeCodeJobEnforcementTest.java
+++ b/flowtree/src/test/java/io/flowtree/jobs/ClaudeCodeJobEnforcementTest.java
@@ -359,6 +359,68 @@ public class ClaudeCodeJobEnforcementTest extends TestSuiteBase {
 		assertEquals(3, violationCount.get());
 	}
 
+	// ── Correction session activity tagging ─────────────────────────────────
+
+	/**
+	 * {@link DeduplicationRule} must return {@code "deduplication"} from
+	 * {@link EnforcementRule#getName()} so that correction sessions started
+	 * by that rule pass {@code "deduplication"} as the activity to
+	 * {@code runCorrectionSession}, which propagates it to the
+	 * {@code AR_AGENT_ACTIVITY} environment variable.
+	 */
+	@Test(timeout = 30000)
+	public void deduplicationRuleNameIsDeduplication() {
+		DeduplicationRule rule = new DeduplicationRule();
+		assertEquals("deduplication", rule.getName());
+	}
+
+	/**
+	 * Verifies that correction sessions are tagged with the enforcement rule's
+	 * name as the activity.  The rule's {@link EnforcementRule#getName()} return
+	 * value is the activity identifier propagated to {@code AR_AGENT_ACTIVITY}
+	 * in the subprocess environment so that {@code send_message} calls made by
+	 * the correction-session agent are automatically tagged with the rule name.
+	 *
+	 * <p>This test verifies that the activity value captured at the
+	 * {@code runEnforcementRules} call site equals {@code rule.getName()},
+	 * using a spy rule that records the name at correction time.</p>
+	 */
+	@Test(timeout = 30000)
+	public void correctionSessionActivityMatchesRuleName() {
+		AtomicReference<String> capturedRuleName = new AtomicReference<>();
+
+		EnforcementRule rule = new EnforcementRule() {
+			private boolean done = false;
+
+			@Override
+			public String getName() { return "maven_dependency_protection"; }
+
+			@Override
+			public boolean isViolated(ClaudeCodeJob job) { return !done; }
+
+			@Override
+			public String buildCorrectionPrompt(ClaudeCodeJob job) {
+				// Record the name that runEnforcementRules() would use as activity
+				capturedRuleName.set(getName());
+				done = true;
+				// Return null so the enforcement loop skips the subprocess launch
+				return null;
+			}
+		};
+
+		ClaudeCodeJob job = new ClaudeCodeJob("t1", "test");
+
+		// Simulate the enforcement loop: isViolated triggers buildCorrectionPrompt,
+		// which records getName() — the value later passed as activity.
+		if (rule.isViolated(job)) {
+			rule.buildCorrectionPrompt(job);
+			assertNotNull("rule.getName() must return a non-null activity string",
+					capturedRuleName.get());
+		}
+
+		assertEquals("maven_dependency_protection", capturedRuleName.get());
+	}
+
 	// ── Backward compatibility ───────────────────────────────────────────────
 
 	@Test(timeout = 30000)

--- a/flowtree/src/test/java/io/flowtree/jobs/McpToolDiscoveryTest.java
+++ b/flowtree/src/test/java/io/flowtree/jobs/McpToolDiscoveryTest.java
@@ -394,6 +394,13 @@ public class McpToolDiscoveryTest extends TestSuiteBase {
 			McpToolDiscovery.discoverToolParameters(serverFile, "send_message");
 		assertTrue("send_message must declare text in signature",
 			sendMessageParams.contains("text"));
+		assertTrue("send_message must declare activity in signature",
+			sendMessageParams.contains("activity"));
+
+		List<String> workstreamContextParams =
+			McpToolDiscovery.discoverToolParameters(serverFile, "workstream_context");
+		assertTrue("workstream_context must declare include_activities in signature",
+			workstreamContextParams.contains("include_activities"));
 	}
 
 	@Test(timeout = 30000)

--- a/tools/mcp/manager/server.py
+++ b/tools/mcp/manager/server.py
@@ -2480,6 +2480,7 @@ def workstream_context(
     include_commits: bool = True,
     commit_limit: int = 30,
     job_limit: int = 20,
+    include_activities: str = "primary",
 ) -> dict:
     """Reconstruct the narrative of a workstream — what agents have been
     thinking about and doing on a branch. This is the primary tool for
@@ -2526,6 +2527,14 @@ def workstream_context(
         commit_limit: Maximum number of commits to include (default 30).
         job_limit: Maximum number of jobs to include in the timeline
             (default 20). Pass 0 to omit jobs entirely.
+        include_activities: Comma-separated list of activity values to
+            include, or ``"all"`` to skip filtering.  Defaults to
+            ``"primary"``, which returns only messages with no activity
+            tag (primary work) or with the ``activity:primary`` tag.
+            Audit-phase messages (e.g. ``activity:deduplication``) are
+            hidden by default.  Pass ``"all"`` to see every message, or
+            a specific activity name (e.g. ``"deduplication"``) to see
+            only that phase.
 
     Returns:
         Dictionary with branch memories, optionally commits, and optionally
@@ -2596,6 +2605,32 @@ def workstream_context(
                 memories = combined
         except ConnectionError:
             pass  # Non-critical: proceed without messages
+
+    # Filter memories by activity.  Each message may carry a tag of the
+    # form ``activity:<name>`` (e.g. ``activity:deduplication``).  Memories
+    # without any such tag are considered primary work.  The
+    # ``include_activities`` parameter controls which activities are shown.
+    #
+    # Special values:
+    #   "all"     — no filtering; return every memory regardless of activity
+    #   "primary" — (default) return only primary/untagged and activity:primary
+    #   any other — return memories whose activity tag matches that value,
+    #               plus primary/untagged memories
+    #
+    # Multiple values can be comma-separated, e.g. "primary,deduplication".
+    effective_include = (include_activities or "primary").strip()
+    if effective_include != "all":
+        allowed = {v.strip() for v in effective_include.split(",") if v.strip()}
+
+        def _activity_allowed(mem: dict) -> bool:
+            tags = mem.get("tags") or []
+            activity_tags = [t[len("activity:"):] for t in tags if t.startswith("activity:")]
+            if not activity_tags:
+                # No activity tag — primary work, always included
+                return True
+            return any(a in allowed for a in activity_tags)
+
+        memories = [m for m in memories if _activity_allowed(m)]
 
     # Fetch commit history from GitHub Compare API if requested
     commits = None
@@ -2806,6 +2841,7 @@ def send_message(
     text: str,
     workstream_id: str = "",
     job_id: str = "",
+    activity: str = "",
 ) -> dict:
     """Send a message for archival and optional notification.
 
@@ -2820,6 +2856,14 @@ def send_message(
             the workstream from the auth token when available.
         job_id: Job to thread the message under.  Defaults to the job
             from the auth token when available.
+        activity: Optional tag identifying the phase or activity this
+            message belongs to (e.g. ``"deduplication"``,
+            ``"organizational_placement"``,
+            ``"maven_dependency_protection"``).  Defaults to empty
+            (primary work).  When the environment variable
+            ``AR_AGENT_ACTIVITY`` is set and ``activity`` is not
+            supplied, the env var value is used automatically so that
+            correction-session agents do not need to pass it explicitly.
 
     Returns:
         Dictionary with ok=true on success or ok=false with error details.
@@ -2828,13 +2872,14 @@ def send_message(
 
     effective_ws = workstream_id or _get_token_workstream_id() or ""
     effective_job = job_id or _get_token_job_id() or ""
+    effective_activity = activity or os.environ.get("AR_AGENT_ACTIVITY", "")
 
     if not effective_ws:
         return {"ok": False, "error": "workstream_id is required (pass explicitly or use a job token)"}
 
     _require_workstream_in_scope(effective_ws)
     _audit("send_message", workstream_id=effective_ws, job_id=effective_job,
-           text=text[:80])
+           activity=effective_activity, text=text[:80])
 
     err = _check_length(text, "text", MAX_CONTENT_LEN)
     if err:
@@ -2846,7 +2891,10 @@ def send_message(
         path += f"/jobs/{quote(effective_job, safe='')}"
     path += "/messages"
 
-    return _controller_post(path, {"text": text})
+    body: dict = {"text": text}
+    if effective_activity:
+        body["activity"] = effective_activity
+    return _controller_post(path, body)
 
 
 # ---------------------------------------------------------------------------

--- a/tools/mcp/manager/server.py
+++ b/tools/mcp/manager/server.py
@@ -1207,6 +1207,30 @@ def _parse_dependent_repos(dependent_repos: str) -> list:
     return [r.strip() for r in stripped.split(",") if r.strip()]
 
 
+def _parse_activities_param(include_activities) -> str:
+    """Normalize include_activities to a comma-separated string.
+
+    Accepts a native Python list, a JSON-array string, or a plain comma-separated
+    string.  Returns a normalised comma-separated string (e.g. ``"primary"``).
+    """
+    if isinstance(include_activities, list):
+        joined = ",".join(str(v).strip() for v in include_activities if str(v).strip())
+        return joined or "primary"
+    if not include_activities:
+        return "primary"
+    stripped = include_activities.strip()
+    if stripped.startswith("["):
+        import json as _json
+        try:
+            parsed = _json.loads(stripped)
+            if isinstance(parsed, list):
+                joined = ",".join(str(v).strip() for v in parsed if str(v).strip())
+                return joined or "primary"
+        except ValueError:
+            pass
+    return stripped or "primary"
+
+
 @mcp.tool()
 def workstream_submit_task(
     prompt: str,
@@ -2480,7 +2504,7 @@ def workstream_context(
     include_commits: bool = True,
     commit_limit: int = 30,
     job_limit: int = 20,
-    include_activities: str = "primary",
+    include_activities: "list[str] | str" = "primary",
 ) -> dict:
     """Reconstruct the narrative of a workstream — what agents have been
     thinking about and doing on a branch. This is the primary tool for
@@ -2527,14 +2551,15 @@ def workstream_context(
         commit_limit: Maximum number of commits to include (default 30).
         job_limit: Maximum number of jobs to include in the timeline
             (default 20). Pass 0 to omit jobs entirely.
-        include_activities: Comma-separated list of activity values to
-            include, or ``"all"`` to skip filtering.  Defaults to
-            ``"primary"``, which returns only messages with no activity
-            tag (primary work) or with the ``activity:primary`` tag.
-            Audit-phase messages (e.g. ``activity:deduplication``) are
-            hidden by default.  Pass ``"all"`` to see every message, or
-            a specific activity name (e.g. ``"deduplication"``) to see
-            only that phase.
+        include_activities: Activity filter — accepts a Python list of strings,
+            a JSON-array string (``["deduplication","primary"]``), or a plain
+            comma-separated string.  Defaults to ``"primary"``, which returns
+            only messages with no activity tag (primary work) or with the
+            explicit ``activity:primary`` tag — both are treated as primary.
+            Audit-phase messages (e.g. ``activity:deduplication``) are hidden
+            by default.  Pass ``"all"`` to see every message, or a specific
+            activity name (e.g. ``"deduplication"``) to see that phase plus
+            primary/untagged messages.
 
     Returns:
         Dictionary with branch memories, optionally commits, and optionally
@@ -2618,15 +2643,16 @@ def workstream_context(
     #               plus primary/untagged memories
     #
     # Multiple values can be comma-separated, e.g. "primary,deduplication".
-    effective_include = (include_activities or "primary").strip()
+    # Also accepts a Python list or a JSON-array string via _parse_activities_param.
+    effective_include = _parse_activities_param(include_activities)
     if effective_include != "all":
         allowed = {v.strip() for v in effective_include.split(",") if v.strip()}
 
         def _activity_allowed(mem: dict) -> bool:
             tags = mem.get("tags") or []
             activity_tags = [t[len("activity:"):] for t in tags if t.startswith("activity:")]
-            if not activity_tags:
-                # No activity tag — primary work, always included
+            if not activity_tags or "primary" in activity_tags:
+                # No activity tag or explicit activity:primary — primary work, always included
                 return True
             return any(a in allowed for a in activity_tags)
 
@@ -2872,10 +2898,15 @@ def send_message(
 
     effective_ws = workstream_id or _get_token_workstream_id() or ""
     effective_job = job_id or _get_token_job_id() or ""
-    effective_activity = activity or os.environ.get("AR_AGENT_ACTIVITY", "")
+    effective_activity = (activity or os.environ.get("AR_AGENT_ACTIVITY", "")).strip()
 
     if not effective_ws:
         return {"ok": False, "error": "workstream_id is required (pass explicitly or use a job token)"}
+
+    if effective_activity:
+        err = _check_length(effective_activity, "activity", MAX_SHORT_STRING_LEN)
+        if err:
+            return err
 
     _require_workstream_in_scope(effective_ws)
     _audit("send_message", workstream_id=effective_ws, job_id=effective_job,

--- a/tools/mcp/manager/test_server.py
+++ b/tools/mcp/manager/test_server.py
@@ -1100,6 +1100,165 @@ class TestMemoryStore(unittest.TestCase):
 
 
 # -----------------------------------------------------------------------
+# send_message activity tagging
+# -----------------------------------------------------------------------
+
+
+class TestSendMessageActivity(unittest.TestCase):
+
+    def setUp(self):
+        _grant_all_scopes()
+        server._set_token_context(workstream_id="ws-1", job_id="job-1")
+
+    def tearDown(self):
+        server._set_token_context(workstream_id=None, job_id=None)
+        # Clear any AR_AGENT_ACTIVITY env var set by tests
+        os.environ.pop("AR_AGENT_ACTIVITY", None)
+
+    @patch.object(server, "_controller_post")
+    def test_activity_passed_to_controller(self, mock_post):
+        """Explicit activity parameter is forwarded in the POST body."""
+        mock_post.return_value = {"ok": True}
+        server.send_message(text="Hello", activity="deduplication")
+        mock_post.assert_called_once()
+        call_args = mock_post.call_args
+        body = call_args[0][1]
+        self.assertEqual(body["text"], "Hello")
+        self.assertEqual(body["activity"], "deduplication")
+
+    @patch.object(server, "_controller_post")
+    def test_no_activity_omits_field(self, mock_post):
+        """When no activity is given and env var is unset, body has no activity field."""
+        mock_post.return_value = {"ok": True}
+        os.environ.pop("AR_AGENT_ACTIVITY", None)
+        server.send_message(text="Primary work")
+        body = mock_post.call_args[0][1]
+        self.assertNotIn("activity", body)
+
+    @patch.object(server, "_controller_post")
+    def test_env_var_fallback(self, mock_post):
+        """AR_AGENT_ACTIVITY env var is used when activity param is empty."""
+        mock_post.return_value = {"ok": True}
+        os.environ["AR_AGENT_ACTIVITY"] = "organizational_placement"
+        server.send_message(text="Audit msg")
+        body = mock_post.call_args[0][1]
+        self.assertEqual(body["activity"], "organizational_placement")
+
+    @patch.object(server, "_controller_post")
+    def test_explicit_activity_overrides_env_var(self, mock_post):
+        """Explicit activity takes precedence over AR_AGENT_ACTIVITY env var."""
+        mock_post.return_value = {"ok": True}
+        os.environ["AR_AGENT_ACTIVITY"] = "organizational_placement"
+        server.send_message(text="Override", activity="deduplication")
+        body = mock_post.call_args[0][1]
+        self.assertEqual(body["activity"], "deduplication")
+
+
+# -----------------------------------------------------------------------
+# workstream_context activity filtering
+# -----------------------------------------------------------------------
+
+
+class TestWorkstreamContextActivityFilter(unittest.TestCase):
+    """Tests for the include_activities filtering in workstream_context."""
+
+    def _make_memories(self):
+        """Return a mix of primary, deduplication, and organizational messages."""
+        return [
+            {"id": "m1", "content": "primary work", "created_at": "2026-04-01",
+             "tags": ["message"], "namespace": "messages"},
+            {"id": "m2", "content": "dedup audit", "created_at": "2026-04-02",
+             "tags": ["message", "activity:deduplication"], "namespace": "messages"},
+            {"id": "m3", "content": "org placement", "created_at": "2026-04-03",
+             "tags": ["message", "activity:organizational_placement"], "namespace": "messages"},
+            {"id": "m4", "content": "tagged primary", "created_at": "2026-04-04",
+             "tags": ["message", "activity:primary"], "namespace": "messages"},
+            {"id": "m5", "content": "no tags", "created_at": "2026-04-05",
+             "tags": [], "namespace": "default"},
+        ]
+
+    @patch.object(server, "_github_request", return_value={"ok": False, "error": "off"})
+    @patch.object(server, "_get_memory_client")
+    def test_default_hides_audit_activities(self, mock_client_fn, _gh):
+        """Default include_activities=primary hides audit-phase messages."""
+        _grant_all_scopes()
+        client = MagicMock()
+        client.search_by_branch.return_value = self._make_memories()
+        mock_client_fn.return_value = client
+        result = server.workstream_context(
+            repo_url="https://github.com/org/repo",
+            branch="feature/x",
+            include_commits=False,
+        )
+        self.assertTrue(result["ok"])
+        ids = [m["id"] for m in result["memories"]]
+        # Primary (m1, m4, m5) included; dedup (m2) and org (m3) excluded
+        self.assertIn("m1", ids)
+        self.assertIn("m4", ids)
+        self.assertIn("m5", ids)
+        self.assertNotIn("m2", ids)
+        self.assertNotIn("m3", ids)
+
+    @patch.object(server, "_github_request", return_value={"ok": False, "error": "off"})
+    @patch.object(server, "_get_memory_client")
+    def test_include_all_returns_everything(self, mock_client_fn, _gh):
+        """include_activities='all' disables filtering."""
+        _grant_all_scopes()
+        client = MagicMock()
+        client.search_by_branch.return_value = self._make_memories()
+        mock_client_fn.return_value = client
+        result = server.workstream_context(
+            repo_url="https://github.com/org/repo",
+            branch="feature/x",
+            include_commits=False,
+            include_activities="all",
+        )
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["count"], 5)
+
+    @patch.object(server, "_github_request", return_value={"ok": False, "error": "off"})
+    @patch.object(server, "_get_memory_client")
+    def test_specific_activity_filter(self, mock_client_fn, _gh):
+        """Requesting a specific activity returns only that activity's messages."""
+        _grant_all_scopes()
+        client = MagicMock()
+        client.search_by_branch.return_value = self._make_memories()
+        mock_client_fn.return_value = client
+        result = server.workstream_context(
+            repo_url="https://github.com/org/repo",
+            branch="feature/x",
+            include_commits=False,
+            include_activities="deduplication",
+        )
+        self.assertTrue(result["ok"])
+        ids = [m["id"] for m in result["memories"]]
+        # m2 (dedup) and untagged memories (m1, m5) included; org (m3) excluded
+        self.assertIn("m2", ids)
+        self.assertIn("m1", ids)
+        self.assertIn("m5", ids)
+        self.assertNotIn("m3", ids)
+
+    @patch.object(server, "_github_request", return_value={"ok": False, "error": "off"})
+    @patch.object(server, "_get_memory_client")
+    def test_multiple_activities_comma_separated(self, mock_client_fn, _gh):
+        """Comma-separated list includes all named activities."""
+        _grant_all_scopes()
+        client = MagicMock()
+        client.search_by_branch.return_value = self._make_memories()
+        mock_client_fn.return_value = client
+        result = server.workstream_context(
+            repo_url="https://github.com/org/repo",
+            branch="feature/x",
+            include_commits=False,
+            include_activities="deduplication,organizational_placement",
+        )
+        self.assertTrue(result["ok"])
+        ids = [m["id"] for m in result["memories"]]
+        self.assertIn("m2", ids)
+        self.assertIn("m3", ids)
+
+
+# -----------------------------------------------------------------------
 # Controller HTTP helpers
 # -----------------------------------------------------------------------
 

--- a/tools/mcp/manager/test_server.py
+++ b/tools/mcp/manager/test_server.py
@@ -1219,7 +1219,7 @@ class TestWorkstreamContextActivityFilter(unittest.TestCase):
     @patch.object(server, "_github_request", return_value={"ok": False, "error": "off"})
     @patch.object(server, "_get_memory_client")
     def test_specific_activity_filter(self, mock_client_fn, _gh):
-        """Requesting a specific activity returns only that activity's messages."""
+        """Requesting a specific activity returns that activity's messages plus primary/untagged messages."""
         _grant_all_scopes()
         client = MagicMock()
         client.search_by_branch.return_value = self._make_memories()


### PR DESCRIPTION
## Background

When an agent runs a job, it posts progress messages via `send_message`. During enforcement phases (deduplication, organizational placement review, maven dependency check, etc.), the agent generates a LOT of these messages that are useful during the job but clutter up the branch context afterward. We want to tag these messages so they can be hidden by default.

## Changes

### 1. Add `activity` parameter to `send_message`

In `tools/mcp/manager/server.py`, update the `send_message` MCP tool to accept an optional `activity` parameter (string). This identifies what phase or activity the message belongs to. Common values would be things like:
- `primary` (or empty/null — default: normal job work)
- `deduplication`
- `organizational_placement`
- `maven_dependency_protection`
- `merge_conflict_resolution`

Don't enum-constrain it — let agents pass arbitrary strings so new enforcement rules can be added later without schema changes. Store it alongside the message in the memory/namespace system.

### 2. Store activity on the message

The underlying memory record (or message record — whatever `send_message` persists to) needs a new `activity` field. Update the storage layer so this is captured.

### 3. Filter by default in workstream_context

Update `workstream_context` (the tool recently renamed from `memory_branch_context`) to filter out non-primary-activity messages by default. Add an `include_activities` parameter (list of strings) that callers can use to opt into specific activities or `"all"` to get everything.

Default behavior: only messages with activity `primary` or null/empty (i.e., the normal job work) are returned. Audit-phase messages are hidden.

### 4. Update the ClaudeCodeJob enforcement rule framework

The agent workflow for enforcement rules already posts `send_message` updates during each rule's correction session. Update `ClaudeCodeJob.runCorrectionSession()` (or wherever the rule invokes the sub-session) to pass the rule name as the `activity` when the agent is running in a correction session. The rule's `getName()` value is the natural identifier.

This may require plumbing — the sub-session needs to know what activity it's running under so `send_message` calls within it get tagged. A thread-local, an env var passed to the agent, or a parameter on the message submission are all options — pick the cleanest one that fits the existing architecture.

### 5. Tests

- Tests for `send_message` accepting and persisting the `activity` field
- Tests for `workstream_context` filtering by default and respecting `include_activities`
- Tests confirming messages posted during a dedup correction session get tagged with `deduplication`