### PR TITLE
Add github_read_file and github_pr_check_status MCP tools to ar-manager

### DIFF
--- a/flowtree/src/test/java/io/flowtree/jobs/McpToolDiscoveryTest.java
+++ b/flowtree/src/test/java/io/flowtree/jobs/McpToolDiscoveryTest.java
@@ -304,7 +304,9 @@ public class McpToolDiscoveryTest extends TestSuiteBase {
 			"github_pr_reply",
 			"github_list_open_prs",
 			"github_create_pr",
-			"github_request_copilot_review"
+			"github_request_copilot_review",
+			"github_read_file",
+			"github_pr_check_status"
 		));
 
 		List<String> discovered = McpToolDiscovery.discoverToolNames(serverFile);
@@ -401,6 +403,28 @@ public class McpToolDiscoveryTest extends TestSuiteBase {
 			McpToolDiscovery.discoverToolParameters(serverFile, "workstream_context");
 		assertTrue("workstream_context must declare include_activities in signature",
 			workstreamContextParams.contains("include_activities"));
+
+		List<String> readFileParams =
+			McpToolDiscovery.discoverToolParameters(serverFile, "github_read_file");
+		assertTrue("github_read_file must declare path in signature",
+			readFileParams.contains("path"));
+		assertTrue("github_read_file must declare workstream_id in signature",
+			readFileParams.contains("workstream_id"));
+		assertTrue("github_read_file must declare repo_url in signature",
+			readFileParams.contains("repo_url"));
+		assertTrue("github_read_file must declare branch in signature",
+			readFileParams.contains("branch"));
+		assertTrue("github_read_file must declare ref in signature",
+			readFileParams.contains("ref"));
+
+		List<String> prCheckParams =
+			McpToolDiscovery.discoverToolParameters(serverFile, "github_pr_check_status");
+		assertTrue("github_pr_check_status must declare pr_number in signature",
+			prCheckParams.contains("pr_number"));
+		assertTrue("github_pr_check_status must declare workstream_id in signature",
+			prCheckParams.contains("workstream_id"));
+		assertTrue("github_pr_check_status must declare branch in signature",
+			prCheckParams.contains("branch"));
 	}
 
 	@Test(timeout = 30000)

--- a/tools/mcp/manager/server.py
+++ b/tools/mcp/manager/server.py
@@ -33,6 +33,7 @@ forwarding the request.
 """
 
 import base64
+import binascii
 import contextvars
 import hmac
 import json
@@ -2933,6 +2934,34 @@ def send_message(
 # ---------------------------------------------------------------------------
 
 
+def _find_open_pr_by_branch(owner: str, repo: str, branch: str) -> dict:
+    """Look up the first open pull request for ``branch`` on ``owner/repo``.
+
+    Returns a dict with ``ok=True`` and ``pr`` (the raw GitHub PR object)
+    on success, ``ok=True`` with ``found=False`` when no open PR exists
+    for the branch, or an ``ok=False`` error dict when the GitHub call
+    fails or returns an unexpected payload. Centralising this lookup
+    avoids drift between tools that need to resolve a PR by branch
+    (e.g. ``github_pr_find``, ``github_request_copilot_review``,
+    ``github_pr_check_status``).
+    """
+    head = f"{owner}:{branch}"
+    pr_list = _github_request(
+        "GET",
+        f"/repos/{owner}/{repo}/pulls?head={quote(head, safe=':/')}&state=open",
+    )
+    if isinstance(pr_list, dict) and pr_list.get("ok") is False:
+        return pr_list
+    if not isinstance(pr_list, list):
+        return {
+            "ok": False,
+            "error": "Unexpected response listing pull requests",
+        }
+    if not pr_list:
+        return {"ok": True, "found": False, "branch": branch}
+    return {"ok": True, "found": True, "pr": pr_list[0], "branch": branch}
+
+
 @mcp.tool()
 def github_pr_find(
     workstream_id: str = "",
@@ -2964,23 +2993,21 @@ def github_pr_find(
 
     _audit("github_pr_find", workstream_id=workstream_id, branch=effective_branch)
 
-    head = f"{owner}:{effective_branch}"
-    result = _github_request("GET", f"/repos/{owner}/{repo}/pulls?head={quote(head, safe=':/')}&state=open")
-
-    if isinstance(result, list):
-        if not result:
-            return {"ok": True, "found": False, "branch": effective_branch}
-        pr = result[0]
-        return {
-            "ok": True,
-            "found": True,
-            "number": pr.get("number"),
-            "title": pr.get("title"),
-            "url": pr.get("html_url"),
-            "state": pr.get("state"),
-            "branch": effective_branch,
-        }
-    return result  # error dict from _github_request
+    lookup = _find_open_pr_by_branch(owner, repo, effective_branch)
+    if not lookup.get("ok"):
+        return lookup
+    if not lookup.get("found"):
+        return {"ok": True, "found": False, "branch": effective_branch}
+    pr = lookup["pr"]
+    return {
+        "ok": True,
+        "found": True,
+        "number": pr.get("number"),
+        "title": pr.get("title"),
+        "url": pr.get("html_url"),
+        "state": pr.get("state"),
+        "branch": effective_branch,
+    }
 
 
 @mcp.tool()
@@ -3520,11 +3547,12 @@ def github_request_copilot_review(
                 ],
             }
         # Look up the open PR for the branch.
-        head = f"{owner}:{effective_branch}"
-        pr_list = _github_request("GET", f"/repos/{owner}/{repo}/pulls?head={quote(head, safe=':/')}&state=open")
-        if not isinstance(pr_list, list) or not pr_list:
+        lookup = _find_open_pr_by_branch(owner, repo, effective_branch)
+        if not lookup.get("ok"):
+            return lookup
+        if not lookup.get("found"):
             return {"ok": False, "error": f"No open PR found for branch '{effective_branch}'"}
-        effective_pr = pr_list[0]["number"]
+        effective_pr = lookup["pr"].get("number")
 
     _audit("github_request_copilot_review", pr_number=effective_pr)
 
@@ -3560,11 +3588,14 @@ def github_read_file(
 
     Args:
         path: File path within the repository (e.g. ``docs/README.md``).
-        workstream_id: Workstream to resolve the repository from. Either
-            this or ``repo_url`` must be provided.
+        workstream_id: Workstream to resolve the repository from. When
+            both ``workstream_id`` and ``repo_url`` are empty, the
+            resolver falls back to local-git detection (useful when the
+            server runs against a developer checkout).
         repo_url: Explicit GitHub repository URL (e.g.
             ``https://github.com/owner/repo``). Overrides workstream
-            resolution when provided.
+            resolution when provided. Scoped tokens are checked against
+            the parsed owner via the workspace scope gate.
         branch: Branch to read from. Defaults to the workstream's
             ``defaultBranch`` when available, otherwise the repo's
             default branch. Ignored when ``ref`` is provided.
@@ -3592,6 +3623,7 @@ def github_read_file(
         if not owner_repo:
             return {"ok": False, "error": f"Cannot parse owner/repo from: {repo_url}"}
         owner, repo = owner_repo
+        _require_org_in_scope(owner)
         _current_github_org.set(owner)
         effective_branch = branch
     else:
@@ -3615,6 +3647,22 @@ def github_read_file(
             "Check the repo_url or workstream_id is correct",
         ])
         return result
+
+    # The GitHub Contents API returns a JSON array (not a dict) when the
+    # supplied path refers to a directory. Surface this explicitly rather
+    # than reporting a misleading "Unexpected response".
+    if isinstance(result, list):
+        return {
+            "ok": False,
+            "error": (
+                f"Path '{path}' refers to a directory, not a file"
+            ),
+            "repo": f"{owner}/{repo}",
+            "next_steps": [
+                "Pass a specific file path within the directory",
+                "Use git/grep tools to enumerate directory contents",
+            ],
+        }
 
     if not isinstance(result, dict):
         return {
@@ -3640,7 +3688,16 @@ def github_read_file(
     encoding = result.get("encoding", "")
     if encoding == "base64" and content_b64:
         # GitHub wraps base64 output in newlines; strip them before decoding.
-        raw_bytes = base64.b64decode(content_b64.replace("\n", ""))
+        try:
+            raw_bytes = base64.b64decode(content_b64.replace("\n", ""))
+        except (binascii.Error, ValueError) as exc:
+            return {
+                "ok": False,
+                "error": (
+                    f"Failed to decode base64 content for '{path}': {exc}"
+                ),
+                "repo": f"{owner}/{repo}",
+            }
         try:
             content = raw_bytes.decode("utf-8")
         except UnicodeDecodeError:
@@ -3737,20 +3794,19 @@ def github_pr_check_status(
                     "Or supply workstream_id/branch so the open PR can be found",
                 ],
             }
-        head = f"{owner}:{effective_branch}"
-        pr_list = _github_request(
-            "GET",
-            f"/repos/{owner}/{repo}/pulls?head={quote(head, safe=':/')}&state=open",
-        )
-        if not isinstance(pr_list, list) or not pr_list:
+        lookup = _find_open_pr_by_branch(owner, repo, effective_branch)
+        if not lookup.get("ok"):
+            return lookup
+        if not lookup.get("found"):
             return {
                 "ok": False,
                 "error": f"No open PR found for branch '{effective_branch}'",
                 "next_steps": ["Pass pr_number explicitly if the PR is closed"],
             }
-        effective_pr = pr_list[0]["number"]
-        head_sha = pr_list[0].get("head", {}).get("sha", "")
-        pr_branch = pr_list[0].get("head", {}).get("ref", effective_branch)
+        pr = lookup["pr"]
+        effective_pr = pr.get("number")
+        head_sha = pr.get("head", {}).get("sha", "")
+        pr_branch = pr.get("head", {}).get("ref", effective_branch)
 
     if not head_sha:
         return {"ok": False, "error": "Could not determine PR head commit SHA"}
@@ -3761,10 +3817,13 @@ def github_pr_check_status(
         f"/repos/{owner}/{repo}/actions/runs?head_sha={quote(head_sha, safe='')}",
     )
 
+    if isinstance(runs_result, dict) and runs_result.get("ok") is False:
+        return runs_result
+
     workflow_runs = []
     pipeline_current = False
 
-    if isinstance(runs_result, dict) and runs_result.get("ok") is not False:
+    if isinstance(runs_result, dict):
         for run in runs_result.get("workflow_runs", []):
             if run.get("head_sha") == head_sha:
                 pipeline_current = True
@@ -3785,9 +3844,22 @@ def github_pr_check_status(
         f"/repos/{owner}/{repo}/commits/{head_sha}/check-runs",
     )
 
+    if isinstance(check_result, dict) and check_result.get("ok") is False:
+        return {
+            "ok": False,
+            "error": "Failed to fetch check runs",
+            "check_runs_error": check_result,
+        }
+
     check_runs = []
-    if isinstance(check_result, dict) and check_result.get("ok") is not False:
+    if isinstance(check_result, dict):
         for check in check_result.get("check_runs", []):
+            # check_runs are scoped to head_sha by the URL, so any returned
+            # entry is also evidence that the pipeline targets the current
+            # commit. workflow_runs and check_runs come from independent
+            # GitHub endpoints — relying on workflow_runs alone misses cases
+            # where check_runs is populated but workflow_runs is empty.
+            pipeline_current = True
             check_info = {
                 "id": check.get("id"),
                 "name": check.get("name", ""),
@@ -3807,8 +3879,16 @@ def github_pr_check_status(
     elif workflow_runs and not pipeline_current:
         overall = "stale"
     else:
+        # An in-progress check (status != "completed") means CI is still
+        # running even if other checks have already concluded — report
+        # "pending" rather than letting completed conclusions decide.
+        has_incomplete_checks = any(
+            r.get("status") != "completed" for r in check_runs
+        )
         conclusions = [r["conclusion"] for r in check_runs if r.get("conclusion")]
-        if not conclusions:
+        if has_incomplete_checks:
+            overall = "pending"
+        elif not conclusions:
             overall = "pending"
         elif any(c == "failure" for c in conclusions):
             overall = "failure"

--- a/tools/mcp/manager/server.py
+++ b/tools/mcp/manager/server.py
@@ -3532,6 +3532,327 @@ def github_request_copilot_review(
 
 
 # ---------------------------------------------------------------------------
+# GitHub file and pipeline tools
+# ---------------------------------------------------------------------------
+
+# Size limit for github_read_file — reject files over this threshold.
+_GITHUB_READ_FILE_SIZE_LIMIT = 1_048_576  # 1 MB
+
+
+@mcp.tool()
+def github_read_file(
+    path: str,
+    workstream_id: str = "",
+    repo_url: str = "",
+    branch: str = "",
+    ref: str = "",
+) -> dict:
+    """Read any file from a GitHub repository.
+
+    Fetches file content via the GitHub Contents API, routed through the
+    FlowTree controller proxy for authentication. The repository is
+    resolved from the workstream or supplied explicitly via ``repo_url``.
+
+    Returns the file content as text. Binary files that cannot be decoded
+    as UTF-8 are rejected with a clear error. Files larger than 1 MB are
+    rejected to prevent accidental large pulls — use grep tools or read
+    specific line ranges for large files.
+
+    Args:
+        path: File path within the repository (e.g. ``docs/README.md``).
+        workstream_id: Workstream to resolve the repository from. Either
+            this or ``repo_url`` must be provided.
+        repo_url: Explicit GitHub repository URL (e.g.
+            ``https://github.com/owner/repo``). Overrides workstream
+            resolution when provided.
+        branch: Branch to read from. Defaults to the workstream's
+            ``defaultBranch`` when available, otherwise the repo's
+            default branch. Ignored when ``ref`` is provided.
+        ref: Git ref to read at (branch, tag, or commit SHA). Takes
+            precedence over ``branch`` when both are provided.
+
+    Returns:
+        Dictionary with file content, path, ref, sha, and repo.
+    """
+    _require_scope("read")
+    err = _check_short_strings(
+        path=path, workstream_id=workstream_id, branch=branch, ref=ref,
+    )
+    if err:
+        return err
+    if not path:
+        return {"ok": False, "error": "path is required"}
+
+    _audit("github_read_file", path=path, workstream_id=workstream_id,
+           branch=branch, ref=ref)
+
+    # Resolve owner/repo
+    if repo_url:
+        owner_repo = _extract_owner_repo(repo_url)
+        if not owner_repo:
+            return {"ok": False, "error": f"Cannot parse owner/repo from: {repo_url}"}
+        owner, repo = owner_repo
+        _current_github_org.set(owner)
+        effective_branch = branch
+    else:
+        owner, repo, effective_branch, err = _resolve_github_repo(
+            workstream_id=workstream_id, branch=branch,
+        )
+        if err:
+            return err
+
+    effective_ref = ref or effective_branch
+    ref_suffix = f"?ref={quote(effective_ref, safe='')}" if effective_ref else ""
+
+    result = _github_request(
+        "GET",
+        f"/repos/{owner}/{repo}/contents/{quote(path, safe='/')}{ref_suffix}",
+    )
+
+    if isinstance(result, dict) and result.get("ok") is False:
+        result.setdefault("next_steps", [
+            f"Verify the file exists at '{path}' on the specified ref/branch",
+            "Check the repo_url or workstream_id is correct",
+        ])
+        return result
+
+    if not isinstance(result, dict):
+        return {
+            "ok": False,
+            "error": "Unexpected response from GitHub Contents API",
+        }
+
+    # Enforce size limit before decoding
+    file_size = result.get("size", 0)
+    if file_size > _GITHUB_READ_FILE_SIZE_LIMIT:
+        return {
+            "ok": False,
+            "error": (
+                f"File '{path}' is {file_size:,} bytes, which exceeds the 1 MB "
+                "limit. Use grep tools or read specific line ranges instead."
+            ),
+            "size": file_size,
+            "repo": f"{owner}/{repo}",
+        }
+
+    # Decode content
+    content_b64 = result.get("content", "")
+    encoding = result.get("encoding", "")
+    if encoding == "base64" and content_b64:
+        # GitHub wraps base64 output in newlines; strip them before decoding.
+        raw_bytes = base64.b64decode(content_b64.replace("\n", ""))
+        try:
+            content = raw_bytes.decode("utf-8")
+        except UnicodeDecodeError:
+            return {
+                "ok": False,
+                "error": (
+                    f"File '{path}' appears to be binary and cannot be returned "
+                    "as text. Fetch it directly from the repository instead."
+                ),
+                "size": file_size,
+                "repo": f"{owner}/{repo}",
+            }
+    else:
+        content = content_b64
+
+    return {
+        "ok": True,
+        "path": result.get("path", path),
+        "repo": f"{owner}/{repo}",
+        "ref": effective_ref or "(default branch)",
+        "sha": result.get("sha", ""),
+        "size": file_size,
+        "content": content,
+    }
+
+
+@mcp.tool()
+def github_pr_check_status(
+    pr_number: int = 0,
+    workstream_id: str = "",
+    branch: str = "",
+    org: str = "",
+    repo: str = "",
+) -> dict:
+    """Check CI pipeline status for a pull request.
+
+    Fetches the PR's current HEAD commit SHA, then retrieves workflow runs
+    and check runs for that exact commit. This answers whether the CI
+    pipeline has run for the latest commit and whether it passed.
+
+    The ``pipeline_current`` flag in the response indicates whether at
+    least one workflow run targets the PR's HEAD commit SHA — if False,
+    the run results shown are for an older commit.
+
+    Args:
+        pr_number: Pull request number. If omitted, the open PR for the
+            workstream/branch is looked up automatically.
+        workstream_id: Workstream to resolve repo from. Defaults to token
+            context.
+        branch: Branch hint used to find the PR when pr_number is not
+            given. Defaults to the workstream's defaultBranch.
+        org: GitHub org (owner) to address directly. Must be passed
+            together with ``repo``. Bypasses workstream resolution;
+            scoped tokens are checked against this org via the workspace
+            scope gate.
+        repo: GitHub repository name. Must be passed together with ``org``.
+
+    Returns:
+        Dictionary with pr_number, head_sha, pipeline_current flag,
+        overall_status, workflow_runs list, and check_runs list. Failed
+        check runs include html_url and details_url for log access.
+    """
+    _require_scope("read")
+    if org and repo:
+        _require_org_in_scope(org)
+    owner, repo, effective_branch, err = _resolve_github_repo(
+        workstream_id=workstream_id, branch=branch, owner=org, repo=repo,
+    )
+    if err:
+        return err
+
+    _audit("github_pr_check_status", pr_number=pr_number,
+           workstream_id=workstream_id, branch=effective_branch)
+
+    # Resolve PR number and head SHA
+    effective_pr = pr_number
+    head_sha = ""
+    pr_branch = effective_branch
+
+    if effective_pr:
+        pr_data = _github_request("GET", f"/repos/{owner}/{repo}/pulls/{effective_pr}")
+        if isinstance(pr_data, dict) and pr_data.get("ok") is False:
+            return pr_data
+        if isinstance(pr_data, dict):
+            head_sha = pr_data.get("head", {}).get("sha", "")
+            pr_branch = pr_data.get("head", {}).get("ref", effective_branch)
+    else:
+        if not effective_branch:
+            return {
+                "ok": False,
+                "error": "pr_number or branch is required to look up the PR",
+                "next_steps": [
+                    "Pass pr_number explicitly",
+                    "Or supply workstream_id/branch so the open PR can be found",
+                ],
+            }
+        head = f"{owner}:{effective_branch}"
+        pr_list = _github_request(
+            "GET",
+            f"/repos/{owner}/{repo}/pulls?head={quote(head, safe=':/')}&state=open",
+        )
+        if not isinstance(pr_list, list) or not pr_list:
+            return {
+                "ok": False,
+                "error": f"No open PR found for branch '{effective_branch}'",
+                "next_steps": ["Pass pr_number explicitly if the PR is closed"],
+            }
+        effective_pr = pr_list[0]["number"]
+        head_sha = pr_list[0].get("head", {}).get("sha", "")
+        pr_branch = pr_list[0].get("head", {}).get("ref", effective_branch)
+
+    if not head_sha:
+        return {"ok": False, "error": "Could not determine PR head commit SHA"}
+
+    # Fetch workflow runs for the head SHA
+    runs_result = _github_request(
+        "GET",
+        f"/repos/{owner}/{repo}/actions/runs?head_sha={quote(head_sha, safe='')}",
+    )
+
+    workflow_runs = []
+    pipeline_current = False
+
+    if isinstance(runs_result, dict) and runs_result.get("ok") is not False:
+        for run in runs_result.get("workflow_runs", []):
+            if run.get("head_sha") == head_sha:
+                pipeline_current = True
+            workflow_runs.append({
+                "run_id": run.get("id"),
+                "name": run.get("name", ""),
+                "status": run.get("status", ""),
+                "conclusion": run.get("conclusion"),
+                "head_sha": run.get("head_sha", ""),
+                "created_at": run.get("created_at", ""),
+                "updated_at": run.get("updated_at", ""),
+                "html_url": run.get("html_url", ""),
+            })
+
+    # Fetch check runs for the head SHA
+    check_result = _github_request(
+        "GET",
+        f"/repos/{owner}/{repo}/commits/{head_sha}/check-runs",
+    )
+
+    check_runs = []
+    if isinstance(check_result, dict) and check_result.get("ok") is not False:
+        for check in check_result.get("check_runs", []):
+            check_info = {
+                "id": check.get("id"),
+                "name": check.get("name", ""),
+                "status": check.get("status", ""),
+                "conclusion": check.get("conclusion"),
+                "html_url": check.get("html_url", ""),
+                "started_at": check.get("started_at"),
+                "completed_at": check.get("completed_at"),
+            }
+            if check.get("conclusion") == "failure":
+                check_info["details_url"] = check.get("details_url", "")
+            check_runs.append(check_info)
+
+    # Derive overall status
+    if not workflow_runs and not check_runs:
+        overall = "no_runs"
+    elif workflow_runs and not pipeline_current:
+        overall = "stale"
+    else:
+        conclusions = [r["conclusion"] for r in check_runs if r.get("conclusion")]
+        if not conclusions:
+            overall = "pending"
+        elif any(c == "failure" for c in conclusions):
+            overall = "failure"
+        elif all(c in ("success", "skipped", "neutral") for c in conclusions):
+            overall = "success"
+        else:
+            overall = "mixed"
+
+    next_steps: list = []
+    if overall == "no_runs":
+        next_steps = [
+            "No workflow runs found; the pipeline may not be configured or "
+            "hasn't triggered yet",
+        ]
+    elif overall == "stale":
+        next_steps = [
+            "The latest workflow run targets an older commit; push a new "
+            "commit or manually re-run CI to update the status",
+        ]
+    elif overall == "failure":
+        next_steps = [
+            "Review failed check runs above for error details",
+            "Use the html_url or details_url links to view full logs",
+        ]
+    elif overall == "success":
+        next_steps = ["All checks passed; the PR is ready to review or merge"]
+    elif overall == "pending":
+        next_steps = ["CI is still running; check back later"]
+
+    return {
+        "ok": True,
+        "pr_number": effective_pr,
+        "repo": f"{owner}/{repo}",
+        "head_sha": head_sha,
+        "branch": pr_branch,
+        "pipeline_current": pipeline_current,
+        "overall_status": overall,
+        "workflow_runs": workflow_runs,
+        "check_runs": check_runs,
+        "next_steps": next_steps,
+    }
+
+
+# ---------------------------------------------------------------------------
 # Server startup
 # ---------------------------------------------------------------------------
 

--- a/tools/mcp/manager/test_server.py
+++ b/tools/mcp/manager/test_server.py
@@ -1446,6 +1446,312 @@ class TestExtractOwnerRepo(unittest.TestCase):
 
 
 # -----------------------------------------------------------------------
+# github_read_file
+# -----------------------------------------------------------------------
+
+
+class TestGithubReadFile(unittest.TestCase):
+    """Tests for github_read_file."""
+
+    def setUp(self):
+        _grant_all_scopes()
+
+    def _make_contents_response(self, path, content_text, size=None):
+        """Build a mock GitHub Contents API response for a text file."""
+        import base64 as _b64
+        encoded = _b64.b64encode(content_text.encode("utf-8")).decode("ascii")
+        return {
+            "path": path,
+            "sha": "abc123",
+            "size": size if size is not None else len(content_text.encode("utf-8")),
+            "content": encoded,
+            "encoding": "base64",
+        }
+
+    @patch.object(server, "_resolve_github_repo",
+                  return_value=("owner", "repo", "main", None))
+    @patch.object(server, "_github_request")
+    def test_success(self, mock_gh, mock_repo):
+        mock_gh.return_value = self._make_contents_response(
+            "docs/README.md", "# Hello World\n"
+        )
+        result = server.github_read_file(path="docs/README.md")
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["content"], "# Hello World\n")
+        self.assertEqual(result["path"], "docs/README.md")
+        self.assertEqual(result["repo"], "owner/repo")
+        self.assertIn("sha", result)
+
+    @patch.object(server, "_resolve_github_repo",
+                  return_value=("owner", "repo", "main", None))
+    @patch.object(server, "_github_request")
+    def test_file_not_found(self, mock_gh, mock_repo):
+        mock_gh.return_value = {"ok": False, "error": "GitHub returned HTTP 404: Not Found"}
+        result = server.github_read_file(path="missing/file.py")
+        self.assertFalse(result["ok"])
+        self.assertIn("next_steps", result)
+
+    @patch.object(server, "_resolve_github_repo",
+                  return_value=("owner", "repo", "main", None))
+    @patch.object(server, "_github_request")
+    def test_binary_file_rejected(self, mock_gh, mock_repo):
+        # Craft a response whose base64 decodes to non-UTF-8 bytes.
+        import base64 as _b64
+        raw_binary = bytes([0x00, 0xFF, 0xFE, 0x80, 0x81])
+        encoded = _b64.b64encode(raw_binary).decode("ascii")
+        mock_gh.return_value = {
+            "path": "image.png",
+            "sha": "abc",
+            "size": len(raw_binary),
+            "content": encoded,
+            "encoding": "base64",
+        }
+        result = server.github_read_file(path="image.png")
+        self.assertFalse(result["ok"])
+        self.assertIn("binary", result["error"].lower())
+
+    @patch.object(server, "_resolve_github_repo",
+                  return_value=("owner", "repo", "main", None))
+    @patch.object(server, "_github_request")
+    def test_oversized_file_rejected(self, mock_gh, mock_repo):
+        # Size field exceeds 1 MB limit — content should never be decoded.
+        import base64 as _b64
+        small_content = "x"
+        encoded = _b64.b64encode(small_content.encode()).decode("ascii")
+        mock_gh.return_value = {
+            "path": "big.bin",
+            "sha": "abc",
+            "size": 1_100_000,  # > 1 MB
+            "content": encoded,
+            "encoding": "base64",
+        }
+        result = server.github_read_file(path="big.bin")
+        self.assertFalse(result["ok"])
+        self.assertIn("1 MB", result["error"])
+        self.assertEqual(result["size"], 1_100_000)
+
+    @patch.object(server, "_resolve_github_repo",
+                  return_value=("owner", "repo", "main", None))
+    @patch.object(server, "_github_request")
+    def test_ref_used_in_request(self, mock_gh, mock_repo):
+        mock_gh.return_value = self._make_contents_response(
+            "src/main.py", "print('hello')\n"
+        )
+        server.github_read_file(path="src/main.py", ref="v1.2.3")
+        call_args = mock_gh.call_args[0]
+        self.assertIn("v1.2.3", call_args[1])
+
+    @patch.object(server, "_github_request")
+    def test_explicit_repo_url(self, mock_gh):
+        mock_gh.return_value = self._make_contents_response(
+            "README.md", "content\n"
+        )
+        result = server.github_read_file(
+            path="README.md",
+            repo_url="https://github.com/myorg/myrepo",
+            branch="develop",
+        )
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["repo"], "myorg/myrepo")
+        call_path = mock_gh.call_args[0][1]
+        self.assertIn("develop", call_path)
+
+    @patch.object(server, "_github_request")
+    def test_invalid_repo_url_returns_error(self, mock_gh):
+        result = server.github_read_file(
+            path="README.md",
+            repo_url="not-a-github-url",
+        )
+        self.assertFalse(result["ok"])
+        self.assertIn("Cannot parse", result["error"])
+        mock_gh.assert_not_called()
+
+    def test_missing_path_returns_error(self):
+        result = server.github_read_file(path="")
+        self.assertFalse(result["ok"])
+        self.assertIn("path is required", result["error"])
+
+    def test_requires_read_scope(self):
+        _grant_scopes("write")
+        with self.assertRaises(PermissionError):
+            server.github_read_file(path="README.md")
+
+    @patch.object(server, "_resolve_github_repo",
+                  return_value=("", "", "", {"ok": False, "error": "not found"}))
+    def test_repo_resolution_error_propagates(self, mock_repo):
+        result = server.github_read_file(path="README.md", workstream_id="bad")
+        self.assertFalse(result["ok"])
+
+
+# -----------------------------------------------------------------------
+# github_pr_check_status
+# -----------------------------------------------------------------------
+
+
+class TestGithubPrCheckStatus(unittest.TestCase):
+    """Tests for github_pr_check_status."""
+
+    def setUp(self):
+        _grant_all_scopes()
+
+    def _make_pr(self, number, sha="abc123", ref="feature/x"):
+        return {
+            "number": number,
+            "head": {"sha": sha, "ref": ref},
+            "html_url": f"https://github.com/owner/repo/pull/{number}",
+        }
+
+    def _make_runs(self, head_sha, runs_data):
+        """Build a mock workflow runs API response."""
+        return {"workflow_runs": [
+            {
+                "id": r.get("id", 1),
+                "name": r.get("name", "CI"),
+                "status": r.get("status", "completed"),
+                "conclusion": r.get("conclusion", "success"),
+                "head_sha": r.get("head_sha", head_sha),
+                "created_at": "2026-04-24T00:00:00Z",
+                "updated_at": "2026-04-24T00:01:00Z",
+                "html_url": "https://github.com/owner/repo/actions/runs/1",
+            }
+            for r in runs_data
+        ]}
+
+    def _make_checks(self, checks_data):
+        return {"check_runs": [
+            {
+                "id": c.get("id", 1),
+                "name": c.get("name", "test"),
+                "status": c.get("status", "completed"),
+                "conclusion": c.get("conclusion", "success"),
+                "html_url": "https://github.com/owner/repo/runs/1",
+                "started_at": "2026-04-24T00:00:00Z",
+                "completed_at": "2026-04-24T00:01:00Z",
+                "details_url": c.get("details_url", ""),
+            }
+            for c in checks_data
+        ]}
+
+    @patch.object(server, "_resolve_github_repo",
+                  return_value=("owner", "repo", "feature/x", None))
+    @patch.object(server, "_github_request")
+    def test_all_success(self, mock_gh, mock_repo):
+        mock_gh.side_effect = [
+            self._make_pr(42, sha="abc123"),
+            self._make_runs("abc123", [{"head_sha": "abc123", "conclusion": "success"}]),
+            self._make_checks([{"conclusion": "success"}, {"conclusion": "skipped"}]),
+        ]
+        result = server.github_pr_check_status(pr_number=42)
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["overall_status"], "success")
+        self.assertTrue(result["pipeline_current"])
+        self.assertEqual(result["pr_number"], 42)
+        self.assertEqual(result["head_sha"], "abc123")
+
+    @patch.object(server, "_resolve_github_repo",
+                  return_value=("owner", "repo", "feature/x", None))
+    @patch.object(server, "_github_request")
+    def test_partial_failure(self, mock_gh, mock_repo):
+        mock_gh.side_effect = [
+            self._make_pr(42, sha="abc123"),
+            self._make_runs("abc123", [{"head_sha": "abc123", "conclusion": "failure"}]),
+            self._make_checks([
+                {"name": "build", "conclusion": "success"},
+                {"name": "test", "conclusion": "failure", "details_url": "https://logs/123"},
+            ]),
+        ]
+        result = server.github_pr_check_status(pr_number=42)
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["overall_status"], "failure")
+        failed_checks = [c for c in result["check_runs"] if c["conclusion"] == "failure"]
+        self.assertEqual(len(failed_checks), 1)
+        self.assertIn("details_url", failed_checks[0])
+
+    @patch.object(server, "_resolve_github_repo",
+                  return_value=("owner", "repo", "feature/x", None))
+    @patch.object(server, "_github_request")
+    def test_no_workflow_runs(self, mock_gh, mock_repo):
+        mock_gh.side_effect = [
+            self._make_pr(42, sha="abc123"),
+            {"workflow_runs": []},
+            {"check_runs": []},
+        ]
+        result = server.github_pr_check_status(pr_number=42)
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["overall_status"], "no_runs")
+        self.assertFalse(result["pipeline_current"])
+
+    @patch.object(server, "_resolve_github_repo",
+                  return_value=("owner", "repo", "feature/x", None))
+    @patch.object(server, "_github_request")
+    def test_stale_workflow_run(self, mock_gh, mock_repo):
+        # Workflow run exists but targets an older commit SHA
+        mock_gh.side_effect = [
+            self._make_pr(42, sha="new_sha"),
+            self._make_runs("new_sha", [{"head_sha": "old_sha", "conclusion": "success"}]),
+            {"check_runs": []},
+        ]
+        result = server.github_pr_check_status(pr_number=42)
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["overall_status"], "stale")
+        self.assertFalse(result["pipeline_current"])
+
+    @patch.object(server, "_resolve_github_repo",
+                  return_value=("owner", "repo", "feature/x", None))
+    @patch.object(server, "_github_request")
+    def test_lookup_pr_by_branch(self, mock_gh, mock_repo):
+        mock_gh.side_effect = [
+            [self._make_pr(7, sha="sha7")],  # PR list
+            self._make_runs("sha7", [{"head_sha": "sha7"}]),
+            {"check_runs": []},
+        ]
+        result = server.github_pr_check_status()
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["pr_number"], 7)
+        self.assertEqual(result["head_sha"], "sha7")
+
+    @patch.object(server, "_resolve_github_repo",
+                  return_value=("owner", "repo", "feature/x", None))
+    @patch.object(server, "_github_request", return_value=[])
+    def test_no_open_pr_for_branch(self, mock_gh, mock_repo):
+        result = server.github_pr_check_status()
+        self.assertFalse(result["ok"])
+        self.assertIn("No open PR", result["error"])
+
+    @patch.object(server, "_resolve_github_repo",
+                  return_value=("owner", "repo", "", None))
+    def test_no_branch_and_no_pr_number(self, mock_repo):
+        result = server.github_pr_check_status()
+        self.assertFalse(result["ok"])
+        self.assertIn("pr_number or branch", result["error"])
+
+    @patch.object(server, "_resolve_github_repo",
+                  return_value=("", "", "", {"ok": False, "error": "bad repo"}))
+    def test_repo_resolution_error_propagates(self, mock_repo):
+        result = server.github_pr_check_status(pr_number=1)
+        self.assertFalse(result["ok"])
+
+    def test_requires_read_scope(self):
+        _grant_scopes("write")
+        with self.assertRaises(PermissionError):
+            server.github_pr_check_status(pr_number=1)
+
+    @patch.object(server, "_resolve_github_repo",
+                  return_value=("owner", "repo", "feature/x", None))
+    @patch.object(server, "_github_request")
+    def test_pending_checks(self, mock_gh, mock_repo):
+        mock_gh.side_effect = [
+            self._make_pr(42, sha="abc123"),
+            self._make_runs("abc123", [{"head_sha": "abc123", "conclusion": None,
+                                        "status": "in_progress"}]),
+            self._make_checks([{"status": "in_progress", "conclusion": None}]),
+        ]
+        result = server.github_pr_check_status(pr_number=42)
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["overall_status"], "pending")
+
+
+# -----------------------------------------------------------------------
 # Tool registration (no duplicate names)
 # -----------------------------------------------------------------------
 
@@ -1492,6 +1798,8 @@ class TestToolRegistration(unittest.TestCase):
             "github_list_open_prs",
             "github_create_pr",
             "github_request_copilot_review",
+            "github_read_file",
+            "github_pr_check_status",
         }
         registered = set(tools.keys())
         missing = expected - registered


### PR DESCRIPTION
Adds two new GitHub-related tools to tools/mcp/manager/server.py:

- github_read_file: reads any file from any GitHub repo/branch/ref via the Contents API. Enforces a 1 MB size limit and rejects binary files with a clear error rather than returning garbage. Accepts workstream_id for repo resolution or an explicit repo_url.

- github_pr_check_status: answers "is CI current and did it pass?" for a PR. Fetches the PR's HEAD commit SHA, queries /actions/runs?head_sha= for workflow runs, and /commits/{sha}/check-runs for individual check results. Returns a structured response including pipeline_current flag (whether any run targets the exact HEAD commit), overall_status (success/failure/stale/no_runs/pending/mixed), per-run details, and per-check details with html_url/details_url for failed jobs.

Both tools follow the existing @mcp.tool() decorator pattern and declare all parameters in their function signatures so FastMCP generates correct JSON schemas.

Updates:
- tools/mcp/manager/test_server.py: 22 new test cases covering success, file-not-found, binary file, oversized file, stale runs, no runs, partial failure, pending CI, and branch-based PR lookup.
- flowtree/src/test/java/io/flowtree/jobs/McpToolDiscoveryTest.java: adds both tools to the expected set and asserts key parameters are declared in the signatures.

All 204 Python tests and 14 Java McpToolDiscoveryTest tests pass.