### PR TITLE
Refactor project_read_plan to delegate to github_read_file

### DIFF
--- a/tools/mcp/manager/server.py
+++ b/tools/mcp/manager/server.py
@@ -2141,35 +2141,28 @@ def project_commit_plan(
 @mcp.tool()
 def project_read_plan(
     workstream_id: str,
-    path: str = "",
     branch: str = "",
 ) -> dict:
-    """Read the planning document for a workstream from GitHub.
+    """Read the planning document for a workstream (delegates to github_read_file).
 
-    Fetches the file content via the GitHub Contents API, routed through
-    the FlowTree controller's proxy for authentication. Only works for
-    repositories hosted on GitHub.
-
-    If no path is provided, uses the workstream's configured
-    ``planningDocument`` path.
+    Looks up the workstream's configured ``planningDocument`` path and
+    delegates to :func:`github_read_file` to fetch its content. The
+    planning document path must be set via ``workstream_update_config``.
 
     Args:
         workstream_id: Workstream to read from (from workstream_list).
-        path: File path in the repository. Defaults to the workstream's
-            configured planningDocument.
-        branch: Branch to read from (default: workstream's defaultBranch).
+        branch: Branch to read from. Defaults to the workstream's
+            ``defaultBranch``.
 
     Returns:
-        Dictionary with the file content, path, and branch.
+        Dictionary with file content, path, sha, and repo.
     """
     _require_scope("read")
-    err = _check_short_strings(
-        workstream_id=workstream_id, path=path, branch=branch,
-    )
+    err = _check_short_strings(workstream_id=workstream_id, branch=branch)
     if err:
         return err
     _require_workstream_in_scope(workstream_id)
-    _audit("project_read_plan", workstream_id=workstream_id, path=path, branch=branch)
+    _audit("project_read_plan", workstream_id=workstream_id, branch=branch)
 
     ws = _find_workstream(workstream_id)
     if ws is None:
@@ -2179,75 +2172,36 @@ def project_read_plan(
             "next_steps": ["Use workstream_list to find valid workstream IDs"],
         }
 
-    _set_github_org(ws)
-
-    repo_url = ws.get("repoUrl")
-    if not repo_url:
-        return _pipeline_error(workstream_id, "repo_url is not configured")
-
-    owner_repo = _extract_owner_repo(repo_url)
-    if not owner_repo:
-        return {
-            "ok": False,
-            "error": f"Cannot parse owner/repo from: {repo_url}",
-            "next_steps": ["Use workstream_update_config to fix repo_url"],
-        }
-
-    owner, repo = owner_repo
-    effective_branch = branch or ws.get("defaultBranch", "")
-    if not effective_branch:
-        return {
-            "ok": False,
-            "error": "No branch specified and workstream has no defaultBranch",
-            "next_steps": ["Provide the branch parameter explicitly"],
-        }
-
-    effective_path = path or ws.get("planningDocument", "")
-    if not effective_path:
+    planning_doc = ws.get("planningDocument", "")
+    if not planning_doc:
         return {
             "ok": False,
             "error": "No planning document path configured for this workstream",
             "next_steps": [
-                "Provide the path parameter explicitly",
-                "Or use workstream_update_config to set planning_document",
+                "Use workstream_update_config to set planning_document",
             ],
         }
 
-    ref_param = quote(effective_branch, safe="")
-    result = _github_request(
-        "GET",
-        f"/repos/{owner}/{repo}/contents/{quote(effective_path, safe='/')}?ref={ref_param}",
+    repo_url = ws.get("repoUrl", "")
+    effective_branch = branch or ws.get("defaultBranch", "")
+
+    result = github_read_file(
+        path=planning_doc,
+        repo_url=repo_url,
+        branch=effective_branch,
     )
 
-    if result.get("ok") is False:
-        result.setdefault("next_steps", [
-            f"Verify the file exists at '{effective_path}' on branch '{effective_branch}'",
-            "Use project_commit_plan to create the planning document first",
-        ])
-        return result
-
-    content_b64 = result.get("content", "")
-    encoding = result.get("encoding", "")
-    if encoding == "base64" and content_b64:
-        try:
-            content = base64.b64decode(content_b64).decode("utf-8")
-        except Exception:
-            content = content_b64
-    else:
-        content = content_b64
-
-    return {
-        "ok": True,
-        "path": effective_path,
-        "branch": effective_branch,
-        "repo": f"{owner}/{repo}",
-        "content": content,
-        "sha": result.get("sha", ""),
-        "next_steps": [
+    if result.get("ok"):
+        result["next_steps"] = [
             "Use project_commit_plan to update this document",
             "Use workstream_submit_task to send an agent to work on the plan",
-        ],
-    }
+        ]
+    else:
+        result.setdefault("next_steps", [
+            f"Verify the file exists at '{planning_doc}'",
+            "Use project_commit_plan to create the planning document first",
+        ])
+    return result
 
 
 # -- Tier 3: Memory tools ---------------------------------------------------

--- a/tools/mcp/manager/server.py
+++ b/tools/mcp/manager/server.py
@@ -2141,6 +2141,7 @@ def project_commit_plan(
 @mcp.tool()
 def project_read_plan(
     workstream_id: str,
+    path: str = "",
     branch: str = "",
 ) -> dict:
     """Read the planning document for a workstream (delegates to github_read_file).
@@ -2151,18 +2152,22 @@ def project_read_plan(
 
     Args:
         workstream_id: Workstream to read from (from workstream_list).
+        path: Override for the planning document path. When omitted, the
+            workstream's configured ``planningDocument`` path is used.
         branch: Branch to read from. Defaults to the workstream's
             ``defaultBranch``.
 
     Returns:
-        Dictionary with file content, path, sha, and repo.
+        Dictionary with file content, path, branch, sha, and repo.
     """
     _require_scope("read")
-    err = _check_short_strings(workstream_id=workstream_id, branch=branch)
+    err = _check_short_strings(
+        workstream_id=workstream_id, path=path, branch=branch,
+    )
     if err:
         return err
     _require_workstream_in_scope(workstream_id)
-    _audit("project_read_plan", workstream_id=workstream_id, branch=branch)
+    _audit("project_read_plan", workstream_id=workstream_id, path=path, branch=branch)
 
     ws = _find_workstream(workstream_id)
     if ws is None:
@@ -2172,33 +2177,55 @@ def project_read_plan(
             "next_steps": ["Use workstream_list to find valid workstream IDs"],
         }
 
-    planning_doc = ws.get("planningDocument", "")
-    if not planning_doc:
+    effective_path = path or ws.get("planningDocument", "")
+    if not effective_path:
         return {
             "ok": False,
             "error": "No planning document path configured for this workstream",
             "next_steps": [
+                "Provide the path parameter explicitly",
                 "Use workstream_update_config to set planning_document",
             ],
         }
 
     repo_url = ws.get("repoUrl", "")
+    if not repo_url:
+        return {
+            "ok": False,
+            "error": "No repository URL configured for this workstream",
+            "next_steps": [
+                "Use workstream_update_config to set repo_url",
+            ],
+        }
+
     effective_branch = branch or ws.get("defaultBranch", "")
+    if not effective_branch:
+        return {
+            "ok": False,
+            "error": "No branch configured for this workstream",
+            "next_steps": [
+                "Pass branch explicitly when calling project_read_plan",
+                "Use workstream_update_config to set default_branch",
+            ],
+        }
 
     result = github_read_file(
-        path=planning_doc,
+        path=effective_path,
         repo_url=repo_url,
         branch=effective_branch,
+        workstream_id=workstream_id,
     )
 
     if result.get("ok"):
+        # Expose branch alongside ref for backward compatibility
+        result.setdefault("branch", result.get("ref", effective_branch))
         result["next_steps"] = [
             "Use project_commit_plan to update this document",
             "Use workstream_submit_task to send an agent to work on the plan",
         ]
     else:
         result.setdefault("next_steps", [
-            f"Verify the file exists at '{planning_doc}'",
+            f"Verify the file exists at '{effective_path}'",
             "Use project_commit_plan to create the planning document first",
         ])
     return result

--- a/tools/mcp/manager/test_server.py
+++ b/tools/mcp/manager/test_server.py
@@ -664,6 +664,60 @@ class TestProjectReadPlan(unittest.TestCase):
         self.assertEqual(result["content"], "# My Plan")
         self.assertEqual(result["path"], "docs/plans/PLAN.md")
 
+    @patch.object(server, "github_read_file")
+    @patch.object(server, "_find_workstream")
+    def test_delegates_to_github_read_file(self, mock_find, mock_read_file):
+        """project_read_plan must resolve the planningDocument and delegate to github_read_file."""
+        _grant_all_scopes()
+        mock_find.return_value = {
+            "repoUrl": "https://github.com/org/repo",
+            "defaultBranch": "feature/x",
+            "planningDocument": "docs/plans/PLAN.md",
+        }
+        mock_read_file.return_value = {
+            "ok": True,
+            "path": "docs/plans/PLAN.md",
+            "content": "# My Plan",
+            "sha": "abc123",
+            "repo": "org/repo",
+        }
+        result = server.project_read_plan(workstream_id="ws-test")
+        mock_read_file.assert_called_once_with(
+            path="docs/plans/PLAN.md",
+            repo_url="https://github.com/org/repo",
+            branch="feature/x",
+        )
+        self.assertTrue(result["ok"])
+        next_steps = result.get("next_steps", [])
+        self.assertTrue(
+            any("project_commit_plan" in s for s in next_steps),
+            "Expected project_commit_plan in next_steps",
+        )
+
+    @patch.object(server, "github_read_file")
+    @patch.object(server, "_find_workstream")
+    def test_delegate_uses_explicit_branch(self, mock_find, mock_read_file):
+        """An explicit branch parameter is forwarded to github_read_file."""
+        _grant_all_scopes()
+        mock_find.return_value = {
+            "repoUrl": "https://github.com/org/repo",
+            "defaultBranch": "master",
+            "planningDocument": "docs/plans/PLAN.md",
+        }
+        mock_read_file.return_value = {
+            "ok": True,
+            "path": "docs/plans/PLAN.md",
+            "content": "# Plan",
+            "sha": "def456",
+            "repo": "org/repo",
+        }
+        server.project_read_plan(workstream_id="ws-test", branch="feature/x")
+        mock_read_file.assert_called_once_with(
+            path="docs/plans/PLAN.md",
+            repo_url="https://github.com/org/repo",
+            branch="feature/x",
+        )
+
     @patch.object(server, "_find_workstream")
     def test_no_planning_document(self, mock_find):
         _grant_all_scopes()

--- a/tools/mcp/manager/test_server.py
+++ b/tools/mcp/manager/test_server.py
@@ -643,21 +643,22 @@ class TestProjectCommitPlan(unittest.TestCase):
 
 class TestProjectReadPlan(unittest.TestCase):
 
+    @patch.object(server, "github_read_file")
     @patch.object(server, "_find_workstream")
-    @patch.object(server, "_github_request")
-    def test_read_plan(self, mock_gh, mock_find):
+    def test_read_plan(self, mock_find, mock_read_file):
         _grant_all_scopes()
-        import base64
-        content_b64 = base64.b64encode(b"# My Plan").decode()
         mock_find.return_value = {
             "repoUrl": "https://github.com/org/repo",
             "defaultBranch": "feature/x",
             "planningDocument": "docs/plans/PLAN.md",
         }
-        mock_gh.return_value = {
-            "content": content_b64,
-            "encoding": "base64",
+        mock_read_file.return_value = {
+            "ok": True,
+            "path": "docs/plans/PLAN.md",
+            "content": "# My Plan",
             "sha": "abc123",
+            "ref": "feature/x",
+            "repo": "org/repo",
         }
         result = server.project_read_plan(workstream_id="ws-test")
         self.assertTrue(result["ok"])
@@ -686,6 +687,7 @@ class TestProjectReadPlan(unittest.TestCase):
             path="docs/plans/PLAN.md",
             repo_url="https://github.com/org/repo",
             branch="feature/x",
+            workstream_id="ws-test",
         )
         self.assertTrue(result["ok"])
         next_steps = result.get("next_steps", [])
@@ -716,6 +718,7 @@ class TestProjectReadPlan(unittest.TestCase):
             path="docs/plans/PLAN.md",
             repo_url="https://github.com/org/repo",
             branch="feature/x",
+            workstream_id="ws-test",
         )
 
     @patch.object(server, "_find_workstream")


### PR DESCRIPTION
project_read_plan was duplicating GitHub file-fetch logic that now lives in the more general github_read_file tool. Reduce it to a thin delegate: resolve the workstream's planningDocument path, then forward to github_read_file with repo_url and branch. Add planning-document- specific next_steps to the result on both success and failure paths.

Also add two new delegation tests (test_delegates_to_github_read_file, test_delegate_uses_explicit_branch) that verify the planning document path is looked up from the workstream config and passed through correctly.