### PR TITLE
SkyTNT track-filter substrate: add allowedTrackIds parameter

### DIFF
--- a/studio/compose/src/main/java/org/almostrealism/studio/midi/SkyTntMidi.java
+++ b/studio/compose/src/main/java/org/almostrealism/studio/midi/SkyTntMidi.java
@@ -34,9 +34,11 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 
 import org.almostrealism.music.midi.MidiNoteEvent;
 
@@ -238,12 +240,11 @@ public class SkyTntMidi implements AttentionFeatures, ConsoleFeatures {
 	// -----------------------------------------------------------------------
 
 	/**
-	 * Generate a MIDI event sequence from a prompt token sequence.
+	 * Generate a MIDI event sequence from a prompt token sequence with no track filter.
 	 *
-	 * <p>The prompt is prefilled into the main transformer's KV cache before generation
-	 * begins.  The first row of {@code promptTokens} should be the BOS event
-	 * ({@code [1, 0, 0, 0, 0, 0, 0, 0]}).  Generation stops when the model produces
-	 * an EOS token or {@code maxNewEvents} events have been generated.</p>
+	 * <p>Equivalent to calling
+	 * {@link #generate(int[][], int, double, double, int, int[])} with
+	 * {@code allowedTrackIds == null}.</p>
 	 *
 	 * @param promptTokens  token array of shape (promptLen x maxTokenSeq); must not be null
 	 * @param maxNewEvents  maximum number of new events to generate
@@ -254,6 +255,42 @@ public class SkyTntMidi implements AttentionFeatures, ConsoleFeatures {
 	 */
 	public int[][] generate(int[][] promptTokens, int maxNewEvents,
 							double temperature, double topP, int topK) {
+		return generate(promptTokens, maxNewEvents, temperature, topP, topK, null);
+	}
+
+	/**
+	 * Generate a MIDI event sequence from a prompt token sequence, optionally
+	 * restricting generated events to a subset of MIDI track IDs.
+	 *
+	 * <p>The prompt is prefilled into the main transformer's KV cache before generation
+	 * begins.  The first row of {@code promptTokens} should be the BOS event
+	 * ({@code [1, 0, 0, 0, 0, 0, 0, 0]}).  Generation stops when the model produces
+	 * an EOS token or {@code maxNewEvents} events have been generated.</p>
+	 *
+	 * <p>When {@code allowedTrackIds} is non-null the per-event track parameter
+	 * (step 3 of the inner token loop) is constrained to the supplied set: only
+	 * track values present in the array can be sampled.  Other event parameters
+	 * (event-type, time, channel, pitch, velocity, duration, etc.) are unaffected.
+	 * Prompt events are never filtered — they are prefilled verbatim — so events
+	 * with disallowed tracks in the prompt remain in the returned sequence.</p>
+	 *
+	 * @param promptTokens    token array of shape (promptLen x maxTokenSeq); must not be null
+	 * @param maxNewEvents    maximum number of new events to generate
+	 * @param temperature     sampling temperature (0 = greedy argmax)
+	 * @param topP            nucleus sampling threshold (1.0 = no nucleus filtering)
+	 * @param topK            top-k limit (0 = no top-k filtering)
+	 * @param allowedTrackIds when non-null, restricts generated events to the
+	 *                        specified track IDs (0–127). {@code null} means
+	 *                        no filter (preserves legacy behaviour). Empty array
+	 *                        is rejected because it would block all generation.
+	 * @return full token array including prompt, shape ((promptLen + generatedLen) x maxTokenSeq)
+	 * @throws IllegalArgumentException if {@code allowedTrackIds} is a zero-length array
+	 *         or contains a value outside the valid range [0, 127]
+	 */
+	public int[][] generate(int[][] promptTokens, int maxNewEvents,
+							double temperature, double topP, int topK,
+							int[] allowedTrackIds) {
+		Set<Integer> allowedTrackTokens = validateAndExpandTrackFilter(allowedTrackIds);
 		List<int[]> sequence = new ArrayList<>(Arrays.asList(promptTokens));
 
 		// Prefill: process all prompt positions to populate the net KV cache.
@@ -289,6 +326,9 @@ public class SkyTntMidi implements AttentionFeatures, ConsoleFeatures {
 				// Apply validity mask: zero out logits for tokens that are not valid
 				// at this step (given the event type chosen at step 0)
 				int[] validIds = tokenizer.getValidTokenIds(step, eventTypeId);
+				if (step == 3 && allowedTrackTokens != null) {
+					validIds = intersectWithTokenSet(validIds, allowedTrackTokens);
+				}
 				PackedCollection maskedLogits = applyMask(rawLogits, validIds);
 
 				int sampledToken = sampleWithTopK(maskedLogits, temperature, topP, topK);
@@ -323,11 +363,11 @@ public class SkyTntMidi implements AttentionFeatures, ConsoleFeatures {
 	}
 
 	/**
-	 * Generate complementary MIDI events from a list of existing events.
+	 * Generate complementary MIDI events from a list of existing events with no track filter.
 	 *
-	 * <p>Converts the events to tokens (with BOS), generates up to
-	 * {@code maxNewEvents} additional events, detokenizes the generated portion,
-	 * and returns only the newly generated events (not the prompt events).</p>
+	 * <p>Equivalent to calling
+	 * {@link #generateFromEvents(List, int, double, double, int, int, int[])}
+	 * with {@code allowedTrackIds == null}.</p>
 	 *
 	 * @param promptEvents   existing events to use as context (not returned in output)
 	 * @param maxNewEvents   maximum number of new events to generate
@@ -340,10 +380,46 @@ public class SkyTntMidi implements AttentionFeatures, ConsoleFeatures {
 	public List<MidiNoteEvent> generateFromEvents(List<MidiNoteEvent> promptEvents,
 													int maxNewEvents, double temperature,
 													double topP, int topK, int ticksPerBeat) {
+		return generateFromEvents(promptEvents, maxNewEvents, temperature,
+				topP, topK, ticksPerBeat, null);
+	}
+
+	/**
+	 * Generate complementary MIDI events from a list of existing events, optionally
+	 * restricting generated events to a subset of MIDI track IDs.
+	 *
+	 * <p>Converts the events to tokens (with BOS), generates up to
+	 * {@code maxNewEvents} additional events, detokenizes the generated portion,
+	 * and returns only the newly generated events (not the prompt events).</p>
+	 *
+	 * <p>When {@code allowedTrackIds} is non-null, generated events are constrained
+	 * to the supplied track IDs (see
+	 * {@link #generate(int[][], int, double, double, int, int[])} for full filter
+	 * semantics).  Prompt events are tokenized verbatim — the filter does not
+	 * touch them — and are absent from the returned list either way.</p>
+	 *
+	 * @param promptEvents    existing events to use as context (not returned in output)
+	 * @param maxNewEvents    maximum number of new events to generate
+	 * @param temperature     sampling temperature
+	 * @param topP            nucleus sampling threshold
+	 * @param topK            top-k limit (0 = disabled)
+	 * @param ticksPerBeat    MIDI PPQ resolution for timing quantization
+	 * @param allowedTrackIds when non-null, restricts generated events to the
+	 *                        specified track IDs (0–127). {@code null} means
+	 *                        no filter. Empty array is rejected.
+	 * @return newly generated MIDI events (does not include prompt events)
+	 * @throws IllegalArgumentException if {@code allowedTrackIds} is a zero-length array
+	 *         or contains a value outside the valid range [0, 127]
+	 */
+	public List<MidiNoteEvent> generateFromEvents(List<MidiNoteEvent> promptEvents,
+													int maxNewEvents, double temperature,
+													double topP, int topK, int ticksPerBeat,
+													int[] allowedTrackIds) {
 		int[][] promptTokens = tokenizer.tokenize(promptEvents, ticksPerBeat);
 		int promptLen = promptTokens.length;
 
-		int[][] fullSequence = generate(promptTokens, maxNewEvents, temperature, topP, topK);
+		int[][] fullSequence = generate(promptTokens, maxNewEvents, temperature, topP, topK,
+				allowedTrackIds);
 
 		// Detokenize only the newly generated rows (excluding prompt)
 		int generatedLen = fullSequence.length - promptLen;
@@ -500,6 +576,70 @@ public class SkyTntMidi implements AttentionFeatures, ConsoleFeatures {
 		PackedCollection result = new PackedCollection(new TraversalPolicy(1, config.hiddenSize));
 		result.setMem(0, netTokenEmbedTokens, tokenId * config.hiddenSize, config.hiddenSize);
 		return result;
+	}
+
+	// -----------------------------------------------------------------------
+	//  Track-filter helpers (orchestration over int[] vocabulary positions)
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Validates a caller-supplied {@code allowedTrackIds} array and expands it
+	 * to the corresponding vocabulary token positions used at step 3 of the
+	 * inner token loop.
+	 *
+	 * <p>The returned set is built once per call to {@code generate()} and
+	 * re-used on every iteration of the inner token loop, so the per-event
+	 * filter intersection at step 3 is O(|validIds|) rather than O(|validIds|
+	 * + |filter|).</p>
+	 *
+	 * @param allowedTrackIds the raw track ID filter from the caller; may be null
+	 * @return null when {@code allowedTrackIds} is null (no filter); otherwise a
+	 *         set of vocabulary positions {@code TRACK_OFFSET + id} for each
+	 *         allowed track ID
+	 * @throws IllegalArgumentException if the array is empty or contains values
+	 *         outside [0, 127]
+	 */
+	static Set<Integer> validateAndExpandTrackFilter(int[] allowedTrackIds) {
+		if (allowedTrackIds == null) {
+			return null;
+		}
+		if (allowedTrackIds.length == 0) {
+			throw new IllegalArgumentException(
+					"empty track filter would block all generation");
+		}
+		Set<Integer> tokens = new HashSet<>(allowedTrackIds.length * 2);
+		for (int i = 0; i < allowedTrackIds.length; i++) {
+			int id = allowedTrackIds[i];
+			if (id < 0 || id >= SkyTntTokenizerV2.TRACK_RANGE) {
+				throw new IllegalArgumentException(
+						"allowedTrackIds[" + i + "] = " + id +
+								" is out of range [0, " +
+								(SkyTntTokenizerV2.TRACK_RANGE - 1) + "]");
+			}
+			tokens.add(SkyTntTokenizerV2.TRACK_OFFSET + id);
+		}
+		return tokens;
+	}
+
+	/**
+	 * Returns the intersection of a tokenizer validity mask with a
+	 * caller-supplied allow-list expressed as a {@link Set} of token IDs.
+	 * The result preserves the order of the input {@code validIds}, which
+	 * keeps the per-step distribution shape predictable.
+	 *
+	 * @param validIds   the base validity mask from the tokenizer
+	 * @param filterSet  the supplemental allow-list (e.g. allowed track token IDs)
+	 * @return new array containing only token IDs present in both inputs
+	 */
+	static int[] intersectWithTokenSet(int[] validIds, Set<Integer> filterSet) {
+		int[] tmp = new int[validIds.length];
+		int n = 0;
+		for (int id : validIds) {
+			if (filterSet.contains(id)) {
+				tmp[n++] = id;
+			}
+		}
+		return Arrays.copyOf(tmp, n);
 	}
 
 	// -----------------------------------------------------------------------

--- a/studio/compose/src/main/java/org/almostrealism/studio/midi/SkyTntTokenizerV2.java
+++ b/studio/compose/src/main/java/org/almostrealism/studio/midi/SkyTntTokenizerV2.java
@@ -127,8 +127,11 @@ public class SkyTntTokenizerV2 implements ConsoleFeatures {
     /** Base token ID for duration parameter (2048 values). */
     public static final int DURATION_OFFSET = 153;
 
-    /** Base token ID for track parameter (128 values). */
+    /** Base token ID for track parameter. */
     public static final int TRACK_OFFSET = 2201;
+
+    /** Number of distinct track parameter values (track IDs 0..TRACK_RANGE-1). */
+    public static final int TRACK_RANGE = 128;
 
     /** Base token ID for channel parameter (16 values). */
     public static final int CHANNEL_OFFSET = 2329;

--- a/studio/compose/src/test/java/org/almostrealism/studio/midi/test/SkyTntMidiTest.java
+++ b/studio/compose/src/test/java/org/almostrealism/studio/midi/test/SkyTntMidiTest.java
@@ -27,13 +27,18 @@ import org.almostrealism.studio.midi.SkyTntConfig;
 import org.almostrealism.studio.midi.SkyTntMidi;
 import org.almostrealism.studio.midi.SkyTntTokenizerV2;
 import org.almostrealism.model.CompiledModel;
+import org.almostrealism.music.midi.MidiNoteEvent;
 import org.almostrealism.util.TestSuiteBase;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 
 /**
  * Milestones 4 and 5 tests: model assembly with synthetic weights and the
@@ -283,9 +288,255 @@ public class SkyTntMidiTest extends TestSuiteBase {
 		}
 	}
 
+	/**
+	 * Verifies that {@link SkyTntMidi#generate(int[][], int, double, double, int, int[])}
+	 * restricts the track parameter of every generated event to the single track
+	 * supplied in {@code allowedTrackIds}.
+	 */
+	@Test(timeout = 60000)
+	public void generateRespectsAllowedTracksSingle() {
+		if (skipLongTests) return;
+
+		SkyTntMidi model = buildSyntheticModel(new Random(11), new Random(13));
+
+		int[][] prompt = bosPrompt(model.getConfig());
+		int[][] output = model.generate(prompt, 4,
+				SkyTntMidi.DEFAULT_TEMPERATURE,
+				SkyTntMidi.DEFAULT_TOP_P,
+				SkyTntMidi.DEFAULT_TOP_K,
+				new int[]{0});
+
+		assertGeneratedTracksWithin(output, prompt.length, new int[]{0});
+	}
+
+	/**
+	 * Verifies that {@link SkyTntMidi#generate(int[][], int, double, double, int, int[])}
+	 * restricts the track parameter of every generated event to one of the values
+	 * supplied in {@code allowedTrackIds}.
+	 */
+	@Test(timeout = 60000)
+	public void generateRespectsAllowedTracksMultiple() {
+		if (skipLongTests) return;
+
+		SkyTntMidi model = buildSyntheticModel(new Random(21), new Random(23));
+
+		int[][] prompt = bosPrompt(model.getConfig());
+		int[][] output = model.generate(prompt, 6,
+				SkyTntMidi.DEFAULT_TEMPERATURE,
+				SkyTntMidi.DEFAULT_TOP_P,
+				SkyTntMidi.DEFAULT_TOP_K,
+				new int[]{0, 5});
+
+		assertGeneratedTracksWithin(output, prompt.length, new int[]{0, 5});
+	}
+
+	/**
+	 * Verifies that passing {@code null} as the track filter preserves the
+	 * legacy (no-filter) behaviour, producing the same token sequence as the
+	 * legacy overload when called with identical RNG state.
+	 */
+	@Test(timeout = 60000)
+	public void generateNullFilterMatchesUnfiltered() {
+		if (skipLongTests) return;
+
+		SkyTntMidi modelA = buildSyntheticModel(new Random(31), new Random(37));
+		int[][] promptA = bosPrompt(modelA.getConfig());
+		int[][] outputLegacy = modelA.generate(promptA, 3,
+				SkyTntMidi.DEFAULT_TEMPERATURE,
+				SkyTntMidi.DEFAULT_TOP_P,
+				SkyTntMidi.DEFAULT_TOP_K);
+
+		SkyTntMidi modelB = buildSyntheticModel(new Random(31), new Random(37));
+		int[][] promptB = bosPrompt(modelB.getConfig());
+		int[][] outputNullFilter = modelB.generate(promptB, 3,
+				SkyTntMidi.DEFAULT_TEMPERATURE,
+				SkyTntMidi.DEFAULT_TOP_P,
+				SkyTntMidi.DEFAULT_TOP_K,
+				null);
+
+		Assert.assertEquals("Null filter must produce the same row count as the legacy overload",
+				outputLegacy.length, outputNullFilter.length);
+		for (int i = 0; i < outputLegacy.length; i++) {
+			Assert.assertArrayEquals(
+					"Row " + i + " must match between the legacy and null-filter overloads",
+					outputLegacy[i], outputNullFilter[i]);
+		}
+	}
+
+	/**
+	 * Verifies that an empty (zero-length) track filter is rejected with
+	 * {@link IllegalArgumentException} rather than silently blocking all
+	 * generation.  This test does not require a forward pass, so it runs
+	 * unconditionally.
+	 */
+	@Test(timeout = 60000)
+	public void generateEmptyFilterRejected() {
+		SkyTntMidi model = buildSyntheticModel(new Random(41), new Random(43));
+
+		int[][] prompt = bosPrompt(model.getConfig());
+
+		try {
+			model.generate(prompt, 2,
+					SkyTntMidi.DEFAULT_TEMPERATURE,
+					SkyTntMidi.DEFAULT_TOP_P,
+					SkyTntMidi.DEFAULT_TOP_K,
+					new int[0]);
+			Assert.fail("Empty allowedTrackIds should be rejected with IllegalArgumentException");
+		} catch (IllegalArgumentException expected) {
+			// pass — message content not enforced
+		}
+	}
+
+	/**
+	 * Verifies that the track filter only constrains the track parameter and
+	 * leaves the rest of the per-event token layout intact, including events
+	 * whose non-track parameters (BPM, controller value, etc.) live in
+	 * separate vocabulary regions.  The test asserts the contract by feeding
+	 * SET_TEMPO and CONTROL_CHANGE events through the prompt path and
+	 * verifying that they round-trip unmodified while a filtered single-track
+	 * generation still produces correctly-tracked output.
+	 */
+	@Test(timeout = 60000)
+	public void generateFilterDoesNotAffectTempoOrControl() {
+		if (skipLongTests) return;
+
+		SkyTntMidi model = buildSyntheticModel(new Random(51), new Random(53));
+
+		List<MidiNoteEvent> prompt = new ArrayList<>();
+		prompt.add(MidiNoteEvent.setTempo(0, 99, 120));
+		prompt.add(MidiNoteEvent.controlChange(0, 99, 1, 7, 64));
+		prompt.add(MidiNoteEvent.note(48, 0, 0, 60, 80, 16));
+
+		// Sanity: tokenize -> detokenize round-trips the tempo and control events,
+		// proving that the filter site (step 3) is the only point that touches the
+		// track parameter for these event types.
+		int[][] roundTripTokens = model.getTokenizer().tokenize(prompt,
+				SkyTntMidi.DEFAULT_TICKS_PER_BEAT);
+		List<MidiNoteEvent> roundTrip = model.getTokenizer().detokenize(roundTripTokens,
+				SkyTntMidi.DEFAULT_TICKS_PER_BEAT);
+		Assert.assertEquals("Round-trip should preserve the prompt event count",
+				prompt.size(), roundTrip.size());
+		boolean sawTempo = false;
+		boolean sawControl = false;
+		for (MidiNoteEvent event : roundTrip) {
+			if (event.getEventType() == MidiNoteEvent.EventType.SET_TEMPO) {
+				Assert.assertEquals(120, event.getBpm());
+				Assert.assertEquals(99, event.getTrack());
+				sawTempo = true;
+			} else if (event.getEventType() == MidiNoteEvent.EventType.CONTROL_CHANGE) {
+				Assert.assertEquals(7, event.getController());
+				Assert.assertEquals(64, event.getCcValue());
+				Assert.assertEquals(99, event.getTrack());
+				sawControl = true;
+			}
+		}
+		Assert.assertTrue("Tempo event must round-trip with bpm and track preserved", sawTempo);
+		Assert.assertTrue("Control event must round-trip with controller/value/track preserved",
+				sawControl);
+
+		List<MidiNoteEvent> generated = model.generateFromEvents(prompt, 4,
+				SkyTntMidi.DEFAULT_TEMPERATURE,
+				SkyTntMidi.DEFAULT_TOP_P,
+				SkyTntMidi.DEFAULT_TOP_K,
+				SkyTntMidi.DEFAULT_TICKS_PER_BEAT,
+				new int[]{0});
+
+		for (MidiNoteEvent event : generated) {
+			Assert.assertEquals(
+					"Every generated event (event-type " + event.getEventType() +
+							") should have track == 0 under the filter",
+					0, event.getTrack());
+		}
+	}
+
 	// -----------------------------------------------------------------------
 	//  Helpers
 	// -----------------------------------------------------------------------
+
+	/** Build a synthetic SkyTntMidi instance suitable for fast filter tests. */
+	static SkyTntMidi buildSyntheticModel(Random weightRng, Random samplerRng) {
+		SkyTntConfig config = new SkyTntConfig(VOCAB, DIM, EPSILON, 10000.0,
+				NET_LAYERS, HEADS, FFN, SEQ_LEN,
+				NET_TOKEN_LAYERS, HEADS_TOKEN, FFN_TOKEN);
+
+		StateDictionary stateDict = createSyntheticWeights(config, weightRng);
+
+		PdslLoader loader = new PdslLoader();
+		PdslNode.Program blockProgram = loader.parseResource("/pdsl/midi/skytnt_block.pdsl");
+		PdslNode.Program lmHeadProgram = loader.parseResource("/pdsl/midi/skytnt_lm_head.pdsl");
+
+		int netHeadSize = DIM / HEADS;
+		int tokenHeadSize = DIM / HEADS_TOKEN;
+		PackedCollection netPos = new PackedCollection(1);
+		PackedCollection tokenPos = new PackedCollection(1);
+		CollectionProducer netFreqCis = RotationFeatures.computeRopeFreqs(
+				config.ropeTheta, netHeadSize, SEQ_LEN);
+		CollectionProducer tokenFreqCis = RotationFeatures.computeRopeFreqs(
+				config.ropeTheta, tokenHeadSize, SEQ_LEN);
+
+		PackedCollection netEmbed = new PackedCollection(new TraversalPolicy(VOCAB, DIM));
+		PackedCollection tokenEmbed = new PackedCollection(new TraversalPolicy(VOCAB, DIM));
+		PackedCollection lmHeadWeight = stateDict.get("lm_head.weight");
+
+		CompiledModel netModel = SkyTntMidi.buildTransformerModel(
+				"net", stateDict, blockProgram, lmHeadProgram,
+				config.netLayers, config.netHeads,
+				netFreqCis, netPos, false, EPSILON, null);
+
+		CompiledModel netTokenModel = SkyTntMidi.buildTransformerModel(
+				"net_token", stateDict, blockProgram, lmHeadProgram,
+				config.netTokenLayers, config.netTokenHeads,
+				tokenFreqCis, tokenPos, true, EPSILON, lmHeadWeight);
+
+		return new SkyTntMidi(config, netEmbed, tokenEmbed,
+				netModel, netTokenModel, samplerRng);
+	}
+
+	/** Build a single-row BOS prompt for the supplied configuration. */
+	static int[][] bosPrompt(SkyTntConfig config) {
+		int[][] prompt = new int[1][config.maxTokenSeq];
+		prompt[0][0] = config.bosId;
+		return prompt;
+	}
+
+	/**
+	 * Asserts that every generated row (after the prompt prefix) carries a
+	 * track-parameter token whose decoded track ID is in {@code allowedIds},
+	 * if the row's event type has a track parameter at step 3.
+	 */
+	static void assertGeneratedTracksWithin(int[][] output, int promptLen, int[] allowedIds) {
+		Assert.assertNotNull("Generation output should not be null", output);
+		Assert.assertTrue("Output should retain the prompt rows", output.length >= promptLen);
+
+		Set<Integer> allowed = new HashSet<>();
+		for (int id : allowedIds) allowed.add(id);
+
+		int generatedRows = 0;
+		for (int i = promptLen; i < output.length; i++) {
+			int[] row = output[i];
+			int step0 = row[0];
+			if (step0 < SkyTntTokenizerV2.EVENT_NOTE
+					|| step0 > SkyTntTokenizerV2.EVENT_KEY_SIGNATURE) {
+				continue;  // EOS / PAD / unrecognized event — no track to check
+			}
+			int trackToken = row[3];
+			Assert.assertTrue(
+					"Row " + i + " step-3 token " + trackToken +
+							" is outside the track-token range",
+					trackToken >= SkyTntTokenizerV2.TRACK_OFFSET &&
+							trackToken < SkyTntTokenizerV2.TRACK_OFFSET +
+									SkyTntTokenizerV2.TRACK_RANGE);
+			int trackId = trackToken - SkyTntTokenizerV2.TRACK_OFFSET;
+			Assert.assertTrue(
+					"Row " + i + " has track " + trackId +
+							" which is outside the allowed set " + allowed,
+					allowed.contains(trackId));
+			generatedRows++;
+		}
+		Assert.assertTrue("Generation should have produced at least one trackable event",
+				generatedRows >= 1);
+	}
+
 
 	/**
 	 * Create a {@link StateDictionary} populated with random synthetic weights that


### PR DESCRIPTION
Iteration 2 of the ML-MIDI integration plan: add a track-filter parameter to SkyTNT's inference API so callers can constrain the generated track parameter to a chosen subset of MIDI track IDs.

Changes (common-only, no ringsdesktop touched):
- SkyTntMidi.generate(...): new 6-arg overload taking int[] allowedTrackIds; legacy 5-arg form delegates with null. Filter is applied only at step 3 of the inner token loop, intersecting the tokenizer validity mask with the caller's allow-list expanded to TRACK_OFFSET + id token positions. Filter is built once per generate() call as a Set for O(1) lookup inside the per-event step-3 intersection.
- SkyTntMidi.generateFromEvents(...): new 7-arg overload taking the same parameter; legacy 6-arg form delegates with null.
- SkyTntTokenizerV2: TRACK_RANGE constant (= 128) added alongside TRACK_OFFSET so the allow-list bounds check has a single source of truth.
- Helpers in SkyTntMidi: validateAndExpandTrackFilter (validates [0,127] range, rejects empty array with IllegalArgumentException) and intersectWithTokenSet (validity-mask intersection that preserves the original tokenizer order).
- Tests (SkyTntMidiTest): five new methods covering single-id, multi-id, null-filter parity with the legacy overload, empty-filter rejection, and filter passthrough for tempo/control events that have no track parameter at step 3.

Scope: substrate change only. No orchestration logic, no encoder exposure, no UX surface. Ringsdesktop integration is the next iteration.