### PR TITLE
Corrected issue with message tool

### DIFF
--- a/flowtree/runtime/src/main/java/io/flowtree/slack/FlowTreeApiEndpoint.java
+++ b/flowtree/runtime/src/main/java/io/flowtree/slack/FlowTreeApiEndpoint.java
@@ -525,6 +525,8 @@ public class FlowTreeApiEndpoint extends NanoHTTPD implements ConsoleFeatures {
         if (threadTs != null) {
             resultTs = targetNotifier.postMessageInThread(workstream.getChannelId(), text, threadTs);
         } else {
+            if (jobId != null) warn("send_message_no_thread_ts workstream_id=" + workstreamId
+                    + " job_id=" + jobId + " activity=" + (activity != null ? activity : ""));
             resultTs = targetNotifier.postMessage(workstream.getChannelId(), text);
         }
 
@@ -543,7 +545,6 @@ public class FlowTreeApiEndpoint extends NanoHTTPD implements ConsoleFeatures {
     /**
      * Stores a message in the ar-memory server's "messages" namespace.
      * A non-empty {@code activity} is appended as an {@code activity:<value>} tag.
-     *
      * @param activity enforcement phase name, or null/empty for primary work
      * @return null on success, or an error description on failure
      */

--- a/flowtree/runtime/src/main/java/io/flowtree/slack/JobStatsStore.java
+++ b/flowtree/runtime/src/main/java/io/flowtree/slack/JobStatsStore.java
@@ -576,6 +576,44 @@ public class JobStatsStore implements ConsoleFeatures {
     }
 
     /**
+     * Returns the persisted Slack message timestamp for {@code jobId}, or
+     * {@code null} when none has been recorded.
+     *
+     * <p>This is the durable counterpart to
+     * {@link SlackNotifier#getThreadTs(String)}'s in-memory lookup. The
+     * in-memory map is cleared by
+     * {@link SlackNotifier#onJobCompleted(String, JobCompletionEvent)} once
+     * the completion message has been posted; a late-arriving
+     * {@code send_message} call (e.g. an enforcement-phase agent that
+     * flushes its last tool call after the controller has already moved
+     * on) would otherwise fall back to posting at the top of the channel
+     * instead of inside the job's thread. Callers that want the message
+     * to land in the original thread regardless of lifecycle ordering
+     * should consult this method as a fallback.</p>
+     *
+     * @param jobId the job identifier (must not be {@code null})
+     * @return the previously-recorded Slack message timestamp, or
+     *         {@code null} when no row exists, no {@code slack_message_ts}
+     *         has been recorded for it, or the store is unavailable
+     */
+    public synchronized String getJobSlackTs(String jobId) {
+        if (connection == null || jobId == null) return null;
+        String sql = "SELECT slack_message_ts FROM job_timing WHERE job_id = ?";
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setString(1, jobId);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    String ts = rs.getString(1);
+                    if (ts != null && !ts.isEmpty()) return ts;
+                }
+            }
+        } catch (SQLException e) {
+            warn("Failed to read slack_message_ts for job " + jobId + ": " + e.getMessage());
+        }
+        return null;
+    }
+
+    /**
      * Returns per-workstream job activity for jobs completed on or after {@code since}.
      *
      * <p>Only workstreams with at least one completed job in the window are returned.

--- a/flowtree/runtime/src/main/java/io/flowtree/slack/SlackNotifier.java
+++ b/flowtree/runtime/src/main/java/io/flowtree/slack/SlackNotifier.java
@@ -799,11 +799,29 @@ public class SlackNotifier implements JobCompletionListener, ConsoleFeatures {
      * Returns the Slack thread timestamp for a job, if one has been established.
      * This is the timestamp of the submission message posted when the job was queued.
      *
+     * <p>The in-memory {@code jobThreadTs} map is the fast path; it is
+     * populated by {@link #onJobSubmitted(String, JobCompletionEvent, String)}
+     * (or its single-argument overload) and removed by
+     * {@link #onJobCompleted(String, JobCompletionEvent)} once the
+     * completion message has been posted. When the in-memory entry is
+     * absent (job already completed, controller restarted, or the
+     * submission message arrived from a peer node), this method falls
+     * back to {@link JobStatsStore#getJobSlackTs(String)} so a late
+     * {@code send_message} call from an enforcement-phase agent still
+     * lands inside the original job thread instead of at the top of the
+     * channel.</p>
+     *
      * @param jobId the job ID
      * @return the thread timestamp, or null if no thread exists for this job
      */
     public String getThreadTs(String jobId) {
-        return jobId != null ? jobThreadTs.get(jobId) : null;
+        if (jobId == null) return null;
+        String ts = jobThreadTs.get(jobId);
+        if (ts != null) return ts;
+        if (statsStore != null) {
+            return statsStore.getJobSlackTs(jobId);
+        }
+        return null;
     }
 
     /**

--- a/flowtree/runtime/src/test/java/io/flowtree/slack/SlackIntegrationTest.java
+++ b/flowtree/runtime/src/test/java/io/flowtree/slack/SlackIntegrationTest.java
@@ -44,6 +44,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.junit.Assert;
+
 import static org.junit.Assert.*;
 
 /**
@@ -2198,6 +2200,72 @@ public class SlackIntegrationTest extends TestSuiteBase {
         } finally {
             endpoint.stop();
         }
+    }
+
+    /**
+     * Regression for the opencode {@code send_message} threading bug
+     * recurrence. After {@link SlackNotifier#onJobCompleted} the
+     * in-memory {@code jobThreadTs} entry is cleared, so a
+     * late-arriving message (an enforcement-phase agent flushing a
+     * final tool call) used to fall through to a top-of-channel post
+     * even when the URL correctly addressed
+     * {@code /jobs/{jobId}/messages}.
+     *
+     * <p>This test exercises the real
+     * {@link JobStatsStore#getJobSlackTs} fallback through a temp HSQLDB
+     * file — no mocks of the bug surface — and asserts that
+     * {@link SlackNotifier#getThreadTs} returns the persisted timestamp
+     * after the in-memory entry has been removed.</p>
+     */
+    @Test(timeout = 10000)
+    public void testGetThreadTsFallsBackToStatsStoreAfterJobCompletion()
+            throws Exception {
+        File tempDir = Files.createTempDirectory("thread-ts-fallback").toFile();
+        tempDir.deleteOnExit();
+        String dbPath = new File(tempDir, "stats").getAbsolutePath();
+
+        JobStatsStore store = new JobStatsStore(dbPath);
+        store.initialize();
+        try {
+            // Seed the job row + slack_message_ts the way SlackNotifier
+            // would in production (recordJobStarted creates the row,
+            // updateJobSlackTs records the submission message ts).
+            store.recordJobStarted("job-A", "ws-A", "demo", Instant.now());
+            store.updateJobSlackTs("job-A", "1700000000.000001");
+
+            // Direct lookup against the persisted store.
+            Assert.assertEquals("Persisted slack_message_ts must be readable",
+                    "1700000000.000001", store.getJobSlackTs("job-A"));
+
+            // SlackNotifier with no in-memory submission entry for
+            // job-A (simulates the post-onJobCompleted state where
+            // jobThreadTs has already been emptied by remove()).
+            SlackNotifier notifier = new SlackNotifier(null);
+            notifier.setStatsStore(store);
+            Assert.assertEquals("getThreadTs must fall back to the durable store"
+                    + " when the in-memory map has no entry for the jobId",
+                    "1700000000.000001", notifier.getThreadTs("job-A"));
+
+            // No statsStore-side row for a different job → null
+            // (unchanged behaviour, no spurious thread routing).
+            assertNull("Unknown job IDs must remain null",
+                    notifier.getThreadTs("job-Unknown"));
+            assertNull("Null jobId must remain null", notifier.getThreadTs(null));
+        } finally {
+            store.close();
+        }
+    }
+
+    /**
+     * The {@link SlackNotifier#getThreadTs} fallback must remain a no-op
+     * when no {@link JobStatsStore} is attached, matching the historical
+     * single-source behaviour for deployments that do not run the
+     * stats database.
+     */
+    @Test(timeout = 10000)
+    public void testGetThreadTsReturnsNullWhenNoStoreAndNoInMemoryEntry() {
+        SlackNotifier notifier = new SlackNotifier(null);
+        assertNull(notifier.getThreadTs("job-Z"));
     }
 }
 

--- a/tools/mcp/manager/server.py
+++ b/tools/mcp/manager/server.py
@@ -308,9 +308,9 @@ def _decode_current_request_token_full(
     try:
         request_context = ctx.request_context
     except (LookupError, ValueError, AttributeError):
-        return None, None, None, "no_context"
+        return None, None, None, "no_request"
     if request_context is None:
-        return None, None, None, "no_context"
+        return None, None, None, "no_request"
     request = getattr(request_context, "request", None)
     if request is None:
         return None, None, None, "no_request"
@@ -3903,8 +3903,13 @@ def send_message(
     tl_ws = getattr(_thread_local, "workstream_id", None)
     tl_job = getattr(_thread_local, "job_id", None)
 
-    effective_ws = workstream_id or _get_token_workstream_id() or ""
-    effective_job = job_id or _get_token_job_id() or ""
+    # Reuse the already-decoded per_req_ws/per_req_job and the already-read
+    # ctx_* / tl_* values rather than calling _get_token_workstream_id() /
+    # _get_token_job_id(), which would each invoke _decode_current_request_token_full()
+    # a second time. The resolution order is identical: explicit arg wins, then
+    # per-request bearer, then ContextVar, then thread-local.
+    effective_ws = workstream_id or per_req_ws or ctx_ws or tl_ws or ""
+    effective_job = job_id or per_req_job or ctx_job or tl_job or ""
     effective_activity = (activity or os.environ.get("AR_AGENT_ACTIVITY", "")).strip()
 
     if effective_ws and not effective_job:

--- a/tools/mcp/manager/server.py
+++ b/tools/mcp/manager/server.py
@@ -253,12 +253,22 @@ def _require_workspace(workspace_id: Optional[str]) -> None:
             + (workspace_id if workspace_id else "<unknown>")
         )
 
-def _decode_current_request_token() -> tuple[Optional[str], Optional[str]]:
-    """Decode the Bearer token of the in-flight MCP tool call's HTTP request.
+def _decode_current_request_token_full(
+) -> tuple[Optional[str], Optional[str], Optional[str], str]:
+    """Decode the Bearer token of the in-flight MCP tool call's HTTP request
+    and return diagnostic detail.
 
-    Returns ``(workstream_id, job_id)`` on a valid HMAC temp token, or
-    ``(None, None)`` on absent/invalid bearer, a static token, or any
-    lookup failure.
+    Returns ``(workstream_id, job_id, label, reason)`` where:
+      * ``workstream_id`` and ``job_id`` are the values from a valid HMAC
+        temp token, or ``None`` when decoding does not succeed.
+      * ``label`` is the audit label for the temp token (``tmp:ws/job``),
+        or ``None`` on any failure path.
+      * ``reason`` is a short identifier describing which path was taken
+        — ``"ok"`` on success, otherwise one of
+        ``"no_context"``, ``"no_request"``, ``"no_auth_header"``,
+        ``"non_bearer_scheme"``, ``"not_temp_token"`` — for diagnostic
+        logging. This is the only return slot meant for an operator to
+        read; the body of the token is never echoed.
 
     The auth middleware also writes the decoded ``(workstream_id, job_id)``
     into a :class:`contextvars.ContextVar` plus a :mod:`threading` local —
@@ -279,34 +289,57 @@ def _decode_current_request_token() -> tuple[Optional[str], Optional[str]]:
     via ``ServerMessageMetadata`` into the dispatch-time ``RequestContext``
     (accessible via :meth:`FastMCP.get_context`), so every tool call sees
     the bearer that the client actually sent on that call.
+
+    A diagnostic 0de652686 fix landed for this in ``feature/pluggable-agents``
+    but the production symptom (``send_message`` from an ``opencode``-driven
+    enforcement phase landing at the top of the Slack channel rather than
+    in the job's thread) recurred. The investigation could reproduce the
+    success case end-to-end but not the failure, so this function carries
+    the diagnostic ``reason`` slot so the next opencode job lands the
+    evidence in the controller log on its own.
     """
     try:
         ctx = mcp.get_context()
     except (LookupError, AttributeError):
-        return None, None
+        return None, None, None, "no_context"
     # ``Context.request_context`` raises ``ValueError`` when invoked
     # outside of a live MCP request (e.g. unit tests that call the tool
     # function directly). Treat that as "no request" and fall back.
     try:
         request_context = ctx.request_context
     except (LookupError, ValueError, AttributeError):
-        return None, None
+        return None, None, None, "no_context"
     if request_context is None:
-        return None, None
+        return None, None, None, "no_context"
     request = getattr(request_context, "request", None)
     if request is None:
-        return None, None
+        return None, None, None, "no_request"
     try:
         auth_header = request.headers.get("authorization", "")
     except Exception:
-        return None, None
-    if not auth_header or not auth_header.startswith("Bearer "):
-        return None, None
+        return None, None, None, "no_auth_header"
+    if not auth_header:
+        return None, None, None, "no_auth_header"
+    # RFC 7235 declares the scheme name case-insensitive; opencode and
+    # Claude Code both emit "Bearer " but a proxy could lowercase the
+    # value en route, so match either casing rather than failing closed
+    # on a cosmetic difference.
+    if not (auth_header.startswith("Bearer ") or auth_header.startswith("bearer ")):
+        return None, None, None, "non_bearer_scheme"
     token_value = auth_header[7:].strip()
     result = _validate_temp_token(token_value)
     if result is None:
-        return None, None
-    _, _, ws_id, job_id = result
+        return None, None, None, "not_temp_token"
+    _, label, ws_id, job_id = result
+    return ws_id, job_id, label, "ok"
+
+
+def _decode_current_request_token() -> tuple[Optional[str], Optional[str]]:
+    """Backwards-compatible 2-tuple wrapper around
+    :func:`_decode_current_request_token_full`. New callers that want the
+    diagnostic ``reason`` should use the full variant directly.
+    """
+    ws_id, job_id, _, _ = _decode_current_request_token_full()
     return ws_id, job_id
 
 
@@ -615,6 +648,20 @@ class BearerAuthMiddleware:
                     _set_scopes(scopes, label)
                     _set_workspace_scopes([workspace_id] if workspace_id else None)
                     _set_token_context(ws_id, job_id)
+                    # One line per HTTP request carrying a valid temp
+                    # token. Pair with send_message_resolved /
+                    # send_message_missing_job_id from the tool handler
+                    # to determine whether the per-request decode in the
+                    # handler saw the same (ws, job) that the middleware
+                    # observed here.
+                    audit_log.info(
+                        "temp_token_request "
+                        "method=%s path=%s "
+                        "workstream_id=%s job_id=%s workspace_id=%s",
+                        scope.get("method", ""),
+                        scope.get("path", ""),
+                        ws_id or "", job_id or "",
+                        workspace_id or "")
                     await self.app(scope, receive, send)
                     return
 
@@ -3839,9 +3886,67 @@ def send_message(
     """
     _require_scope("write")
 
+    # Resolve (workstream, job) from explicit args first, then from the
+    # in-flight HTTP request's bearer, then from the auth-middleware's
+    # ContextVar/thread-local. Emit a structured diagnostic *before* the
+    # routing decision so a production failure (e.g. opencode-driven
+    # phase posting top-of-channel instead of in the job's thread) leaves
+    # enough evidence in the controller log to pinpoint which source
+    # supplied the empty job_id without further speculation. The
+    # diagnostic does not echo any token body, only the four-way
+    # provenance and the decode reason. See
+    # :func:`_decode_current_request_token_full` for the reason vocabulary.
+    per_req_ws, per_req_job, per_req_label, per_req_reason = (
+        _decode_current_request_token_full())
+    ctx_ws = _request_workstream_id.get(None)
+    ctx_job = _request_job_id.get(None)
+    tl_ws = getattr(_thread_local, "workstream_id", None)
+    tl_job = getattr(_thread_local, "job_id", None)
+
     effective_ws = workstream_id or _get_token_workstream_id() or ""
     effective_job = job_id or _get_token_job_id() or ""
     effective_activity = (activity or os.environ.get("AR_AGENT_ACTIVITY", "")).strip()
+
+    if effective_ws and not effective_job:
+        # The exact production failure mode: a workstream is resolved
+        # but the job_id binding has been lost, so the controller URL
+        # falls back to the workstream-level /messages endpoint and
+        # the message lands at the top of the Slack channel rather
+        # than inside the job's thread. Surface every source we
+        # examined so a single log line says which one failed.
+        audit_log.warning(
+            "send_message_missing_job_id "
+            "explicit_workstream_id=%s explicit_job_id=%s "
+            "per_request_workstream_id=%s per_request_job_id=%s "
+            "per_request_label=%s per_request_decode_reason=%s "
+            "contextvar_workstream_id=%s contextvar_job_id=%s "
+            "thread_local_workstream_id=%s thread_local_job_id=%s "
+            "effective_workstream_id=%s effective_job_id=%s "
+            "activity=%s",
+            workstream_id or "", job_id or "",
+            per_req_ws or "", per_req_job or "",
+            per_req_label or "", per_req_reason,
+            ctx_ws or "", ctx_job or "",
+            tl_ws or "", tl_job or "",
+            effective_ws, effective_job,
+            effective_activity or "")
+    else:
+        audit_log.info(
+            "send_message_resolved "
+            "explicit_workstream_id=%s explicit_job_id=%s "
+            "per_request_workstream_id=%s per_request_job_id=%s "
+            "per_request_decode_reason=%s "
+            "contextvar_workstream_id=%s contextvar_job_id=%s "
+            "thread_local_workstream_id=%s thread_local_job_id=%s "
+            "effective_workstream_id=%s effective_job_id=%s "
+            "activity=%s",
+            workstream_id or "", job_id or "",
+            per_req_ws or "", per_req_job or "",
+            per_req_reason,
+            ctx_ws or "", ctx_job or "",
+            tl_ws or "", tl_job or "",
+            effective_ws, effective_job,
+            effective_activity or "")
 
     if not effective_ws:
         return {"ok": False, "error": "workstream_id is required (pass explicitly or use a job token)"}

--- a/tools/mcp/manager/test_server.py
+++ b/tools/mcp/manager/test_server.py
@@ -2539,6 +2539,41 @@ class TestPerRequestTokenDecoding(unittest.TestCase):
         self.assertIsNone(ws)
         self.assertIsNone(job)
 
+    # ------------------------------------------------------------------
+    # Reason-string accuracy tests (Copilot review comment, PR #237)
+    # _decode_current_request_token_full() must return "no_request" when
+    # there is no live MCP request, and "no_context" only when the MCP
+    # context itself is unavailable.
+    # ------------------------------------------------------------------
+
+    @patch.object(server, "SHARED_SECRET", "test-secret")
+    def test_full_decode_reason_no_context_when_get_context_raises(self):
+        # mcp.get_context() raises → no MCP context at all → "no_context"
+        with patch.object(server.mcp, "get_context",
+                          side_effect=LookupError("no context")):
+            _, _, _, reason = server._decode_current_request_token_full()
+        self.assertEqual(reason, "no_context")
+
+    @patch.object(server, "SHARED_SECRET", "test-secret")
+    def test_full_decode_reason_no_request_when_request_context_none(self):
+        # Context exists but request_context is None → no active request → "no_request"
+        fake_ctx = MagicMock()
+        fake_ctx.request_context = None
+        with patch.object(server.mcp, "get_context", return_value=fake_ctx):
+            _, _, _, reason = server._decode_current_request_token_full()
+        self.assertEqual(reason, "no_request")
+
+    @patch.object(server, "SHARED_SECRET", "test-secret")
+    def test_full_decode_reason_no_request_when_request_context_raises(self):
+        # request_context property raises ValueError (e.g. unit-test context)
+        # → no active request → "no_request"
+        fake_ctx = MagicMock()
+        type(fake_ctx).request_context = mock.PropertyMock(
+            side_effect=ValueError("Context is not available outside of a request"))
+        with patch.object(server.mcp, "get_context", return_value=fake_ctx):
+            _, _, _, reason = server._decode_current_request_token_full()
+        self.assertEqual(reason, "no_request")
+
     @patch.object(server, "SHARED_SECRET", "test-secret")
     def test_decode_returns_none_for_static_token_bearer(self):
         # A non-HMAC bearer (e.g. a static long-lived admin token) is


### PR DESCRIPTION
Even with the per-request token decode fix in 0de652686 in place, an opencode-driven enforcement phase (organizational-placement, in the recurrence report) can still post send_message to the top of the Slack channel rather than inside the job's thread. The previous investigation reproduced the per-request decoder end-to-end and confirmed both runners attach the Authorization header on every MCP HTTP call, but the production symptom recurred — strong evidence that there is a second failure path on the Java controller side, distinct from the Python per-request decoding path that 0de652686 patched.

This change closes that second path. SlackNotifier.onJobCompleted clears the in-memory jobThreadTs entry the moment the completion message is posted; any subsequent send_message call (an enforcement-phase agent flushing a final tool call, a peer-node message that races completion, or a controller restart between submission and the message) finds null in the map and falls through to a top-of-channel postMessage in FlowTreeApiEndpoint.handleMessage, even though the URL correctly addresses /api/workstreams/{ws}/jobs/{job}/messages.

Changes:

 * JobStatsStore.getJobSlackTs(jobId) — new durable read of the slack_message_ts column that updateJobSlackTs already populates from SlackNotifier.onJobStarted. No schema change; the column already exists.
 * SlackNotifier.getThreadTs(jobId) — falls back to JobStatsStore.getJobSlackTs when the in-memory map has no entry, so late messages land in the original thread instead of at the top of the channel. No-op when no stats store is attached, preserving the minimal-deployment behaviour.
 * FlowTreeApiEndpoint.handleMessage — emits a structured "send_message_no_thread_ts" warn line when a job-addressed message still cannot find a thread anchor after the fallback, so operators can identify residual top-of-channel posts directly in the controller log instead of after-the-fact Slack screenshots.
 * tools/mcp/manager/server.py — adds diagnostic logging on every send_message and every authenticated HTTP request that carries a valid temp token. Emits temp_token_request, send_message_resolved, and send_message_missing_job_id structured audit lines that pinpoint exactly which provenance layer (explicit args, per-request bearer, ContextVar, threading.local) supplied the workstream / job binding. _decode_current_request_token gains a 4-tuple variant carrying a "reason" slot for the same diagnostic surface.
 * SlackIntegrationTest — covers the JobStatsStore fallback path against a real temp HSQLDB file (not a mock) and asserts that SlackNotifier.getThreadTs returns the persisted timestamp once the in-memory entry has been cleared, plus the null-store no-op case.

Limitations: this fix targets the Java controller's known fall-through path. I cannot reproduce the original symptom locally, but the diagnostic logging — paired across the Python (send_message_resolved / missing) and Java (send_message_no_thread_ts) sides — will pinpoint the next production occurrence's exact failure provenance without further speculation, so a third recurrence can be triaged from a single log read instead of another from-scratch investigation.