### PR TITLE
Add reply_broadcast to Slack completion messages

### DIFF
--- a/flowtree/runtime/src/main/java/io/flowtree/slack/SlackNotifier.java
+++ b/flowtree/runtime/src/main/java/io/flowtree/slack/SlackNotifier.java
@@ -719,8 +719,8 @@ public class SlackNotifier implements JobCompletionListener, ConsoleFeatures {
             String broadcastParam = replyBroadcast ? ",\"reply_broadcast\":true" : "";
             messageCallback.accept("{\"channel\":\"" + effectiveChannel +
                                    "\",\"thread_ts\":\"" + JsonFieldExtractor.escapeJson(threadTs) +
-                                   broadcastParam +
-                                   "\",\"text\":\"" + JsonFieldExtractor.escapeJson(text) + "\"}");
+                                   "\"" + broadcastParam +
+                                   ",\"text\":\"" + JsonFieldExtractor.escapeJson(text) + "\"}");
         }
 
         if (client == null) {

--- a/flowtree/runtime/src/main/java/io/flowtree/slack/SlackNotifier.java
+++ b/flowtree/runtime/src/main/java/io/flowtree/slack/SlackNotifier.java
@@ -608,7 +608,7 @@ public class SlackNotifier implements JobCompletionListener, ConsoleFeatures {
         String threadTs = event.getJobId() != null ? jobThreadTs.remove(event.getJobId()) : null;
 
         if (threadTs != null) {
-            postMessageInThread(workstream.getChannelId(), message, threadTs);
+            postMessageInThread(workstream.getChannelId(), message, threadTs, true);
         } else {
             postMessage(workstream.getChannelId(), message);
         }
@@ -640,7 +640,10 @@ public class SlackNotifier implements JobCompletionListener, ConsoleFeatures {
         if (client == null) {
             log("No bot token - message would be posted to " + effectiveChannel + ":");
             log(text);
-            return null;
+            // Return a synthetic ts when a test callback is registered so that
+            // callers (e.g. onJobSubmitted) can store it in jobThreadTs and the
+            // threading path is exercised in unit tests.
+            return messageCallback != null ? "test-ts-" + System.nanoTime() : null;
         }
 
         try {
@@ -655,11 +658,11 @@ public class SlackNotifier implements JobCompletionListener, ConsoleFeatures {
                 return response.getTs();
             } else {
                 warn("Failed to post message to " + effectiveChannel + ": " + response.getError());
-                return postToFallbackChannel(effectiveChannel, text, null);
+                return postToFallbackChannel(effectiveChannel, text, null, false);
             }
         } catch (IOException | SlackApiException e) {
             warn("Error posting message to " + effectiveChannel + ": " + e.getMessage());
-            return postToFallbackChannel(effectiveChannel, text, null);
+            return postToFallbackChannel(effectiveChannel, text, null, false);
         }
     }
 
@@ -692,6 +695,20 @@ public class SlackNotifier implements JobCompletionListener, ConsoleFeatures {
      * @return the reply message timestamp, or null on failure
      */
     public String postMessageInThread(String channelId, String text, String threadTs) {
+        return postMessageInThread(channelId, text, threadTs, false);
+    }
+
+    /**
+     * Posts a message as a thread reply under an existing message.
+     *
+     * @param channelId     the Slack channel ID
+     * @param text          the message text (supports Slack mrkdwn formatting)
+     * @param threadTs      the timestamp of the parent message to reply under
+     * @param replyBroadcast if true, also broadcast the message to the channel
+     *                       (Slack's "Also send to channel" feature)
+     * @return the reply message timestamp, or null on failure
+     */
+    public String postMessageInThread(String channelId, String text, String threadTs, boolean replyBroadcast) {
         String effectiveChannel = resolveChannel(channelId);
         if (effectiveChannel == null) {
             log("No channel ID and no default channel - skipping thread reply");
@@ -699,8 +716,10 @@ public class SlackNotifier implements JobCompletionListener, ConsoleFeatures {
         }
 
         if (messageCallback != null) {
+            String broadcastParam = replyBroadcast ? ",\"reply_broadcast\":true" : "";
             messageCallback.accept("{\"channel\":\"" + effectiveChannel +
                                    "\",\"thread_ts\":\"" + JsonFieldExtractor.escapeJson(threadTs) +
+                                   broadcastParam +
                                    "\",\"text\":\"" + JsonFieldExtractor.escapeJson(text) + "\"}");
         }
 
@@ -716,6 +735,7 @@ public class SlackNotifier implements JobCompletionListener, ConsoleFeatures {
                 .channel(effectiveChannel)
                 .text(text)
                 .threadTs(threadTs)
+                .replyBroadcast(replyBroadcast)
                 .unfurlLinks(false)
                 .unfurlMedia(false)
             );
@@ -724,11 +744,11 @@ public class SlackNotifier implements JobCompletionListener, ConsoleFeatures {
                 return response.getTs();
             } else {
                 warn("Failed to post thread reply to " + effectiveChannel + ": " + response.getError());
-                return postToFallbackChannel(effectiveChannel, text, null);
+                return postToFallbackChannel(effectiveChannel, text, null, replyBroadcast);
             }
         } catch (IOException | SlackApiException e) {
             warn("Error posting thread reply to " + effectiveChannel + ": " + e.getMessage());
-            return postToFallbackChannel(effectiveChannel, text, null);
+            return postToFallbackChannel(effectiveChannel, text, null, replyBroadcast);
         }
     }
 
@@ -754,9 +774,11 @@ public class SlackNotifier implements JobCompletionListener, ConsoleFeatures {
      * @param failedChannel the channel that failed
      * @param text          the message text
      * @param threadTs      the thread timestamp (may be null for top-level messages)
+     * @param replyBroadcast if true, also broadcast the message to the channel
+     *                       (used only for completion messages)
      * @return the message timestamp from the fallback post, or null
      */
-    private String postToFallbackChannel(String failedChannel, String text, String threadTs) {
+    private String postToFallbackChannel(String failedChannel, String text, String threadTs, boolean replyBroadcast) {
         if (defaultChannelId == null || defaultChannelId.isEmpty()
                 || defaultChannelId.equals(failedChannel)) {
             return null;
@@ -771,6 +793,7 @@ public class SlackNotifier implements JobCompletionListener, ConsoleFeatures {
                     .channel(defaultChannelId)
                     .text(text)
                     .threadTs(threadTs)
+                    .replyBroadcast(replyBroadcast)
                     .unfurlLinks(false)
                     .unfurlMedia(false)
                 );

--- a/flowtree/runtime/src/test/java/io/flowtree/slack/SlackIntegrationTest.java
+++ b/flowtree/runtime/src/test/java/io/flowtree/slack/SlackIntegrationTest.java
@@ -2301,9 +2301,10 @@ public class SlackIntegrationTest extends TestSuiteBase {
 
         assertEquals(1, messages.size());
         String message = messages.get(0);
-        assertTrue("Message should contain reply_broadcast:true",
-            message.contains("\"reply_broadcast\":true"));
-        assertTrue("Message should contain thread_ts", message.contains("\"thread_ts\""));
+        assertTrue("Message should have reply_broadcast=true",
+            JsonFieldExtractor.extractBoolean(message, "reply_broadcast"));
+        assertNotNull("Message should have thread_ts field",
+            JsonFieldExtractor.extractString(message, "thread_ts"));
         assertTrue("Message should contain PR URL", message.contains("https://github.com/test/repo/pull/123"));
     }
 
@@ -2335,9 +2336,10 @@ public class SlackIntegrationTest extends TestSuiteBase {
 
         assertEquals(1, messages.size());
         String message = messages.get(0);
-        assertFalse("Status message should NOT contain reply_broadcast",
-            message.contains("\"reply_broadcast\":true"));
-        assertTrue("Status message should contain thread_ts", message.contains("\"thread_ts\""));
+        assertFalse("Status message should NOT have reply_broadcast=true",
+            JsonFieldExtractor.extractBoolean(message, "reply_broadcast"));
+        assertNotNull("Status message should have thread_ts field",
+            JsonFieldExtractor.extractString(message, "thread_ts"));
     }
 
     /**
@@ -2356,7 +2358,7 @@ public class SlackIntegrationTest extends TestSuiteBase {
 
         assertEquals(1, messages.size());
         String message = messages.get(0);
-        assertFalse("Default should NOT broadcast", message.contains("\"reply_broadcast\":true"));
+        assertFalse("Default should NOT broadcast", JsonFieldExtractor.extractBoolean(message, "reply_broadcast"));
     }
 }
 

--- a/flowtree/runtime/src/test/java/io/flowtree/slack/SlackIntegrationTest.java
+++ b/flowtree/runtime/src/test/java/io/flowtree/slack/SlackIntegrationTest.java
@@ -2267,5 +2267,96 @@ public class SlackIntegrationTest extends TestSuiteBase {
         SlackNotifier notifier = new SlackNotifier(null);
         assertNull(notifier.getThreadTs("job-Z"));
     }
+
+    /**
+     * Tests that the completion message uses reply_broadcast: true when
+     * posted to a thread, ensuring it appears both in the thread and in
+     * the channel's main view (Slack's "Also send to channel" feature).
+     */
+    @Test(timeout = 10000)
+    public void testCompletionMessageBroadcastsToChannel() {
+        List<String> messages = new ArrayList<>();
+        SlackNotifier notifier = new SlackNotifier(null);
+        notifier.setMessageCallback(json -> {
+            messages.add(json);
+        });
+
+        Workstream workstream = new Workstream("C123", "#test");
+        workstream.setDefaultBranch("feature/test");
+        notifier.registerWorkstream(workstream);
+
+        // Submit a job to create a thread
+        JobCompletionEvent startEvent = JobCompletionEvent.started("job-broadcast", "Test task");
+        notifier.onJobSubmitted(workstream.getWorkstreamId(), startEvent);
+
+        // Clear messages from submission
+        messages.clear();
+
+        // Complete the job with PR URL
+        JobCompletionEvent completeEvent = JobCompletionEvent.success("job-broadcast", "Test task");
+        completeEvent.withGitInfo("feature/test", "abc1234567890",
+            List.of("test.py"), List.of(), true);
+        completeEvent.withPullRequestUrl("https://github.com/test/repo/pull/123");
+        notifier.onJobCompleted(workstream.getWorkstreamId(), completeEvent);
+
+        assertEquals(1, messages.size());
+        String message = messages.get(0);
+        assertTrue("Message should contain reply_broadcast:true",
+            message.contains("\"reply_broadcast\":true"));
+        assertTrue("Message should contain thread_ts", message.contains("\"thread_ts\""));
+        assertTrue("Message should contain PR URL", message.contains("https://github.com/test/repo/pull/123"));
+    }
+
+    /**
+     * Tests that status messages (onJobStarted) do NOT use reply_broadcast,
+     * ensuring they only appear in the thread, not broadcast to the channel.
+     */
+    @Test(timeout = 10000)
+    public void testStatusMessageDoesNotBroadcast() {
+        List<String> messages = new ArrayList<>();
+        SlackNotifier notifier = new SlackNotifier(null);
+        notifier.setMessageCallback(json -> {
+            messages.add(json);
+        });
+
+        Workstream workstream = new Workstream("C123", "#test");
+        workstream.setDefaultBranch("feature/test");
+        notifier.registerWorkstream(workstream);
+
+        // Submit a job to create a thread
+        JobCompletionEvent startEvent = JobCompletionEvent.started("job-status", "Test task");
+        notifier.onJobSubmitted(workstream.getWorkstreamId(), startEvent);
+
+        // Clear messages from submission
+        messages.clear();
+
+        // Start the job
+        notifier.onJobStarted(workstream.getWorkstreamId(), startEvent);
+
+        assertEquals(1, messages.size());
+        String message = messages.get(0);
+        assertFalse("Status message should NOT contain reply_broadcast",
+            message.contains("\"reply_broadcast\":true"));
+        assertTrue("Status message should contain thread_ts", message.contains("\"thread_ts\""));
+    }
+
+    /**
+     * Tests that the old postMessageInThread API (without replyBroadcast param)
+     * defaults to replyBroadcast: false (no broadcast).
+     */
+    @Test(timeout = 10000)
+    public void testPostMessageInThreadDefaultIsNoBroadcast() {
+        List<String> messages = new ArrayList<>();
+        SlackNotifier notifier = new SlackNotifier(null);
+        notifier.setMessageCallback(json -> {
+            messages.add(json);
+        });
+
+        notifier.postMessageInThread("C123", "test message", "thread123");
+
+        assertEquals(1, messages.size());
+        String message = messages.get(0);
+        assertFalse("Default should NOT broadcast", message.contains("\"reply_broadcast\":true"));
+    }
 }
 


### PR DESCRIPTION
Update SlackNotifier to use Slack's native "Also send to channel" feature (reply_broadcast parameter) for job completion messages, ensuring they appear both in the job's thread AND in the channel's main view.

Changes:
- Added replyBroadcast parameter to postMessageInThread method
- Completion messages (onJobCompleted) now use replyBroadcast=true
- Status/progress messages continue to be thread-only
- Added backward-compatible overload for existing callers
- Updated callback message format to include reply_broadcast when set
- Added tests for broadcast behavior