### PR TITLE
Add model-level cost breakdown reporting to Slack and workstream status

### DIFF
--- a/flowtree/agents/src/main/java/io/flowtree/jobs/agent/OpencodeOutputParser.java
+++ b/flowtree/agents/src/main/java/io/flowtree/jobs/agent/OpencodeOutputParser.java
@@ -239,13 +239,30 @@ final class OpencodeOutputParser {
             numTurns = countAssistantTurns(rawOutput);
         }
 
+        int inputTokens = 0;
+        int outputTokens = 0;
+        boolean costUnavailable = false;
         double costUsd = 0.0;
-        if (reportsCost && root != null) {
+        if (reportsCost) {
             JsonNode usage = firstNode(root, "usage");
+            if (usage == null) {
+                usage = findUsageBlock(rawOutput);
+            }
             if (usage != null) {
                 JsonNode costNode = firstNode(usage, "cost");
                 if (costNode != null && costNode.isNumber()) {
                     costUsd = costNode.asDouble(0.0);
+                }
+                JsonNode inputTokensNode = firstNode(usage, "input_tokens");
+                if (inputTokensNode != null && inputTokensNode.isNumber()) {
+                    inputTokens = inputTokensNode.asInt(0);
+                }
+                JsonNode outputTokensNode = firstNode(usage, "output_tokens");
+                if (outputTokensNode != null && outputTokensNode.isNumber()) {
+                    outputTokens = outputTokensNode.asInt(0);
+                }
+                if (costUsd == 0.0 && (inputTokens > 0 || outputTokens > 0)) {
+                    costUnavailable = true;
                 }
             }
         }
@@ -262,6 +279,15 @@ final class OpencodeOutputParser {
                 : new LinkedHashMap<>(runnerMetadata);
         if (!responseText.isEmpty()) {
             meta.put("response_text", responseText);
+        }
+        if (inputTokens > 0) {
+            meta.put("input_tokens", String.valueOf(inputTokens));
+        }
+        if (outputTokens > 0) {
+            meta.put("output_tokens", String.valueOf(outputTokens));
+        }
+        if (costUnavailable) {
+            meta.put("cost_unavailable", "true");
         }
 
         return new AgentRunResult(
@@ -461,6 +487,34 @@ final class OpencodeOutputParser {
                 return MAPPER.readTree(raw.substring(start, end + 1));
             } catch (Exception ignored) {
                 end = raw.lastIndexOf('}', start - 1);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Finds the best available {@code usage} block by scanning all NDJSON lines.
+     * This handles cases where the final summary with {@code usage} is not in the
+     * last JSON object (e.g., when opencode outputs metadata-only objects after
+     * the summary, or when the summary appears mid-stream).
+     *
+     * @param raw the captured stdout
+     * @return the {@code usage} node, or {@code null} when absent
+     */
+    private static JsonNode findUsageBlock(String raw) {
+        if (raw == null || raw.isEmpty()) return null;
+        String[] lines = raw.split("\\r?\\n");
+        for (int i = lines.length - 1; i >= 0; i--) {
+            String line = lines[i].trim();
+            if (!line.startsWith("{") || !line.endsWith("}")) continue;
+            try {
+                JsonNode node = MAPPER.readTree(line);
+                JsonNode usage = firstNode(node, "usage");
+                if (usage != null && usage.isObject()) {
+                    return usage;
+                }
+            } catch (Exception ignored) {
+                // continue scanning
             }
         }
         return null;

--- a/flowtree/agents/src/main/java/io/flowtree/jobs/agent/PhaseConfig.java
+++ b/flowtree/agents/src/main/java/io/flowtree/jobs/agent/PhaseConfig.java
@@ -111,6 +111,24 @@ public record PhaseConfig(String runner, String model, String effort, String pro
     }
 
     /**
+     * Returns the provider/model attribution key for this configuration.
+     *
+     * <p>Returns {@code "provider/model"} when a provider is present
+     * (e.g. {@code "openrouter/claude-opus-4-7"}) and just the model name
+     * otherwise. A missing or empty model is reported as {@code "unknown"}
+     * so cost is never silently dropped.</p>
+     *
+     * @return a stable key for per-model cost attribution
+     */
+    public String toModelKey() {
+        String m = (model == null || model.isEmpty()) ? "unknown" : model;
+        if (provider != null && !provider.isEmpty()) {
+            return provider + "/" + m;
+        }
+        return m;
+    }
+
+    /**
      * Returns a configuration where each {@code null} field of {@code this}
      * is filled in from {@code other}; non-null fields of {@code this} win.
      * Used by the resolver to layer one precedence level on top of another.

--- a/flowtree/agents/src/test/java/io/flowtree/jobs/agent/OpencodeOutputParserTest.java
+++ b/flowtree/agents/src/test/java/io/flowtree/jobs/agent/OpencodeOutputParserTest.java
@@ -260,6 +260,55 @@ public class OpencodeOutputParserTest extends TestSuiteBase {
         assertEquals(0.0, result.costUsd(), 1e-9);
     }
 
+    /**
+     * Token counts are extracted from the usage block and stored in runnerMetadata
+     * when {@code reportsCost=true}.
+     */
+    @Test(timeout = 5000)
+    public void extractsTokenCountsWhenReportsCostTrue() {
+        String output = "{\"session_id\":\"s1\",\"steps\":3,\"stopReason\":\"success\","
+                + "\"usage\":{\"cost\":0.0042,\"input_tokens\":500,\"output_tokens\":80}}";
+        AgentRunResult result = OpencodeOutputParser.parse(
+                output, 0, false, 100L, Collections.emptyMap(), SILENT, true);
+        assertEquals("500", result.runnerMetadata().get("input_tokens"));
+        assertEquals("80", result.runnerMetadata().get("output_tokens"));
+        assertNull("cost_unavailable should not be set when cost > 0",
+                result.runnerMetadata().get("cost_unavailable"));
+    }
+
+    /**
+     * When cost is 0 but token counts are available, the cost_unavailable marker
+     * is set in runnerMetadata. This indicates the cost data was not available
+     * from the provider even though token usage was reported.
+     */
+    @Test(timeout = 5000)
+    public void marksCostUnavailableWhenZeroCostButTokensPresent() {
+        String output = "{\"session_id\":\"s1\",\"steps\":3,\"stopReason\":\"success\","
+                + "\"usage\":{\"cost\":0.0,\"input_tokens\":500,\"output_tokens\":80}}";
+        AgentRunResult result = OpencodeOutputParser.parse(
+                output, 0, false, 100L, Collections.emptyMap(), SILENT, true);
+        assertEquals(0.0, result.costUsd(), 1e-9);
+        assertEquals("true", result.runnerMetadata().get("cost_unavailable"));
+        assertEquals("500", result.runnerMetadata().get("input_tokens"));
+        assertEquals("80", result.runnerMetadata().get("output_tokens"));
+    }
+
+    /**
+     * Token counts and cost_unavailable are NOT set when {@code reportsCost=false}
+     * even if usage block is present with token counts.
+     */
+    @Test(timeout = 5000)
+    public void tokenCountsIgnoredWhenReportsCostFalse() {
+        String output = "{\"session_id\":\"s1\",\"steps\":3,\"stopReason\":\"success\","
+                + "\"usage\":{\"cost\":0.0042,\"input_tokens\":500,\"output_tokens\":80}}";
+        AgentRunResult result = OpencodeOutputParser.parse(
+                output, 0, false, 100L, Collections.emptyMap(), SILENT, false);
+        assertEquals(0.0, result.costUsd(), 1e-9);
+        assertNull(result.runnerMetadata().get("input_tokens"));
+        assertNull(result.runnerMetadata().get("output_tokens"));
+        assertNull(result.runnerMetadata().get("cost_unavailable"));
+    }
+
     /** When no step_start events appear but text events carry messageIDs, count those. */
     @Test(timeout = 5000)
     public void countsDistinctMessageIdsWhenStepStartAbsent() {

--- a/flowtree/base/src/main/java/io/flowtree/JsonFieldExtractor.java
+++ b/flowtree/base/src/main/java/io/flowtree/JsonFieldExtractor.java
@@ -620,6 +620,33 @@ public final class JsonFieldExtractor {
 	}
 
 	/**
+	 * Appends a {@link Map} of {@code String} to {@code Double} as a JSON object
+	 * to the given {@link StringBuilder}, using proper JSON key escaping.
+	 * Shared implementation for serializing cost breakdowns in stats reporting.
+	 *
+	 * <p>Output format: {@code {"key1":1.0,"key2":2.0}}</p>
+	 *
+	 * @param sb     the builder to append to (caller adds any surrounding fields)
+	 * @param keyName the JSON key name for this object
+	 * @param map    the map to serialize; {@code null} or empty produces an empty object
+	 */
+	public static void appendDoubleMapJson(StringBuilder sb, String keyName, Map<String, Double> map) {
+		sb.append(",\"").append(keyName).append("\":{");
+		boolean first = true;
+		if (map != null) {
+			for (Map.Entry<String, Double> e : map.entrySet()) {
+				if (!first) sb.append(",");
+				first = false;
+				sb.append("\"")
+					.append(escapeJson(e.getKey()))
+					.append("\":")
+					.append(e.getValue() != null ? e.getValue() : 0.0);
+			}
+		}
+		sb.append("}");
+	}
+
+	/**
 	 * Extracts a numeric string from the beginning of the input.
 	 *
 	 * @param rest         the string to extract from (already trimmed after the colon)

--- a/flowtree/runtime/src/main/java/io/flowtree/jobs/CodingAgentJob.java
+++ b/flowtree/runtime/src/main/java/io/flowtree/jobs/CodingAgentJob.java
@@ -232,6 +232,8 @@ public class CodingAgentJob extends GitManagedJob {
     private double costUsd;
     /** Cumulative USD cost per runner name, summed across every phase invocation in this job. */
     private final Map<String, Double> costByRunner = new LinkedHashMap<>();
+    /** Cumulative USD cost per model (provider/model identifier), summed across every phase invocation in this job. */
+    private final Map<String, Double> costByModel = new LinkedHashMap<>();
     /** Number of agentic turns taken during the Claude Code session. */
     private int numTurns;
     /** Session subtype / stop reason reported by Claude Code (e.g. "success"). */
@@ -1088,6 +1090,9 @@ public class CodingAgentJob extends GitManagedJob {
             log("Enforcement attempt: " + (enforcementAttempt + 1));
         }
 
+        PhaseConfig effective = resolveEffectivePhaseConfig(currentPhase);
+        String modelKey = effective.toModelKey();
+
         output = "";
         AgentRunResult finalResult = null;
         for (int attempt = 0; attempt <= maxInactivityRestarts; attempt++) {
@@ -1113,6 +1118,7 @@ public class CodingAgentJob extends GitManagedJob {
         if (finalResult != null) {
             absorbResult(finalResult);
             costByRunner.merge(runner.getName(), finalResult.costUsd(), Double::sum);
+            costByModel.merge(modelKey, finalResult.costUsd(), Double::sum);
         }
         harnessStatus().phaseExit(currentPhase, finalResult);
         log("Output saved to: " + outputFile);
@@ -1257,6 +1263,11 @@ public class CodingAgentJob extends GitManagedJob {
         return new LinkedHashMap<>(costByRunner);
     }
 
+    /** Returns an immutable snapshot of the cumulative per-model USD cost for this job. */
+    Map<String, Double> getCostByModel() {
+        return new LinkedHashMap<>(costByModel);
+    }
+
     /**
      * Absorbs {@code result} into the orchestrator's accumulated session
      * fields. Across primary and correction sessions, duration / cost / turn
@@ -1332,6 +1343,7 @@ public class CodingAgentJob extends GitManagedJob {
             }
             ccEvent.withRunnerName(runnerName);
             ccEvent.withCostByRunner(costByRunner);
+            ccEvent.withCostByModel(costByModel);
             if (postCompletionCapHit) ccEvent.withPostCompletionCapHit(true);
             if (activeReviewRule != null && activeReviewRule.hasRun()) {
                 ccEvent.withReviewInfo(true, activeReviewRule.getFilesModified(),

--- a/flowtree/runtime/src/main/java/io/flowtree/jobs/CodingAgentJob.java
+++ b/flowtree/runtime/src/main/java/io/flowtree/jobs/CodingAgentJob.java
@@ -34,6 +34,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.EnumMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -1287,12 +1288,12 @@ public class CodingAgentJob extends GitManagedJob {
 
     /** Returns an immutable snapshot of the cumulative per-runner USD cost for this job. */
     Map<String, Double> getCostByRunner() {
-        return new LinkedHashMap<>(costByRunner);
+        return Collections.unmodifiableMap(new LinkedHashMap<>(costByRunner));
     }
 
     /** Returns an immutable snapshot of the cumulative per-model USD cost for this job. */
     Map<String, Double> getCostByModel() {
-        return new LinkedHashMap<>(costByModel);
+        return Collections.unmodifiableMap(new LinkedHashMap<>(costByModel));
     }
 
     /**

--- a/flowtree/runtime/src/main/java/io/flowtree/jobs/CodingAgentJobEvent.java
+++ b/flowtree/runtime/src/main/java/io/flowtree/jobs/CodingAgentJobEvent.java
@@ -78,6 +78,13 @@ public class CodingAgentJobEvent extends JobCompletionEvent {
     private Map<String, Double> costByRunner = Collections.emptyMap();
 
     /**
+     * Cumulative USD cost per model (provider/model identifier), summed across
+     * every phase invocation in this job. Empty for events emitted before
+     * per-model cost tracking.
+     */
+    private Map<String, Double> costByModel = Collections.emptyMap();
+
+    /**
      * {@code true} when the post-completion command exhausted its per-job pass
      * cap without ever exiting zero. Distinguishes "command succeeded after N
      * passes" from "command failed and the gate was abandoned".
@@ -386,6 +393,30 @@ public class CodingAgentJobEvent extends JobCompletionEvent {
     @Override
     public Map<String, Double> getCostByRunner() {
         return costByRunner;
+    }
+
+    /**
+     * Sets the per-model cost breakdown for this job.
+     *
+     * @param costByModel map of provider/model identifier to cumulative USD cost;
+     *                    a {@code null} value is treated as an empty map
+     * @return this event for chaining
+     */
+    public CodingAgentJobEvent withCostByModel(Map<String, Double> costByModel) {
+        this.costByModel = costByModel != null
+                ? Map.copyOf(costByModel) : Collections.emptyMap();
+        return this;
+    }
+
+    /**
+     * Returns the per-model cost breakdown for this job.
+     *
+     * @return an immutable map of provider/model identifier to cumulative USD cost;
+     *         empty when not populated
+     */
+    @Override
+    public Map<String, Double> getCostByModel() {
+        return costByModel;
     }
 
     /**

--- a/flowtree/runtime/src/main/java/io/flowtree/jobs/JobCompletionEvent.java
+++ b/flowtree/runtime/src/main/java/io/flowtree/jobs/JobCompletionEvent.java
@@ -299,6 +299,11 @@ public class JobCompletionEvent {
      * for non-coding-agent jobs and events that predate per-runner tracking.
      */
     public Map<String, Double> getCostByRunner() { return Collections.emptyMap(); }
+    /**
+     * Returns the per-model USD cost breakdown for this job, or an empty map
+     * for non-coding-agent jobs and events that predate per-model tracking.
+     */
+    public Map<String, Double> getCostByModel() { return Collections.emptyMap(); }
 
     // ==================== Builder-pattern setters ====================
 
@@ -377,15 +382,28 @@ public class JobCompletionEvent {
         root.put("commitMessageSource", getCommitMessageSource());
         root.put("runnerName", getRunnerName());
 
-        ObjectNode costByRunnerNode = root.putObject("costByRunner");
-        for (Map.Entry<String, Double> e : getCostByRunner().entrySet()) {
-            costByRunnerNode.put(e.getKey(), e.getValue());
-        }
+        putDoubleMap(root, "costByRunner", getCostByRunner());
+        putDoubleMap(root, "costByModel", getCostByModel());
 
         try {
             return EVENT_MAPPER.writeValueAsString(root);
         } catch (Exception e) {
             return "{}";
+        }
+    }
+
+    /**
+     * Serialises a {@code Map<String, Double>} as a JSON object child of {@code root}.
+     *
+     * @param root the parent object node
+     * @param key  the field name under which the child object is created
+     * @param map  the entries to serialise; {@code null} is treated as empty
+     */
+    private static void putDoubleMap(ObjectNode root, String key, Map<String, Double> map) {
+        ObjectNode node = root.putObject(key);
+        if (map == null) return;
+        for (Map.Entry<String, Double> e : map.entrySet()) {
+            node.put(e.getKey(), e.getValue());
         }
     }
 

--- a/flowtree/runtime/src/main/java/io/flowtree/slack/FlowTreeApiEndpoint.java
+++ b/flowtree/runtime/src/main/java/io/flowtree/slack/FlowTreeApiEndpoint.java
@@ -904,6 +904,7 @@ public class FlowTreeApiEndpoint extends NanoHTTPD implements ConsoleFeatures {
                 ccEvent.withCommitMessageSource(commitMessageSource);
             }
             ccEvent.withCostByRunner(JsonFieldExtractor.extractDoubleObject(body, "costByRunner"));
+            ccEvent.withCostByModel(JsonFieldExtractor.extractDoubleObject(body, "costByModel"));
         }
 
         log("Status event: " + eventStatus + " for job " + jobId + " in workstream " + workstreamId);

--- a/flowtree/runtime/src/main/java/io/flowtree/slack/JobStatsStore.java
+++ b/flowtree/runtime/src/main/java/io/flowtree/slack/JobStatsStore.java
@@ -92,6 +92,19 @@ public class JobStatsStore implements ConsoleFeatures {
         + ")";
 
     /**
+     * Table storing per-model cost breakdowns per job. Mirrors the structure
+     * of {@code job_runner_cost} but keyed by provider/model identifier
+     * (e.g. {@code "openrouter/claude-opus-4-7"}) instead of runner name.
+     */
+    private static final String CREATE_MODEL_COST_TABLE = ""
+        + "CREATE TABLE IF NOT EXISTS job_model_cost ("
+        + "    job_id   VARCHAR(255) NOT NULL,"
+        + "    model    VARCHAR(128)  NOT NULL,"
+        + "    cost_usd DOUBLE,"
+        + "    PRIMARY KEY (job_id, model)"
+        + ")";
+
+    /**
      * ALTER TABLE statements to add new columns to existing databases.
      * HSQLDB 2.x does not support {@code IF NOT EXISTS} on {@code ADD COLUMN},
      * so these statements will throw if the column already exists. The
@@ -140,6 +153,7 @@ public class JobStatsStore implements ConsoleFeatures {
                 stmt.execute(CREATE_TABLE);
                 stmt.execute(CREATE_INDEX);
                 stmt.execute(CREATE_RUNNER_COST_TABLE);
+                stmt.execute(CREATE_MODEL_COST_TABLE);
                 for (String migration : SCHEMA_MIGRATIONS) {
                     try {
                         stmt.execute(migration);
@@ -354,6 +368,7 @@ public class JobStatsStore implements ConsoleFeatures {
             event.getTargetBranch(), event.getCommitHash(),
             event.getPullRequestUrl(), event.getErrorMessage());
         recordRunnerCosts(event.getJobId(), event.getCostByRunner());
+        recordModelCosts(event.getJobId(), event.getCostByModel());
     }
 
     /**
@@ -365,31 +380,53 @@ public class JobStatsStore implements ConsoleFeatures {
      *                     or empty clears any existing rows for the job
      */
     public synchronized void recordRunnerCosts(String jobId, Map<String, Double> costByRunner) {
+        recordCostsInTable(jobId, "job_runner_cost", "runner", 64, costByRunner);
+    }
+
+    /**
+     * Records the per-model cost breakdown for a job, replacing any existing
+     * rows for that job so a re-reported completion event is idempotent.
+     *
+     * @param jobId       the job identifier
+     * @param costByModel map of provider/model identifier to cumulative USD cost;
+     *                    {@code null} or empty clears any existing rows for the job
+     */
+    public synchronized void recordModelCosts(String jobId, Map<String, Double> costByModel) {
+        recordCostsInTable(jobId, "job_model_cost", "model", 128, costByModel);
+    }
+
+    /**
+     * Shared implementation for {@link #recordRunnerCosts} and {@link #recordModelCosts}.
+     * Deletes existing rows for the job in {@code table}, then inserts one row per entry,
+     * truncating the key to {@code maxKeyLen} characters.
+     */
+    private void recordCostsInTable(String jobId, String table, String keyColumn,
+                                    int maxKeyLen, Map<String, Double> costs) {
         if (connection == null || jobId == null) return;
 
         try (PreparedStatement del = connection.prepareStatement(
-                "DELETE FROM job_runner_cost WHERE job_id = ?")) {
+                "DELETE FROM " + table + " WHERE job_id = ?")) {
             del.setString(1, jobId);
             del.executeUpdate();
         } catch (SQLException e) {
-            warn("Failed to clear runner costs for job " + jobId + ": " + e.getMessage());
+            warn("Failed to clear costs for job " + jobId + " in " + table + ": " + e.getMessage());
             return;
         }
 
-        if (costByRunner == null || costByRunner.isEmpty()) return;
+        if (costs == null || costs.isEmpty()) return;
 
-        String sql = "INSERT INTO job_runner_cost (job_id, runner, cost_usd) VALUES (?, ?, ?)";
+        String sql = "INSERT INTO " + table + " (job_id, " + keyColumn + ", cost_usd) VALUES (?, ?, ?)";
         try (PreparedStatement ps = connection.prepareStatement(sql)) {
-            for (Map.Entry<String, Double> entry : costByRunner.entrySet()) {
+            for (Map.Entry<String, Double> entry : costs.entrySet()) {
                 if (entry.getKey() == null) continue;
                 ps.setString(1, jobId);
-                ps.setString(2, truncate(entry.getKey(), 64));
+                ps.setString(2, truncate(entry.getKey(), maxKeyLen));
                 ps.setDouble(3, entry.getValue() != null ? entry.getValue() : 0.0);
                 ps.addBatch();
             }
             ps.executeBatch();
         } catch (SQLException e) {
-            warn("Failed to record runner costs for job " + jobId + ": " + e.getMessage());
+            warn("Failed to record costs for job " + jobId + " in " + table + ": " + e.getMessage());
         }
     }
 
@@ -545,6 +582,7 @@ public class JobStatsStore implements ConsoleFeatures {
                     stats.totalCostUsd = rs.getDouble("total_cost_usd");
                     stats.totalTurns = rs.getInt("total_turns");
                     stats.costByRunner = queryCostByRunner(workstreamId, startInstant, endInstant);
+                    stats.costByModel = queryCostByModel(workstreamId, startInstant, endInstant);
                     return stats;
                 }
             }
@@ -557,8 +595,7 @@ public class JobStatsStore implements ConsoleFeatures {
 
     /**
      * Sums per-runner cost over the given window, optionally filtered to a
-     * single workstream. Joins {@code job_runner_cost} to {@code job_timing}
-     * so the same time-window and status filters as the aggregate query apply.
+     * single workstream.
      *
      * @param workstreamId the workstream to filter by, or {@code null} for all
      * @param startInstant inclusive window start
@@ -567,14 +604,70 @@ public class JobStatsStore implements ConsoleFeatures {
      */
     private Map<String, Double> queryCostByRunner(String workstreamId,
                                                   Instant startInstant, Instant endInstant) {
+        return queryCostFromTable(workstreamId, startInstant, endInstant,
+                "job_runner_cost", "rc", "runner", "runner_cost");
+    }
+
+    /**
+     * Sums per-runner cost grouped by workstream over the given window.
+     *
+     * @param startInstant inclusive window start
+     * @param endInstant   exclusive window end
+     * @return map of workstream ID to (runner → summed USD cost), ordered by cost descending within each workstream
+     */
+    private Map<String, Map<String, Double>> queryCostByRunnerPerWorkstream(
+            Instant startInstant, Instant endInstant) {
+        return queryCostPerWorkstreamFromTable(startInstant, endInstant,
+                "job_runner_cost", "rc", "runner", "runner_cost");
+    }
+
+    /**
+     * Sums per-model cost over the given window, optionally filtered to a
+     * single workstream.
+     *
+     * @param workstreamId the workstream to filter by, or {@code null} for all
+     * @param startInstant inclusive window start
+     * @param endInstant   exclusive window end
+     * @return map of provider/model identifier to summed USD cost, ordered by cost descending
+     */
+    private Map<String, Double> queryCostByModel(String workstreamId,
+                                                 Instant startInstant, Instant endInstant) {
+        return queryCostFromTable(workstreamId, startInstant, endInstant,
+                "job_model_cost", "mc", "model", "model_cost");
+    }
+
+    /**
+     * Sums per-model cost grouped by workstream over the given window.
+     *
+     * @param startInstant inclusive window start
+     * @param endInstant   exclusive window end
+     * @return map of workstream ID to (model → summed USD cost), ordered by cost descending within each workstream
+     */
+    private Map<String, Map<String, Double>> queryCostByModelPerWorkstream(
+            Instant startInstant, Instant endInstant) {
+        return queryCostPerWorkstreamFromTable(startInstant, endInstant,
+                "job_model_cost", "mc", "model", "model_cost");
+    }
+
+    /**
+     * Shared implementation for {@link #queryCostByRunner} and {@link #queryCostByModel}.
+     * Joins {@code table} to {@code job_timing} and sums {@code cost_usd} per key,
+     * using the same time-window and status filters as aggregate queries.
+     */
+    private Map<String, Double> queryCostFromTable(String workstreamId,
+                                                   Instant startInstant, Instant endInstant,
+                                                   String table, String tableAlias,
+                                                   String keyColumn, String costAlias) {
         Map<String, Double> result = new LinkedHashMap<>();
         if (connection == null) return result;
 
-        String sql = "SELECT rc.runner AS runner, COALESCE(SUM(rc.cost_usd), 0) AS runner_cost "
-            + "FROM job_runner_cost rc JOIN job_timing t ON rc.job_id = t.job_id "
+        String sql = "SELECT " + tableAlias + "." + keyColumn + " AS " + keyColumn + ", "
+            + "COALESCE(SUM(" + tableAlias + ".cost_usd), 0) AS " + costAlias + " "
+            + "FROM " + table + " " + tableAlias + " JOIN job_timing t ON "
+            + tableAlias + ".job_id = t.job_id "
             + "WHERE t.started_at >= ? AND t.started_at < ? AND t.status <> 'STARTED'"
             + (workstreamId != null ? " AND t.workstream_id = ?" : "")
-            + " GROUP BY rc.runner ORDER BY runner_cost DESC";
+            + " GROUP BY " + tableAlias + "." + keyColumn + " ORDER BY " + costAlias + " DESC";
 
         try (PreparedStatement ps = connection.prepareStatement(sql)) {
             ps.setTimestamp(1, Timestamp.from(startInstant));
@@ -584,34 +677,34 @@ public class JobStatsStore implements ConsoleFeatures {
             }
             try (ResultSet rs = ps.executeQuery()) {
                 while (rs.next()) {
-                    result.put(rs.getString("runner"), rs.getDouble("runner_cost"));
+                    result.put(rs.getString(keyColumn), rs.getDouble(costAlias));
                 }
             }
         } catch (SQLException e) {
-            warn("Failed to query cost by runner: " + e.getMessage());
+            warn("Failed to query cost from " + table + ": " + e.getMessage());
         }
         return result;
     }
 
     /**
-     * Sums per-runner cost grouped by workstream over the given window in a
-     * single query, avoiding N+1 queries when rendering all-workstream stats.
-     *
-     * @param startInstant inclusive window start
-     * @param endInstant   exclusive window end
-     * @return map of workstream ID to (runner → summed USD cost), ordered by runner cost descending within each workstream
+     * Shared implementation for {@link #queryCostByRunnerPerWorkstream} and
+     * {@link #queryCostByModelPerWorkstream}. Returns a map of workstream ID to
+     * (key → summed cost), grouped and ordered by workstream then cost descending.
      */
-    private Map<String, Map<String, Double>> queryCostByRunnerPerWorkstream(
-            Instant startInstant, Instant endInstant) {
+    private Map<String, Map<String, Double>> queryCostPerWorkstreamFromTable(
+            Instant startInstant, Instant endInstant,
+            String table, String tableAlias,
+            String keyColumn, String costAlias) {
         Map<String, Map<String, Double>> result = new LinkedHashMap<>();
         if (connection == null) return result;
 
-        String sql = "SELECT t.workstream_id, rc.runner, "
-            + "COALESCE(SUM(rc.cost_usd), 0) AS runner_cost "
-            + "FROM job_runner_cost rc JOIN job_timing t ON rc.job_id = t.job_id "
+        String sql = "SELECT t.workstream_id, " + tableAlias + "." + keyColumn + ", "
+            + "COALESCE(SUM(" + tableAlias + ".cost_usd), 0) AS " + costAlias + " "
+            + "FROM " + table + " " + tableAlias + " JOIN job_timing t ON "
+            + tableAlias + ".job_id = t.job_id "
             + "WHERE t.started_at >= ? AND t.started_at < ? AND t.status <> 'STARTED' "
-            + "GROUP BY t.workstream_id, rc.runner "
-            + "ORDER BY t.workstream_id, runner_cost DESC";
+            + "GROUP BY t.workstream_id, " + tableAlias + "." + keyColumn + " "
+            + "ORDER BY t.workstream_id, " + costAlias + " DESC";
 
         try (PreparedStatement ps = connection.prepareStatement(sql)) {
             ps.setTimestamp(1, Timestamp.from(startInstant));
@@ -620,28 +713,28 @@ public class JobStatsStore implements ConsoleFeatures {
                 while (rs.next()) {
                     String wsId = rs.getString("workstream_id");
                     result.computeIfAbsent(wsId, k -> new LinkedHashMap<>())
-                          .put(rs.getString("runner"), rs.getDouble("runner_cost"));
+                          .put(rs.getString(keyColumn), rs.getDouble(costAlias));
                 }
             }
         } catch (SQLException e) {
-            warn("Failed to query cost by runner per workstream: " + e.getMessage());
+            warn("Failed to query cost per workstream from " + table + ": " + e.getMessage());
         }
         return result;
     }
 
     /**
-     * Formats a per-runner cost map compactly for inclusion in a stats line,
+     * Formats a cost-by-key map compactly for inclusion in a stats line,
      * e.g. {@code " (claude $1.20, opencode $0.03)"}. Returns an empty string
      * when the map is empty so callers can append it unconditionally.
      *
-     * @param costByRunner map of runner name to USD cost
+     * @param costMap map of key (runner name, provider/model identifier, etc.) to USD cost
      * @return a compact parenthesised breakdown, or {@code ""} when empty
      */
-    public static String formatRunnerBreakdown(Map<String, Double> costByRunner) {
-        if (costByRunner == null || costByRunner.isEmpty()) return "";
+    public static String formatCostBreakdown(Map<String, Double> costMap) {
+        if (costMap == null || costMap.isEmpty()) return "";
         StringBuilder sb = new StringBuilder(" (");
         boolean first = true;
-        for (Map.Entry<String, Double> entry : costByRunner.entrySet()) {
+        for (Map.Entry<String, Double> entry : costMap.entrySet()) {
             if (!first) sb.append(", ");
             first = false;
             sb.append(entry.getKey()).append(" $")
@@ -706,6 +799,16 @@ public class JobStatsStore implements ConsoleFeatures {
             Map<String, Double> runners = runnerCosts.get(entry.getKey());
             if (runners != null && !runners.isEmpty()) {
                 entry.getValue().costByRunner = runners;
+            }
+        }
+
+        // Populate per-model cost for every workstream in one grouped query
+        Map<String, Map<String, Double>> modelCosts =
+                queryCostByModelPerWorkstream(startInstant, endInstant);
+        for (Map.Entry<String, WeeklyStats> entry : result.entrySet()) {
+            Map<String, Double> models = modelCosts.get(entry.getKey());
+            if (models != null && !models.isEmpty()) {
+                entry.getValue().costByModel = models;
             }
         }
 
@@ -905,5 +1008,11 @@ public class JobStatsStore implements ConsoleFeatures {
          * ordered by cost descending. Empty when no per-runner data is recorded.
          */
         public Map<String, Double> costByRunner = Collections.emptyMap();
+        /**
+         * Per-model USD cost breakdown for the window, keyed by provider/model
+         * identifier and ordered by cost descending. Empty when no per-model
+         * data is recorded.
+         */
+        public Map<String, Double> costByModel = Collections.emptyMap();
     }
 }

--- a/flowtree/runtime/src/main/java/io/flowtree/slack/SlackListener.java
+++ b/flowtree/runtime/src/main/java/io/flowtree/slack/SlackListener.java
@@ -1488,7 +1488,10 @@ public class SlackListener implements ConsoleFeatures {
         sb.append(" (:white_check_mark: ").append(stats.successCount);
         sb.append("  :x: ").append(stats.failedCount);
         sb.append("  :no_entry_sign: ").append(stats.cancelledCount).append(")\n");
-        sb.append("  :moneybag: Cost: $").append(String.format("%.2f", stats.totalCostUsd)).append(JobStatsStore.formatRunnerBreakdown(stats.costByRunner)).append("\n");
+        sb.append("  :moneybag: Cost: $").append(String.format("%.2f", stats.totalCostUsd));
+        sb.append(JobStatsStore.formatCostBreakdown(stats.costByRunner));
+        sb.append(JobStatsStore.formatCostBreakdown(stats.costByModel));
+        sb.append("\n");
         sb.append("  :speech_balloon: Turns: ").append(String.format("%,d", stats.totalTurns)).append("\n");
         return sb.toString();
     }

--- a/flowtree/runtime/src/main/java/io/flowtree/slack/SlackNotifier.java
+++ b/flowtree/runtime/src/main/java/io/flowtree/slack/SlackNotifier.java
@@ -1151,9 +1151,10 @@ public class SlackNotifier implements JobCompletionListener, ConsoleFeatures {
         }
 
         // Cost
-        // TODO(review): per-job completion cost line was not enhanced; weekly /flowtree stats gained :moneybag: + per-runner breakdown but this line stays plain and omits event.getCostByRunner()
         if (event.getCostUsd() > 0) {
-            sb.append("   Cost: $").append(String.format("%.2f", event.getCostUsd())).append("\n");
+            sb.append("   :moneybag: Cost: $").append(String.format("%.2f", event.getCostUsd()));
+            sb.append(JobStatsStore.formatCostBreakdown(event.getCostByModel()));
+            sb.append("\n");
         }
 
         // Duration (wall time and API time)

--- a/flowtree/runtime/src/main/java/io/flowtree/slack/SlackNotifier.java
+++ b/flowtree/runtime/src/main/java/io/flowtree/slack/SlackNotifier.java
@@ -1153,6 +1153,7 @@ public class SlackNotifier implements JobCompletionListener, ConsoleFeatures {
         // Cost
         if (event.getCostUsd() > 0) {
             sb.append("   :moneybag: Cost: $").append(String.format("%.2f", event.getCostUsd()));
+            sb.append(JobStatsStore.formatCostBreakdown(event.getCostByRunner()));
             sb.append(JobStatsStore.formatCostBreakdown(event.getCostByModel()));
             sb.append("\n");
         }

--- a/flowtree/runtime/src/main/java/io/flowtree/slack/StatsQueryHandler.java
+++ b/flowtree/runtime/src/main/java/io/flowtree/slack/StatsQueryHandler.java
@@ -157,25 +157,23 @@ class StatsQueryHandler {
         json.append(",\"totalDurationMs\":").append(stats.totalDurationMs);
         json.append(",\"totalCostUsd\":").append(stats.totalCostUsd);
         json.append(",\"totalTurns\":").append(stats.totalTurns);
-        json.append(",\"costByRunner\":{");
-        boolean first = true;
-        for (Map.Entry<String, Double> entry : stats.costByRunner.entrySet()) {
-            if (!first) json.append(",");
-            first = false;
-            json.append(FlowTreeApiEndpoint.escapeJsonValue(entry.getKey())).append(":")
-                .append(entry.getValue() != null ? entry.getValue() : 0.0);
-        }
+        appendCostMapJson(json, "costByRunner", stats.costByRunner);
+        appendCostMapJson(json, "costByModel", stats.costByModel);
         json.append("}");
-        json.append(",\"costByModel\":{");
-        first = true;
-        for (Map.Entry<String, Double> entry : stats.costByModel.entrySet()) {
-            if (!first) json.append(",");
-            first = false;
-            json.append(FlowTreeApiEndpoint.escapeJsonValue(entry.getKey())).append(":")
-                .append(entry.getValue() != null ? entry.getValue() : 0.0);
-        }
-        json.append("}");
-        json.append("}");
+    }
+
+    /**
+     * Appends a JSON key-value map for a cost breakdown.
+     * Delegates to {@link JsonFieldExtractor#appendDoubleMapJson} for the shared
+     * implementation.
+     *
+     * @param json     the builder to append to
+     * @param keyName  the JSON key name (e.g. {@code "costByRunner"})
+     * @param costMap map of cost key to USD value
+     */
+    private static void appendCostMapJson(StringBuilder json, String keyName,
+                                       Map<String, Double> costMap) {
+        JsonFieldExtractor.appendDoubleMapJson(json, keyName, costMap);
     }
 
 }

--- a/flowtree/runtime/src/main/java/io/flowtree/slack/StatsQueryHandler.java
+++ b/flowtree/runtime/src/main/java/io/flowtree/slack/StatsQueryHandler.java
@@ -166,6 +166,15 @@ class StatsQueryHandler {
                 .append(entry.getValue() != null ? entry.getValue() : 0.0);
         }
         json.append("}");
+        json.append(",\"costByModel\":{");
+        first = true;
+        for (Map.Entry<String, Double> entry : stats.costByModel.entrySet()) {
+            if (!first) json.append(",");
+            first = false;
+            json.append(FlowTreeApiEndpoint.escapeJsonValue(entry.getKey())).append(":")
+                .append(entry.getValue() != null ? entry.getValue() : 0.0);
+        }
+        json.append("}");
         json.append("}");
     }
 

--- a/flowtree/runtime/src/test/java/io/flowtree/slack/JobStatsStoreModelCostTest.java
+++ b/flowtree/runtime/src/test/java/io/flowtree/slack/JobStatsStoreModelCostTest.java
@@ -55,13 +55,16 @@ public class JobStatsStoreModelCostTest extends TestSuiteBase {
         return store;
     }
 
-    /** Returns the Monday of the current ISO week, in UTC. */
-    private static LocalDate currentMonday() {
+    /** Returns the Monday of the current ISO week, in UTC. Shared by {@link JobStatsStoreRunnerCostTest}. */
+    static LocalDate currentMonday() {
         return LocalDate.now(ZoneOffset.UTC).with(DayOfWeek.MONDAY);
     }
 
-    /** Records a started+completed job so its job_timing row exists and is not STARTED. */
-    private static void recordCompletedJob(JobStatsStore store, String jobId,
+    /**
+     * Records a started+completed job so its job_timing row exists and is not STARTED.
+     * Shared by {@link JobStatsStoreRunnerCostTest} (same package).
+     */
+    static void recordCompletedJob(JobStatsStore store, String jobId,
                                          String workstreamId, Instant when, double totalCost) {
         store.recordJobStarted(jobId, workstreamId, "job " + jobId, when);
         store.recordJobCompleted(jobId, workstreamId, "SUCCESS",

--- a/flowtree/runtime/src/test/java/io/flowtree/slack/JobStatsStoreModelCostTest.java
+++ b/flowtree/runtime/src/test/java/io/flowtree/slack/JobStatsStoreModelCostTest.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2026 Michael Murray
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.flowtree.slack;
+
+import fi.iki.elonen.NanoHTTPD;
+import org.almostrealism.util.TestSuiteBase;
+import org.junit.Test;
+
+import java.io.File;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.time.DayOfWeek;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for the per-model cost breakdown added to {@link JobStatsStore}:
+ * aggregation across multiple phases/models within and across jobs, the
+ * compact {@code /flowtree stats} breakdown formatting, and the
+ * {@code /api/stats} JSON surface that backs {@code workstream_get_status}.
+ * Analogous to {@link JobStatsStoreRunnerCostTest} but for the model-cost path.
+ */
+public class JobStatsStoreModelCostTest extends TestSuiteBase {
+
+    /** Creates and initialises a JobStatsStore backed by a fresh temp HSQLDB. */
+    private JobStatsStore newStore() throws Exception {
+        File tempDir = Files.createTempDirectory("model-cost-test").toFile();
+        tempDir.deleteOnExit();
+        String dbPath = new File(tempDir, "stats").getAbsolutePath();
+        JobStatsStore store = new JobStatsStore(dbPath);
+        store.initialize();
+        return store;
+    }
+
+    /** Returns the Monday of the current ISO week, in UTC. */
+    private static LocalDate currentMonday() {
+        return LocalDate.now(ZoneOffset.UTC).with(DayOfWeek.MONDAY);
+    }
+
+    /** Records a started+completed job so its job_timing row exists and is not STARTED. */
+    private static void recordCompletedJob(JobStatsStore store, String jobId,
+                                         String workstreamId, Instant when, double totalCost) {
+        store.recordJobStarted(jobId, workstreamId, "job " + jobId, when);
+        store.recordJobCompleted(jobId, workstreamId, "SUCCESS",
+                when.plusMillis(60000), 55000, 30000, totalCost, 10, "sess-" + jobId,
+                0, "success", false, 0, null, null, null, null);
+    }
+
+    @Test(timeout = 30000)
+    public void singleJobWithTwoModelsBreaksDownByModel() throws Exception {
+        JobStatsStore store = newStore();
+        try {
+            LocalDate monday = currentMonday();
+            Instant when = monday.atStartOfDay(ZoneOffset.UTC).toInstant().plusSeconds(3600);
+
+            recordCompletedJob(store, "job-1", "ws-mixed", when, 0.45);
+            Map<String, Double> perModel = new LinkedHashMap<>();
+            perModel.put("claude-opus-4-7", 0.42);
+            perModel.put("openrouter:qwen3-coder:exacto", 0.03);
+            store.recordModelCosts("job-1", perModel);
+
+            JobStatsStore.WeeklyStats stats = store.getWeeklyStats("ws-mixed", monday);
+            assertEquals(0.42, stats.costByModel.get("claude-opus-4-7"), 1e-9);
+            assertEquals(0.03, stats.costByModel.get("openrouter:qwen3-coder:exacto"), 1e-9);
+        } finally {
+            store.close();
+        }
+    }
+
+    @Test(timeout = 30000)
+    public void costSumsAcrossJobsPerModel() throws Exception {
+        JobStatsStore store = newStore();
+        try {
+            LocalDate monday = currentMonday();
+            Instant when = monday.atStartOfDay(ZoneOffset.UTC).toInstant().plusSeconds(3600);
+
+            recordCompletedJob(store, "job-a", "ws-sum", when, 1.0);
+            recordCompletedJob(store, "job-b", "ws-sum", when, 1.0);
+
+            Map<String, Double> a = new LinkedHashMap<>();
+            a.put("claude-opus-4-7", 0.50);
+            a.put("openrouter:qwen3-coder:exacto", 0.01);
+            store.recordModelCosts("job-a", a);
+
+            Map<String, Double> b = new LinkedHashMap<>();
+            b.put("claude-opus-4-7", 0.30);
+            store.recordModelCosts("job-b", b);
+
+            JobStatsStore.WeeklyStats stats = store.getWeeklyStats("ws-sum", monday);
+            assertEquals("claude-opus-4-7 cost sums across both jobs",
+                    0.80, stats.costByModel.get("claude-opus-4-7"), 1e-9);
+            assertEquals("openrouter:qwen3-coder:exacto appears only from job-a",
+                    0.01, stats.costByModel.get("openrouter:qwen3-coder:exacto"), 1e-9);
+        } finally {
+            store.close();
+        }
+    }
+
+    @Test(timeout = 30000)
+    public void reRecordingReplacesRatherThanDoubleCounts() throws Exception {
+        JobStatsStore store = newStore();
+        try {
+            LocalDate monday = currentMonday();
+            Instant when = monday.atStartOfDay(ZoneOffset.UTC).toInstant().plusSeconds(3600);
+            recordCompletedJob(store, "job-x", "ws-idem", when, 0.2);
+
+            Map<String, Double> first = new LinkedHashMap<>();
+            first.put("claude-opus-4-7", 0.10);
+            store.recordModelCosts("job-x", first);
+
+            Map<String, Double> second = new LinkedHashMap<>();
+            second.put("claude-opus-4-7", 0.25);
+            store.recordModelCosts("job-x", second);
+
+            JobStatsStore.WeeklyStats stats = store.getWeeklyStats("ws-idem", monday);
+            assertEquals(0.25, stats.costByModel.get("claude-opus-4-7"), 1e-9);
+        } finally {
+            store.close();
+        }
+    }
+
+    @Test(timeout = 30000)
+    public void emptyBreakdownClearsExistingRows() throws Exception {
+        JobStatsStore store = newStore();
+        try {
+            LocalDate monday = currentMonday();
+            Instant when = monday.atStartOfDay(ZoneOffset.UTC).toInstant().plusSeconds(3600);
+            recordCompletedJob(store, "job-clear", "ws-clear", when, 0.2);
+
+            Map<String, Double> costs = new LinkedHashMap<>();
+            costs.put("claude-opus-4-7", 0.10);
+            store.recordModelCosts("job-clear", costs);
+            store.recordModelCosts("job-clear", new LinkedHashMap<>());
+
+            JobStatsStore.WeeklyStats stats = store.getWeeklyStats("ws-clear", monday);
+            assertFalse("an empty re-record clears prior rows",
+                    stats.costByModel.containsKey("claude-opus-4-7"));
+        } finally {
+            store.close();
+        }
+    }
+
+    @Test(timeout = 30000)
+    public void apiStatsEndpointIncludesPerModelBreakdown() throws Exception {
+        JobStatsStore store = newStore();
+        try {
+            LocalDate monday = currentMonday();
+            Instant when = monday.atStartOfDay(ZoneOffset.UTC).toInstant().plusSeconds(3600);
+            recordCompletedJob(store, "job-api", "ws-api", when, 0.45);
+
+            Map<String, Double> perModel = new LinkedHashMap<>();
+            perModel.put("claude-opus-4-7", 0.42);
+            perModel.put("openrouter:qwen3-coder:exacto", 0.03);
+            store.recordModelCosts("job-api", perModel);
+
+            SlackNotifier notifier = new SlackNotifier(null);
+            FlowTreeApiEndpoint endpoint = new FlowTreeApiEndpoint(0, notifier);
+            endpoint.setStatsStore(store);
+            endpoint.start(NanoHTTPD.SOCKET_READ_TIMEOUT, false);
+
+            try {
+                int port = endpoint.getListeningPort();
+                HttpURLConnection conn = (HttpURLConnection) new URL(
+                        "http://localhost:" + port + "/api/stats?workstream=ws-api").openConnection();
+                conn.setRequestMethod("GET");
+                assertEquals(200, conn.getResponseCode());
+
+                String response = new String(conn.getInputStream().readAllBytes(),
+                        StandardCharsets.UTF_8);
+                assertTrue("response exposes a costByModel object",
+                        response.contains("\"costByModel\""));
+                assertTrue("response names the claude-opus-4-7 model",
+                        response.contains("\"claude-opus-4-7\""));
+                assertTrue("response names the openrouter:qwen3-coder:exacto model",
+                        response.contains("\"openrouter:qwen3-coder:exacto\""));
+            } finally {
+                endpoint.stop();
+            }
+        } finally {
+            store.close();
+        }
+    }
+
+    @Test(timeout = 30000)
+    public void allWorkstreamsPathPopulatesCostByModel() throws Exception {
+        JobStatsStore store = newStore();
+        try {
+            LocalDate monday = currentMonday();
+            Instant when = monday.atStartOfDay(ZoneOffset.UTC).toInstant().plusSeconds(3600);
+
+            recordCompletedJob(store, "job-ws1", "ws-one", when, 0.50);
+            recordCompletedJob(store, "job-ws2", "ws-two", when, 0.30);
+
+            Map<String, Double> models1 = new LinkedHashMap<>();
+            models1.put("claude-opus-4-7", 0.45);
+            models1.put("openrouter:qwen3-coder:exacto", 0.05);
+            store.recordModelCosts("job-ws1", models1);
+
+            Map<String, Double> models2 = new LinkedHashMap<>();
+            models2.put("claude-opus-4-7", 0.30);
+            store.recordModelCosts("job-ws2", models2);
+
+            Map<String, JobStatsStore.WeeklyStats> byWs = store.getWeeklyStatsByWorkstream(monday);
+            assertTrue("ws-one present", byWs.containsKey("ws-one"));
+            assertTrue("ws-two present", byWs.containsKey("ws-two"));
+
+            assertEquals("ws-one claude-opus-4-7 cost", 0.45, byWs.get("ws-one").costByModel.get("claude-opus-4-7"), 1e-9);
+            assertEquals("ws-one openrouter:qwen3-coder:exacto cost", 0.05, byWs.get("ws-one").costByModel.get("openrouter:qwen3-coder:exacto"), 1e-9);
+            assertEquals("ws-two claude-opus-4-7 cost", 0.30, byWs.get("ws-two").costByModel.get("claude-opus-4-7"), 1e-9);
+        } finally {
+            store.close();
+        }
+    }
+}

--- a/flowtree/runtime/src/test/java/io/flowtree/slack/JobStatsStoreRunnerCostTest.java
+++ b/flowtree/runtime/src/test/java/io/flowtree/slack/JobStatsStoreRunnerCostTest.java
@@ -54,28 +54,14 @@ public class JobStatsStoreRunnerCostTest extends TestSuiteBase {
         return store;
     }
 
-    /** Returns the Monday of the current ISO week, in UTC. */
-    private static LocalDate currentMonday() {
-        return LocalDate.now(ZoneOffset.UTC).with(DayOfWeek.MONDAY);
-    }
-
-    /** Records a started+completed job so its job_timing row exists and is not STARTED. */
-    private static void recordCompletedJob(JobStatsStore store, String jobId,
-                                           String workstreamId, Instant when, double totalCost) {
-        store.recordJobStarted(jobId, workstreamId, "job " + jobId, when);
-        store.recordJobCompleted(jobId, workstreamId, "SUCCESS",
-                when.plusMillis(60000), 55000, 30000, totalCost, 10, "sess-" + jobId,
-                0, "success", false, 0, null, null, null, null);
-    }
-
     @Test(timeout = 30000)
     public void singleJobWithTwoRunnersBreaksDownByRunner() throws Exception {
         JobStatsStore store = newStore();
         try {
-            LocalDate monday = currentMonday();
+            LocalDate monday = JobStatsStoreModelCostTest.currentMonday();
             Instant when = monday.atStartOfDay(ZoneOffset.UTC).toInstant().plusSeconds(3600);
 
-            recordCompletedJob(store, "job-1", "ws-mixed", when, 0.45);
+            JobStatsStoreModelCostTest.recordCompletedJob(store, "job-1", "ws-mixed", when, 0.45);
             // The same job ran two phases on two different runners.
             Map<String, Double> perRunner = new LinkedHashMap<>();
             perRunner.put("claude", 0.42);
@@ -94,11 +80,11 @@ public class JobStatsStoreRunnerCostTest extends TestSuiteBase {
     public void costSumsAcrossJobsPerRunner() throws Exception {
         JobStatsStore store = newStore();
         try {
-            LocalDate monday = currentMonday();
+            LocalDate monday = JobStatsStoreModelCostTest.currentMonday();
             Instant when = monday.atStartOfDay(ZoneOffset.UTC).toInstant().plusSeconds(3600);
 
-            recordCompletedJob(store, "job-a", "ws-sum", when, 1.0);
-            recordCompletedJob(store, "job-b", "ws-sum", when, 1.0);
+            JobStatsStoreModelCostTest.recordCompletedJob(store, "job-a", "ws-sum", when, 1.0);
+            JobStatsStoreModelCostTest.recordCompletedJob(store, "job-b", "ws-sum", when, 1.0);
 
             Map<String, Double> a = new LinkedHashMap<>();
             a.put("claude", 0.50);
@@ -123,9 +109,9 @@ public class JobStatsStoreRunnerCostTest extends TestSuiteBase {
     public void reRecordingReplacesRatherThanDoubleCounts() throws Exception {
         JobStatsStore store = newStore();
         try {
-            LocalDate monday = currentMonday();
+            LocalDate monday = JobStatsStoreModelCostTest.currentMonday();
             Instant when = monday.atStartOfDay(ZoneOffset.UTC).toInstant().plusSeconds(3600);
-            recordCompletedJob(store, "job-x", "ws-idem", when, 0.2);
+            JobStatsStoreModelCostTest.recordCompletedJob(store, "job-x", "ws-idem", when, 0.2);
 
             Map<String, Double> first = new LinkedHashMap<>();
             first.put("claude", 0.10);
@@ -159,9 +145,9 @@ public class JobStatsStoreRunnerCostTest extends TestSuiteBase {
     public void apiStatsEndpointIncludesPerRunnerBreakdown() throws Exception {
         JobStatsStore store = newStore();
         try {
-            LocalDate monday = currentMonday();
+            LocalDate monday = JobStatsStoreModelCostTest.currentMonday();
             Instant when = monday.atStartOfDay(ZoneOffset.UTC).toInstant().plusSeconds(3600);
-            recordCompletedJob(store, "job-api", "ws-api", when, 0.45);
+            JobStatsStoreModelCostTest.recordCompletedJob(store, "job-api", "ws-api", when, 0.45);
 
             Map<String, Double> perRunner = new LinkedHashMap<>();
             perRunner.put("claude", 0.42);
@@ -200,11 +186,11 @@ public class JobStatsStoreRunnerCostTest extends TestSuiteBase {
     public void allWorkstreamsPathPopulatesCostByRunner() throws Exception {
         JobStatsStore store = newStore();
         try {
-            LocalDate monday = currentMonday();
+            LocalDate monday = JobStatsStoreModelCostTest.currentMonday();
             Instant when = monday.atStartOfDay(ZoneOffset.UTC).toInstant().plusSeconds(3600);
 
-            recordCompletedJob(store, "job-ws1", "ws-one", when, 0.50);
-            recordCompletedJob(store, "job-ws2", "ws-two", when, 0.30);
+            JobStatsStoreModelCostTest.recordCompletedJob(store, "job-ws1", "ws-one", when, 0.50);
+            JobStatsStoreModelCostTest.recordCompletedJob(store, "job-ws2", "ws-two", when, 0.30);
 
             Map<String, Double> runners1 = new LinkedHashMap<>();
             runners1.put("claude", 0.45);
@@ -231,9 +217,9 @@ public class JobStatsStoreRunnerCostTest extends TestSuiteBase {
     public void emptyBreakdownClearsExistingRows() throws Exception {
         JobStatsStore store = newStore();
         try {
-            LocalDate monday = currentMonday();
+            LocalDate monday = JobStatsStoreModelCostTest.currentMonday();
             Instant when = monday.atStartOfDay(ZoneOffset.UTC).toInstant().plusSeconds(3600);
-            recordCompletedJob(store, "job-clear", "ws-clear", when, 0.2);
+            JobStatsStoreModelCostTest.recordCompletedJob(store, "job-clear", "ws-clear", when, 0.2);
 
             Map<String, Double> costs = new LinkedHashMap<>();
             costs.put("claude", 0.10);

--- a/flowtree/runtime/src/test/java/io/flowtree/slack/JobStatsStoreRunnerCostTest.java
+++ b/flowtree/runtime/src/test/java/io/flowtree/slack/JobStatsStoreRunnerCostTest.java
@@ -144,14 +144,14 @@ public class JobStatsStoreRunnerCostTest extends TestSuiteBase {
     }
 
     @Test(timeout = 30000)
-    public void formatRunnerBreakdownIsCompactAndOmitsWhenEmpty() {
-        assertEquals("", JobStatsStore.formatRunnerBreakdown(null));
-        assertEquals("", JobStatsStore.formatRunnerBreakdown(new LinkedHashMap<>()));
+    public void formatCostBreakdownIsCompactAndOmitsWhenEmpty() {
+        assertEquals("", JobStatsStore.formatCostBreakdown(null));
+        assertEquals("", JobStatsStore.formatCostBreakdown(new LinkedHashMap<>()));
 
         Map<String, Double> costs = new LinkedHashMap<>();
         costs.put("claude", 42.0);
         costs.put("opencode", 3.0);
-        String formatted = JobStatsStore.formatRunnerBreakdown(costs);
+        String formatted = JobStatsStore.formatCostBreakdown(costs);
         assertEquals(" (claude $42.00, opencode $3.00)", formatted);
     }
 


### PR DESCRIPTION
Track cost by provider/model identifier (e.g., "openrouter/claude-opus-4-7") in addition to the existing per-runner breakdown. Costs are accumulated per-phase and surfaced in:

- Per-job completion messages in SlackNotifier (appendSessionMetrics)
- Weekly stats aggregate lines in SlackListener (formatWeeklyStats)
- /api/stats JSON endpoint via StatsQueryHandler

Changes:
- CodingAgentJob: add costByModel field, buildModelKey() helper, accumulate cost by model alongside costByRunner
- CodingAgentJobEvent: add costByModel field with getter/setter
- JobCompletionEvent: add base getCostByModel() returning empty map
- JobStatsStore: add job_model_cost table, recordModelCosts(), queryCostByModel(), queryCostByModelPerWorkstream(), costByModel in WeeklyStats, formatModelBreakdown() formatter
- StatsQueryHandler: serialize costByModel in JSON response
- SlackNotifier: show model breakdown in per-job completion cost line
- SlackListener: show model breakdown in weekly stats cost line

Example output in Slack:
  :moneybag: Cost: $1.23 (claude $1.20) (openrouter/claude-opus-4-7 $1.23)