### PR TITLE
Wire retrospective_enabled submission parameter to the orchestrator gate

### DIFF
--- a/flowtree/runtime/src/main/java/io/flowtree/api/FlowTreeApiEndpoint.java
+++ b/flowtree/runtime/src/main/java/io/flowtree/api/FlowTreeApiEndpoint.java
@@ -710,6 +710,10 @@ public class FlowTreeApiEndpoint extends NanoHTTPD implements ConsoleFeatures {
         if (extractJsonHasField(body, "enforceOrganizationalPlacement"))
             factory.setEnforceOrganizationalPlacement(
                     extractJsonBooleanField(body, "enforceOrganizationalPlacement"));
+        // Retrospective phase — disabled by default; opt in explicitly
+        if (extractJsonHasField(body, "retrospectiveEnabled"))
+            factory.setRetrospectiveEnabled(
+                    extractJsonBooleanField(body, "retrospectiveEnabled"));
         if (extractJsonHasField(body, "reviewEnabled"))
             factory.setReviewEnabled(extractJsonBooleanField(body, "reviewEnabled"));
         int maxReviewPasses = extractJsonIntField(body, "maxReviewPasses");
@@ -821,6 +825,8 @@ public class FlowTreeApiEndpoint extends NanoHTTPD implements ConsoleFeatures {
         json.append(",\"deduplicationEnabled\":").append(dedupEnabled);
         json.append(",\"organizationalPlacementEnabled\":")
                 .append(factory.isEnforceOrganizationalPlacement());
+        json.append(",\"retrospectiveEnabled\":")
+                .append(factory.isRetrospectiveEnabled());
         json.append("}");
         return newFixedLengthResponse(Response.Status.OK,
                 "application/json", json.toString());

--- a/flowtree/runtime/src/main/java/io/flowtree/jobs/CodingAgentJob.java
+++ b/flowtree/runtime/src/main/java/io/flowtree/jobs/CodingAgentJob.java
@@ -182,7 +182,7 @@ public class CodingAgentJob extends GitManagedJob {
      * analyzing the primary phase transcript for tool-use and context-efficiency
      * improvement opportunities. Defaults to {@code false}; opt in per-job.
      */
-    private boolean reflectionEnabled = false;
+    private boolean retrospectiveEnabled = false;
     /** {@code true} after {@link #runReflectionPhase()} has executed; reset on each {@link #doWork()} call. */
     private boolean reflectionRan;
     /** {@code true} when the retrospective agent found and analyzed a primary-phase transcript. */
@@ -621,9 +621,9 @@ public class CodingAgentJob extends GitManagedJob {
     }
 
     /** Returns whether the retrospective phase is active for this job; default {@code false}. */
-    public boolean isReflectionEnabled() { return reflectionEnabled; }
+    public boolean isRetrospectiveEnabled() { return retrospectiveEnabled; }
     /** Sets whether the retrospective phase is active for this job; {@code true} to enable retrospective analysis. */
-    public void setReflectionEnabled(boolean reflectionEnabled) { this.reflectionEnabled = reflectionEnabled; }
+    public void setRetrospectiveEnabled(boolean retrospectiveEnabled) { this.retrospectiveEnabled = retrospectiveEnabled; }
 
     /** Returns the post-completion command; non-empty activates {@link PostCompletionCommandRule}. */
     public String getPostCompletionCommand() { return postCompletionCommand; }
@@ -949,7 +949,7 @@ public class CodingAgentJob extends GitManagedJob {
         }
         // Retrospective phase runs after enforcement rules; produces memories, not code.
         reflectionRan = false;
-        if (reflectionEnabled) {
+        if (retrospectiveEnabled) {
             runReflectionPhase();
         }
     }

--- a/flowtree/runtime/src/main/java/io/flowtree/jobs/CodingAgentJobCodec.java
+++ b/flowtree/runtime/src/main/java/io/flowtree/jobs/CodingAgentJobCodec.java
@@ -238,7 +238,6 @@ final class CodingAgentJobCodec {
             case "reviewEnabled":
                 job.setReviewEnabled(Boolean.parseBoolean(value));
                 return true;
-            // TODO(review): add case "reflectionEnabled" as a backward-compat alias for jobs serialized with the old key
             case "retrospectiveEnabled":
                 job.setRetrospectiveEnabled(Boolean.parseBoolean(value));
                 return true;

--- a/flowtree/runtime/src/main/java/io/flowtree/jobs/CodingAgentJobCodec.java
+++ b/flowtree/runtime/src/main/java/io/flowtree/jobs/CodingAgentJobCodec.java
@@ -150,8 +150,8 @@ final class CodingAgentJobCodec {
         if (!job.isReviewEnabled()) {
             sb.append("::reviewEnabled:=false");
         }
-        if (job.isReflectionEnabled()) {
-            sb.append("::reflectionEnabled:=true");
+        if (job.isRetrospectiveEnabled()) {
+            sb.append("::retrospectiveEnabled:=true");
         }
         if (job.getMaxReviewPasses() != CodingAgentJob.DEFAULT_MAX_REVIEW_PASSES) {
             sb.append("::maxReviewPasses:=").append(job.getMaxReviewPasses());
@@ -238,8 +238,9 @@ final class CodingAgentJobCodec {
             case "reviewEnabled":
                 job.setReviewEnabled(Boolean.parseBoolean(value));
                 return true;
-            case "reflectionEnabled":
-                job.setReflectionEnabled(Boolean.parseBoolean(value));
+            // TODO(review): add case "reflectionEnabled" as a backward-compat alias for jobs serialized with the old key
+            case "retrospectiveEnabled":
+                job.setRetrospectiveEnabled(Boolean.parseBoolean(value));
                 return true;
             case "maxReviewPasses":
                 job.setMaxReviewPasses(parsePositiveOrDefault(value, CodingAgentJob.DEFAULT_MAX_REVIEW_PASSES));

--- a/flowtree/runtime/src/main/java/io/flowtree/jobs/CodingAgentJobEvent.java
+++ b/flowtree/runtime/src/main/java/io/flowtree/jobs/CodingAgentJobEvent.java
@@ -87,7 +87,7 @@ public class CodingAgentJobEvent extends JobCompletionEvent {
     /** {@code true} when at least one review session ran during this job. */
     private boolean reviewRan;
 
-    /** {@code true} when the retrospective phase ran (reflectionEnabled was true and doWork ran it). */
+    /** {@code true} when the retrospective phase ran (retrospectiveEnabled was true and doWork ran it). */
     private boolean reflectionRan;
     /** USD cost of the retrospective session, accumulated via absorbResult() into costByRunner/costByModel. */
     private double reflectionCostUsd;

--- a/flowtree/runtime/src/main/java/io/flowtree/jobs/CodingAgentJobFactory.java
+++ b/flowtree/runtime/src/main/java/io/flowtree/jobs/CodingAgentJobFactory.java
@@ -1379,7 +1379,6 @@ public class CodingAgentJobFactory extends AbstractJobFactory implements Console
             case "reviewEnabled":
                 this.reviewEnabled = Boolean.parseBoolean(value);
                 return;
-            // TODO(review): add case "reflectionEnabled" as a backward-compat alias for factories serialized with the old key
             case "retrospectiveEnabled":
                 this.retrospectiveEnabled = Boolean.parseBoolean(value);
                 return;

--- a/flowtree/runtime/src/main/java/io/flowtree/jobs/CodingAgentJobFactory.java
+++ b/flowtree/runtime/src/main/java/io/flowtree/jobs/CodingAgentJobFactory.java
@@ -130,7 +130,7 @@ public class CodingAgentJobFactory extends AbstractJobFactory implements Console
      * tool-use and context-efficiency improvement opportunities. Defaults to
      * {@code false}; opt in per-job.
      */
-    private boolean reflectionEnabled = false;
+    private boolean retrospectiveEnabled = false;
 
     /**
      * Per-job cap on review passes propagated to jobs created by this factory.
@@ -735,18 +735,18 @@ public class CodingAgentJobFactory extends AbstractJobFactory implements Console
      *
      * @return {@code true} when retrospective analysis is enabled; {@code false} by default
      */
-    public boolean isReflectionEnabled() {
-        return reflectionEnabled;
+    public boolean isRetrospectiveEnabled() {
+        return retrospectiveEnabled;
     }
 
     /**
      * Sets whether the retrospective phase is active for jobs created by this factory.
      *
-     * @param reflectionEnabled {@code true} to enable retrospective analysis after primary work
+     * @param retrospectiveEnabled {@code true} to enable retrospective analysis after primary work
      */
-    public void setReflectionEnabled(boolean reflectionEnabled) {
-        this.reflectionEnabled = reflectionEnabled;
-        set("reflectionEnabled", String.valueOf(reflectionEnabled));
+    public void setRetrospectiveEnabled(boolean retrospectiveEnabled) {
+        this.retrospectiveEnabled = retrospectiveEnabled;
+        set("retrospectiveEnabled", String.valueOf(retrospectiveEnabled));
     }
 
     /**
@@ -1212,7 +1212,7 @@ public class CodingAgentJobFactory extends AbstractJobFactory implements Console
         job.setEnforceOrganizationalPlacement(enforceOrganizationalPlacement);
         job.setReviewEnabled(reviewEnabled);
         job.setMaxReviewPasses(maxReviewPasses);
-        job.setReflectionEnabled(reflectionEnabled);
+        job.setRetrospectiveEnabled(retrospectiveEnabled);
         if (postCompletionCommand != null && !postCompletionCommand.isEmpty()) {
             job.setPostCompletionCommand(postCompletionCommand);
             if (postCompletionWorkingDir != null) {
@@ -1379,8 +1379,9 @@ public class CodingAgentJobFactory extends AbstractJobFactory implements Console
             case "reviewEnabled":
                 this.reviewEnabled = Boolean.parseBoolean(value);
                 return;
-            case "reflectionEnabled":
-                this.reflectionEnabled = Boolean.parseBoolean(value);
+            // TODO(review): add case "reflectionEnabled" as a backward-compat alias for factories serialized with the old key
+            case "retrospectiveEnabled":
+                this.retrospectiveEnabled = Boolean.parseBoolean(value);
                 return;
             case "maxReviewPasses":
                 this.maxReviewPasses = CodingAgentJobCodec.parsePositiveOrDefault(

--- a/flowtree/runtime/src/test/java/io/flowtree/jobs/CodingAgentJobRetrospectiveTest.java
+++ b/flowtree/runtime/src/test/java/io/flowtree/jobs/CodingAgentJobRetrospectiveTest.java
@@ -311,7 +311,7 @@ public class CodingAgentJobRetrospectiveTest extends TestSuiteBase {
         SpyCodingAgentJob job = new SpyCodingAgentJob("t1", "p");
         job.setRetrospectiveEnabled(true);
         job.doWork();
-        assertTrue("runEnforcementRules() must be called when reflection is enabled",
+        assertTrue("runEnforcementRules() must be called when retrospective is enabled",
                 job.enforcementRulesCalled);
         assertTrue("runReflectionPhase() must be called after runEnforcementRules()",
                 job.reflectionPhaseCalled);

--- a/flowtree/runtime/src/test/java/io/flowtree/jobs/CodingAgentJobRetrospectiveTest.java
+++ b/flowtree/runtime/src/test/java/io/flowtree/jobs/CodingAgentJobRetrospectiveTest.java
@@ -27,7 +27,7 @@ import static org.junit.Assert.assertTrue;
 
 /**
  * Unit tests for the retrospective phase: {@link Phase#RETROSPECTIVE} wire
- * mapping, the {@code reflectionEnabled} flag on {@link CodingAgentJob} and
+ * mapping, the {@code retrospectiveEnabled} flag on {@link CodingAgentJob} and
  * {@link CodingAgentJobFactory}, the wire-format serialisation round-trip,
  * the {@link RetrospectivePromptBuilder}, and the non-code-producing phase
  * completion invariant.
@@ -54,95 +54,95 @@ public class CodingAgentJobRetrospectiveTest extends TestSuiteBase {
         assertEquals("retrospective", Phase.RETROSPECTIVE.wireName());
     }
 
-    // ── reflectionEnabled on CodingAgentJob ────────────────────────────────
+    // ── retrospectiveEnabled on CodingAgentJob ────────────────────────────────
 
-    /** CodingAgentJob isReflectionEnabled defaults to false. */
+    /** CodingAgentJob isRetrospectiveEnabled defaults to false. */
     @Test(timeout = 30000)
-    public void reflectionEnabledDefaultIsFalse() {
-        assertFalse(new CodingAgentJob("t1", "p").isReflectionEnabled());
+    public void retrospectiveEnabledDefaultIsFalse() {
+        assertFalse(new CodingAgentJob("t1", "p").isRetrospectiveEnabled());
     }
 
-    /** CodingAgentJob.setReflectionEnabled(true) is reflected in isReflectionEnabled(). */
+    /** CodingAgentJob.setRetrospectiveEnabled(true) is reflected in isRetrospectiveEnabled(). */
     @Test(timeout = 30000)
-    public void setReflectionEnabledTrue() {
+    public void setRetrospectiveEnabledTrue() {
         CodingAgentJob job = new CodingAgentJob("t1", "p");
-        job.setReflectionEnabled(true);
-        assertTrue(job.isReflectionEnabled());
+        job.setRetrospectiveEnabled(true);
+        assertTrue(job.isRetrospectiveEnabled());
     }
 
-    /** CodingAgentJob.setReflectionEnabled(false) toggles off after true. */
+    /** CodingAgentJob.setRetrospectiveEnabled(false) toggles off after true. */
     @Test(timeout = 30000)
-    public void setReflectionEnabledFalse() {
+    public void setRetrospectiveEnabledFalse() {
         CodingAgentJob job = new CodingAgentJob("t1", "p");
-        job.setReflectionEnabled(true);
-        job.setReflectionEnabled(false);
-        assertFalse(job.isReflectionEnabled());
+        job.setRetrospectiveEnabled(true);
+        job.setRetrospectiveEnabled(false);
+        assertFalse(job.isRetrospectiveEnabled());
     }
 
     // ── Wire format — defaults absent ───────────────────────────────────────
 
-    /** reflectionEnabled absent from wire format when default (false). */
+    /** retrospectiveEnabled absent from wire format when default (false). */
     @Test(timeout = 30000)
-    public void reflectionEnabledAbsentFromWireFormatWhenFalse() {
+    public void retrospectiveEnabledAbsentFromWireFormatWhenFalse() {
         CodingAgentJob job = new CodingAgentJob("t1", "p");
         String encoded = job.encode();
-        assertFalse("reflectionEnabled must not appear when default (false): " + encoded,
-                encoded.contains("reflectionEnabled"));
+        assertFalse("retrospectiveEnabled must not appear when default (false): " + encoded,
+                encoded.contains("retrospectiveEnabled"));
     }
 
-    /** reflectionEnabled appears in wire format when set to true. */
+    /** retrospectiveEnabled appears in wire format when set to true. */
     @Test(timeout = 30000)
-    public void reflectionEnabledAppearsInWireFormatWhenTrue() {
+    public void retrospectiveEnabledAppearsInWireFormatWhenTrue() {
         CodingAgentJob job = new CodingAgentJob("t1", "p");
-        job.setReflectionEnabled(true);
+        job.setRetrospectiveEnabled(true);
         String encoded = job.encode();
-        assertTrue("Expected reflectionEnabled:=true in: " + encoded,
-                encoded.contains("reflectionEnabled:=true"));
+        assertTrue("Expected retrospectiveEnabled:=true in: " + encoded,
+                encoded.contains("retrospectiveEnabled:=true"));
     }
 
-    /** reflectionEnabled round-trips correctly via job.set(). */
+    /** retrospectiveEnabled round-trips correctly via job.set(). */
     @Test(timeout = 30000)
-    public void reflectionEnabledRoundTripViaSet() {
+    public void retrospectiveEnabledRoundTripViaSet() {
         CodingAgentJob job = new CodingAgentJob("t1", "p");
-        job.set("reflectionEnabled", "true");
-        assertTrue(job.isReflectionEnabled());
-        job.set("reflectionEnabled", "false");
-        assertFalse(job.isReflectionEnabled());
+        job.set("retrospectiveEnabled", "true");
+        assertTrue(job.isRetrospectiveEnabled());
+        job.set("retrospectiveEnabled", "false");
+        assertFalse(job.isRetrospectiveEnabled());
     }
 
-    /** CodingAgentJob reflectionEnabled survives encode/decode round-trip. */
+    /** CodingAgentJob retrospectiveEnabled survives encode/decode round-trip. */
     @Test(timeout = 30000)
     public void encodeDecodeRoundTrip() {
         CodingAgentJob job = new CodingAgentJob("t1", "p");
-        job.setReflectionEnabled(true);
+        job.setRetrospectiveEnabled(true);
         CodingAgentJob restored = GitManagedJobSerializationTest.roundTrip(job);
-        assertTrue(restored.isReflectionEnabled());
+        assertTrue(restored.isRetrospectiveEnabled());
     }
 
     // ── Factory propagation ────────────────────────────────────────────────
 
-    /** CodingAgentJobFactory isReflectionEnabled defaults to false. */
+    /** CodingAgentJobFactory isRetrospectiveEnabled defaults to false. */
     @Test(timeout = 30000)
-    public void factoryReflectionEnabledDefaultFalse() {
-        assertFalse(new CodingAgentJobFactory("prompt").isReflectionEnabled());
+    public void factoryRetrospectiveEnabledDefaultFalse() {
+        assertFalse(new CodingAgentJobFactory("prompt").isRetrospectiveEnabled());
     }
 
-    /** CodingAgentJobFactory.setReflectionEnabled propagates to nextJob(). */
+    /** CodingAgentJobFactory.setRetrospectiveEnabled propagates to nextJob(). */
     @Test(timeout = 30000)
-    public void factoryReflectionEnabledPropagatesToJob() {
+    public void factoryRetrospectiveEnabledPropagatesToJob() {
         CodingAgentJobFactory factory = new CodingAgentJobFactory("p");
-        factory.setReflectionEnabled(true);
+        factory.setRetrospectiveEnabled(true);
         CodingAgentJob job = (CodingAgentJob) factory.nextJob();
         assertNotNull(job);
-        assertTrue(job.isReflectionEnabled());
+        assertTrue(job.isRetrospectiveEnabled());
     }
 
-    /** CodingAgentJobFactory reflectionEnabled round-trips via set(). */
+    /** CodingAgentJobFactory retrospectiveEnabled round-trips via set(). */
     @Test(timeout = 30000)
-    public void factoryReflectionEnabledRoundTripViaSet() {
+    public void factoryRetrospectiveEnabledRoundTripViaSet() {
         CodingAgentJobFactory factory = new CodingAgentJobFactory("p");
-        factory.set("reflectionEnabled", "true");
-        assertTrue(factory.isReflectionEnabled());
+        factory.set("retrospectiveEnabled", "true");
+        assertTrue(factory.isRetrospectiveEnabled());
     }
 
     // ── RetrospectivePromptBuilder ──────────────────────────────────────────
@@ -309,7 +309,7 @@ public class CodingAgentJobRetrospectiveTest extends TestSuiteBase {
     @Test(timeout = 30000)
     public void retrospectivePhaseIsOutsideEnforcementRuleLoop() {
         SpyCodingAgentJob job = new SpyCodingAgentJob("t1", "p");
-        job.setReflectionEnabled(true);
+        job.setRetrospectiveEnabled(true);
         job.doWork();
         assertTrue("runEnforcementRules() must be called when reflection is enabled",
                 job.enforcementRulesCalled);
@@ -317,6 +317,26 @@ public class CodingAgentJobRetrospectiveTest extends TestSuiteBase {
                 job.reflectionPhaseCalled);
         assertTrue("runReflectionPhase() must be called exactly once (not looped)",
                 job.reflectionPhaseCallCount == 1);
+    }
+
+    /**
+     * Verifies the orchestrator gate: when {@code retrospectiveEnabled} is false
+     * (the default), {@code doWork()} must NOT invoke {@code runReflectionPhase()}.
+     * This is the negative path of the activation gate that {@code retrospective_enabled}
+     * on the submit tool controls end-to-end.
+     */
+    @Test(timeout = 30000)
+    public void retrospectivePhaseSkippedWhenRetrospectiveEnabledFalse() {
+        SpyCodingAgentJob job = new SpyCodingAgentJob("t1", "p");
+        // retrospectiveEnabled defaults to false; assert that explicitly.
+        assertFalse(job.isRetrospectiveEnabled());
+        job.doWork();
+        assertTrue("runEnforcementRules() must still be called when retrospective is disabled",
+                job.enforcementRulesCalled);
+        assertFalse("runReflectionPhase() must NOT be called when retrospectiveEnabled is false",
+                job.reflectionPhaseCalled);
+        assertEquals("runReflectionPhase() must not be called at all when gate is off",
+                0, job.reflectionPhaseCallCount);
     }
 
     /**
@@ -360,7 +380,7 @@ public class CodingAgentJobRetrospectiveTest extends TestSuiteBase {
     @Test(timeout = 30000)
     public void retrospectivePhaseUsesPhaseEnumWireName() {
         CodingAgentJob job = new CodingAgentJob("t1", "p");
-        job.setReflectionEnabled(true);
+        job.setRetrospectiveEnabled(true);
         assertEquals(Phase.RETROSPECTIVE.wireName(), "retrospective");
     }
 }

--- a/flowtree/runtime/src/test/java/io/flowtree/jobs/McpToolDiscoveryTest.java
+++ b/flowtree/runtime/src/test/java/io/flowtree/jobs/McpToolDiscoveryTest.java
@@ -444,9 +444,9 @@ public class McpToolDiscoveryTest extends TestSuiteBase {
 		assertTrue("workstream_submit_task must declare organizational_placement_enabled in"
 			+ " signature so callers can opt in to placement review for pre-merge jobs",
 			submitParams.contains("organizational_placement_enabled"));
-		assertTrue("workstream_submit_task must declare reflection_enabled in signature"
+		assertTrue("workstream_submit_task must declare retrospective_enabled in signature"
 			+ " so callers can opt in to the retrospective phase",
-			submitParams.contains("reflection_enabled"));
+			submitParams.contains("retrospective_enabled"));
 
 		List<String> registerParams =
 			McpToolDiscovery.discoverToolParameters(serverFile, "workstream_register");

--- a/tools/mcp/manager/phase_config.py
+++ b/tools/mcp/manager/phase_config.py
@@ -35,6 +35,7 @@ _KNOWN_PHASE_WIRE_NAMES = (
     "post-completion",
     "commit-message",
     "git-tampering-restart",
+    "retrospective",
 )
 
 # Runner identifiers mirrored from io.flowtree.jobs.agent.AgentRunnerRegistry.

--- a/tools/mcp/manager/server.py
+++ b/tools/mcp/manager/server.py
@@ -1589,7 +1589,7 @@ def workstream_submit_task(
     deduplication_mode: str = "",
     max_deduplication_passes: int = 0,
     organizational_placement_enabled: bool = False,
-    reflection_enabled: bool = False,
+    retrospective_enabled: bool = False,
     review_enabled: bool = True,
     max_review_passes: int = 0,
     post_completion_command: str = "",
@@ -1668,7 +1668,7 @@ def workstream_submit_task(
             level of the module hierarchy. Disabled by default to keep routine
             exploratory jobs cheaper. Enable for final pre-merge cleanup jobs
             where placement correctness matters.
-        reflection_enabled: When ``True``, activates the retrospective phase
+        retrospective_enabled: When ``True``, activates the retrospective phase
             after all other phases. A separate agent session analyzes the
             primary phase transcript for tool-use and context-efficiency
             improvement opportunities, emitting findings as memories. The
@@ -1736,8 +1736,8 @@ def workstream_submit_task(
             ``"deduplication"``, ``"organizational-placement"``,
             ``"enforce-changes"``, ``"maven-dependency-protection"``,
             ``"post-completion"``, ``"commit-message"``,
-            ``"git-tampering-restart"``) and whose values are
-            ``{runner, model, effort, provider}`` objects (all keys
+            ``"git-tampering-restart"``, ``"retrospective"``) and whose values
+            are ``{runner, model, effort, provider}`` objects (all keys
             optional). Each named phase overrides ``default_phase_config``
             field-by-field. Example::
 
@@ -1912,8 +1912,8 @@ def workstream_submit_task(
         payload["maxDeduplicationPasses"] = max_deduplication_passes
     if organizational_placement_enabled:
         payload["enforceOrganizationalPlacement"] = True
-    if reflection_enabled:
-        payload["reflectionEnabled"] = True
+    if retrospective_enabled:
+        payload["retrospectiveEnabled"] = True
     if not review_enabled:
         payload["reviewEnabled"] = False
     if max_review_passes > 0:

--- a/tools/mcp/manager/test_server.py
+++ b/tools/mcp/manager/test_server.py
@@ -665,6 +665,38 @@ class TestWorkstreamSubmitTask(unittest.TestCase):
         self.assertIs(payload["reviewEnabled"], False)
 
     @patch.object(server, "_controller_post")
+    def test_submit_retrospective_enabled_omitted_by_default(self, mock_post):
+        """retrospective_enabled is opt-in (default false), so the wire payload
+        must omit retrospectiveEnabled when the caller did not pass it."""
+        _grant_all_scopes()
+        mock_post.return_value = {"ok": True, "jobId": "job-rt1"}
+        server.workstream_submit_task(prompt="Task")
+        payload = mock_post.call_args[0][1]
+        self.assertNotIn("retrospectiveEnabled", payload)
+
+    @patch.object(server, "_controller_post")
+    def test_submit_retrospective_enabled_true_forwarded(self, mock_post):
+        """retrospective_enabled=True must reach the controller as
+        retrospectiveEnabled=True so the controller can opt the job into the
+        retrospective phase."""
+        _grant_all_scopes()
+        mock_post.return_value = {"ok": True, "jobId": "job-rt2"}
+        server.workstream_submit_task(prompt="Task", retrospective_enabled=True)
+        payload = mock_post.call_args[0][1]
+        self.assertIs(payload["retrospectiveEnabled"], True)
+
+    @patch.object(server, "_controller_post")
+    def test_submit_retrospective_enabled_false_omitted(self, mock_post):
+        """retrospective_enabled=False is the default; the wire payload must
+        omit the key rather than forward an explicit false (matches the
+        organizational_placement_enabled behaviour)."""
+        _grant_all_scopes()
+        mock_post.return_value = {"ok": True, "jobId": "job-rt3"}
+        server.workstream_submit_task(prompt="Task", retrospective_enabled=False)
+        payload = mock_post.call_args[0][1]
+        self.assertNotIn("retrospectiveEnabled", payload)
+
+    @patch.object(server, "_controller_post")
     def test_submit_preserves_job_id_in_next_steps(self, mock_post):
         _grant_all_scopes()
         mock_post.return_value = {


### PR DESCRIPTION
The RETROSPECTIVE phase is implemented and deployed (Phase.RETROSPECTIVE enum, CodingAgentJob.runReflectionPhase, CodingAgentJobFactory flag, wire serialization) but was unreachable: a partial reflection_enabled stub on workstream_submit_task forwarded to payload["reflectionEnabled"] and the controller never read it, the activation flag on the factory used the mismatched "reflection" name, and _KNOWN_PHASE_WIRE_NAMES did not list "retrospective" so phase_configs={"retrospective": {...}} was rejected.

Mirror the organizational_placement_enabled wiring exactly:

- Rename reflection_enabled/reflectionEnabled -> retrospective_enabled/ retrospectiveEnabled end-to-end (MCP param, payload key, factory field and accessors, job field and accessors, doWork gate, codec wire key, factory decode switch) so the submission name matches the RETROSPECTIVE phase enum. Telemetry fields (reflectionRan, reflectionCostUsd, etc.) are internal and stay as-is.
- Add the controller line in FlowTreeApiEndpoint that reads retrospectiveEnabled from the request body and calls factory.setRetrospectiveEnabled(...), plus echo it back in the /api/submit response (matches the organizationalPlacementEnabled echo).
- Add "retrospective" to _KNOWN_PHASE_WIRE_NAMES in phase_config.py so phase_configs={"retrospective": {...}} is accepted client-side.
- Update the phase_configs docstring in server.py to list "retrospective" as a valid per-phase override target.

Tests:
- CodingAgentJobRetrospectiveTest: rename all reflectionEnabled references to retrospectiveEnabled; add retrospectivePhaseSkippedWhenRetrospectiveEnabledFalse to prove the negative path of the orchestrator gate (the existing retrospectivePhaseIsOutsideEnforcementRuleLoop covers the positive path).
- McpToolDiscoveryTest: assert retrospective_enabled is declared in the workstream_submit_task signature.
- test_server.py: three Python tests mirroring the review_enabled pattern (omitted by default, True forwarded, False omitted).
- phase_config.py: test_all_known_phases_accepted (existing) now also covers "retrospective" automatically.

Verified: 110 + 31 + 90 = 231 Java tests pass across the touched suites; 47 TestWorkstreamSubmitTask tests pass including the 3 new ones; 498 Python tests pass overall; build validator clean on all 4 checks (checkstyle, code_policy, test_timeouts, duplicate_code).