### PR TITLE
Fix silent opencode sessions: disable OAuth on bearer-bound MCP entries

### DIFF
--- a/flowtree/agents/src/main/java/io/flowtree/jobs/agent/OpencodeConfigBuilder.java
+++ b/flowtree/agents/src/main/java/io/flowtree/jobs/agent/OpencodeConfigBuilder.java
@@ -391,8 +391,14 @@ final class OpencodeConfigBuilder {
                     // Code's behaviour for the same MCP config and giving
                     // ``send_message`` the temp token it needs to resolve
                     // the workstream/job context automatically.
-                    if (headers.has("Authorization")
-                            || headers.has("authorization")) {
+                    boolean hasAuthorization = false;
+                    for (Iterator<String> names = headers.fieldNames(); names.hasNext(); ) {
+                        if ("authorization".equalsIgnoreCase(names.next())) {
+                            hasAuthorization = true;
+                            break;
+                        }
+                    }
+                    if (hasAuthorization) {
                         dst.put("oauth", false);
                     }
                 }

--- a/flowtree/agents/src/main/java/io/flowtree/jobs/agent/OpencodeConfigBuilder.java
+++ b/flowtree/agents/src/main/java/io/flowtree/jobs/agent/OpencodeConfigBuilder.java
@@ -333,6 +333,13 @@ final class OpencodeConfigBuilder {
      * for stdio servers. The exact field names are evolving; the translation
      * is isolated here so it can be adjusted in one place.</p>
      *
+     * <p>Remote entries that carry an {@code Authorization} header are emitted
+     * with {@code oauth: false} so opencode's MCP client does not attach an
+     * {@code McpOAuthProvider} and trigger Dynamic Client Registration on the
+     * first 401 — see the inline comment in this method for the bug this
+     * prevents (silent {@code send_message} failures in opencode primary
+     * phases).</p>
+     *
      * @param mcpConfigJson the orchestrator-built JSON (may be null/empty)
      * @return an object node ready to embed under the top-level {@code mcp} key;
      *         empty when no servers were declared
@@ -366,6 +373,28 @@ final class OpencodeConfigBuilder {
                 JsonNode headers = spec.get("headers");
                 if (headers != null && headers.isObject()) {
                     dst.set("headers", headers.deepCopy());
+                    // When the orchestrator pre-supplies an Authorization
+                    // header (as ar-manager does with its HMAC temp token),
+                    // disable opencode's OAuth auto-discovery for this
+                    // entry. Without ``oauth: false`` opencode attaches an
+                    // McpOAuthProvider to the transport, sees ar-manager's
+                    // 401 ``WWW-Authenticate: Bearer ...`` advertising the
+                    // RFC 9728 protected-resource metadata, and initiates a
+                    // DCR/OAuth flow that ar-manager does not host. The
+                    // pre-supplied bearer is then never sent on tool calls,
+                    // ``_decode_current_request_token_full`` returns
+                    // ``no_auth_header``/``non_bearer_scheme``, and the
+                    // first ``send_message`` call fails with
+                    // ``workstream_id is required (pass explicitly or use a
+                    // job token)``. Disabling OAuth here forces opencode to
+                    // use the static bearer verbatim — matching Claude
+                    // Code's behaviour for the same MCP config and giving
+                    // ``send_message`` the temp token it needs to resolve
+                    // the workstream/job context automatically.
+                    if (headers.has("Authorization")
+                            || headers.has("authorization")) {
+                        dst.put("oauth", false);
+                    }
                 }
             } else {
                 dst.put("type", "local");

--- a/flowtree/agents/src/test/java/io/flowtree/jobs/agent/OpencodeConfigBuilderTest.java
+++ b/flowtree/agents/src/test/java/io/flowtree/jobs/agent/OpencodeConfigBuilderTest.java
@@ -141,6 +141,81 @@ public class OpencodeConfigBuilderTest extends TestSuiteBase {
         assertTrue(manager.path("enabled").asBoolean());
     }
 
+    /**
+     * Regression test for the silent-{@code send_message} bug on opencode
+     * primary phases: a remote MCP entry that carries a pre-supplied
+     * {@code Authorization} header must be emitted with {@code oauth: false}
+     * so opencode's MCP client uses the bearer verbatim instead of attaching
+     * an {@code McpOAuthProvider} and triggering Dynamic Client Registration.
+     *
+     * <p>The failure mode this prevents: ar-manager returns 401 with
+     * {@code WWW-Authenticate: Bearer ...} (RFC 9728), opencode's auth
+     * provider starts an OAuth flow that ar-manager does not host, the
+     * connection enters {@code needs_auth}, and every subsequent tool call
+     * (including the agent's very first {@code send_message}) lacks the temp
+     * token — so {@code _decode_current_request_token_full} returns an empty
+     * workstream and {@code send_message} fails with
+     * {@code "workstream_id is required (pass explicitly or use a job
+     * token)"}.</p>
+     *
+     * <p>The case-insensitive header check covers the lowercase form too,
+     * since RFC 7235 declares the header name case-insensitive and a proxy
+     * may normalise it.</p>
+     */
+    @Test(timeout = 5000)
+    public void translateMcpServersDisablesOauthWhenAuthorizationHeaderPresent() {
+        OpencodeConfigBuilder b = new OpencodeConfigBuilder(new HashMap<String, String>()::get);
+        ObjectNode mcp = b.translateMcpServers(MCP_INPUT);
+        JsonNode manager = mcp.get("ar-manager");
+        assertNotNull(manager);
+        assertTrue("remote entry with Authorization header must declare oauth: false "
+                        + "so opencode skips OAuth auto-discovery and uses the bearer verbatim",
+                manager.has("oauth"));
+        assertFalse("oauth must be the boolean literal false, not an OAuth config object",
+                manager.path("oauth").asBoolean(true));
+    }
+
+    /**
+     * The {@code oauth: false} guard fires for the lowercase ``authorization``
+     * header as well — RFC 7235 declares the header name case-insensitive and
+     * an intermediate proxy may normalise it.
+     */
+    @Test(timeout = 5000)
+    public void translateMcpServersDisablesOauthForLowercaseAuthorizationHeader() {
+        String input = "{"
+                + "\"mcpServers\":{"
+                + "\"ar-manager\":{\"type\":\"http\",\"url\":\"http://localhost:7780\","
+                + "\"headers\":{\"authorization\":\"Bearer abc\"}}"
+                + "}}";
+        OpencodeConfigBuilder b = new OpencodeConfigBuilder(new HashMap<String, String>()::get);
+        ObjectNode mcp = b.translateMcpServers(input);
+        JsonNode manager = mcp.get("ar-manager");
+        assertNotNull(manager);
+        assertTrue(manager.has("oauth"));
+        assertFalse(manager.path("oauth").asBoolean(true));
+    }
+
+    /**
+     * Remote MCP entries without any pre-supplied {@code Authorization} header
+     * must NOT have {@code oauth: false} forced on them — these are real
+     * OAuth-capable servers (Sentry, Linear, etc.) where opencode's
+     * auto-discovery is the only way for a user to authenticate. Forcing
+     * {@code oauth: false} here would break those servers.
+     */
+    @Test(timeout = 5000)
+    public void translateMcpServersKeepsOauthEnabledForServersWithoutAuthorizationHeader() {
+        String input = "{"
+                + "\"mcpServers\":{"
+                + "\"sentry-mcp\":{\"type\":\"http\",\"url\":\"https://mcp.sentry.dev/mcp\"}"
+                + "}}";
+        OpencodeConfigBuilder b = new OpencodeConfigBuilder(new HashMap<String, String>()::get);
+        ObjectNode mcp = b.translateMcpServers(input);
+        JsonNode sentry = mcp.get("sentry-mcp");
+        assertNotNull(sentry);
+        assertFalse("server without Authorization header must not have oauth forced off",
+                sentry.has("oauth"));
+    }
+
     /** Stdio MCP servers become opencode {@code type=local} entries with a flattened command list. */
     @Test(timeout = 5000)
     public void translateMcpServersHandlesStdioEntries() {
@@ -226,6 +301,16 @@ public class OpencodeConfigBuilderTest extends TestSuiteBase {
         assertNull(root.path("provider").path("local").path("options").get("apiKey"));
         assertTrue(root.path("provider").path("local").path("models").has("custom-model"));
         assertTrue(root.path("mcp").has("ar-manager"));
+        // The Bearer-bearing ar-manager entry must arrive at opencode with
+        // ``oauth: false`` — see the inline comment in
+        // OpencodeConfigBuilder.translateMcpServers for the silent-agent bug
+        // this guard prevents.
+        JsonNode managerEntry = root.path("mcp").path("ar-manager");
+        assertTrue("ar-manager entry must declare oauth field",
+                managerEntry.has("oauth"));
+        assertFalse("ar-manager entry must declare oauth=false so opencode "
+                        + "uses the supplied bearer instead of attempting DCR",
+                managerEntry.path("oauth").asBoolean(true));
         assertEquals("allow", root.path("permission").path("tools").path("Read").asText());
         assertEquals("allow", root.path("permission").path("mcp").path("ar-manager").asText());
         // external_directory is always granted in the full build so headless

--- a/flowtree/runtime/src/main/java/io/flowtree/jobs/McpToolDiscovery.java
+++ b/flowtree/runtime/src/main/java/io/flowtree/jobs/McpToolDiscovery.java
@@ -136,6 +136,37 @@ public class McpToolDiscovery {
     }
 
     /**
+     * Reports whether the given parameter of the named tool has a default value
+     * in its Python function signature — i.e. whether the parameter is
+     * <em>optional</em> from the MCP client's perspective.
+     *
+     * <p>FastMCP derives the JSON schema {@code required} list from parameters
+     * that have no default. A parameter declared as
+     * {@code workstream_id: str = ""} is optional and will not appear in the
+     * schema's {@code required} list; one declared as
+     * {@code workstream_id: str} (no default) is required. This helper lets
+     * the discovery tests assert the policy intent — "this parameter is
+     * intentionally optional" — without having to embed the full FastMCP
+     * runtime in the build.</p>
+     *
+     * <p>Returns {@code false} when the file does not exist, the tool is not
+     * found, or the parameter is not declared in the signature.</p>
+     *
+     * @param serverFile path to the Python server source file
+     * @param toolName   the tool function name to inspect
+     * @param paramName  the parameter name to check
+     * @return {@code true} when the parameter declares a default value,
+     *         {@code false} otherwise
+     */
+    public static boolean isOptionalToolParameter(Path serverFile,
+                                                  String toolName,
+                                                  String paramName) {
+        List<String> lines = readLines(serverFile);
+        if (lines.isEmpty()) return false;
+        return discoverParameterHasDefault(lines, toolName, paramName);
+    }
+
+    /**
      * Reads all UTF-8 lines from the given Python server source file.
      *
      * @param serverFile path to the file; may be {@code null}
@@ -330,5 +361,59 @@ public class McpToolDiscovery {
         }
 
         return params;
+    }
+
+    /**
+     * Reports whether the given parameter of the named tool declares a default
+     * value in its Python function signature.
+     *
+     * <p>A parameter with a default — for example
+     * {@code workstream_id: str = ""} on a multi-line signature, or
+     * {@code limit: int = 10} on a single-line signature — is optional from
+     * FastMCP's perspective (it will not appear in the generated schema's
+     * {@code required} list). A parameter without a default is required.</p>
+     *
+     * @param lines     all lines of the server source file
+     * @param toolName  the tool function name to inspect
+     * @param paramName the parameter name to check
+     * @return {@code true} when the parameter is declared with {@code = ...}
+     *         in the signature, {@code false} otherwise
+     */
+    private static boolean discoverParameterHasDefault(List<String> lines,
+                                                       String toolName,
+                                                       String paramName) {
+        Pattern funcDefStart = Pattern.compile("def\\s+" + Pattern.quote(toolName) + "\\s*\\(");
+        // TODO(review): [^=,]+ stops at any comma, so parameterized generics like
+        // Dict[str, str] or Tuple[int, str] in the type annotation cause a false
+        // "required" result even when a default is present. Fix with bracket-depth
+        // awareness when this helper is extended beyond simple str/int annotations.
+        Pattern paramLine = Pattern.compile(
+            "^\\s+" + Pattern.quote(paramName) + "\\s*:\\s*[^=,]+=\\s*\\S");
+        Pattern inlineParamWithDefault = Pattern.compile(
+            "(?:^|[\\s,(])" + Pattern.quote(paramName)
+                + "\\s*:\\s*[^=,]+=\\s*\\S");
+
+        for (int i = 0; i < lines.size(); i++) {
+            String defLine = lines.get(i);
+            if (!funcDefStart.matcher(defLine).find()) continue;
+
+            int openParen = defLine.indexOf('(');
+            int closeParen = defLine.lastIndexOf(')');
+            if (openParen >= 0 && closeParen > openParen) {
+                // Single-line signature.
+                String paramSection = defLine.substring(openParen + 1, closeParen);
+                return inlineParamWithDefault.matcher(paramSection).find();
+            }
+            // Multi-line signature.
+            for (int j = i + 1; j < lines.size(); j++) {
+                String trimmed = lines.get(j).trim();
+                if (trimmed.startsWith(") ->") || trimmed.startsWith("):")) break;
+                if (paramLine.matcher(lines.get(j)).find()) {
+                    return true;
+                }
+            }
+            return false;
+        }
+        return false;
     }
 }

--- a/flowtree/runtime/src/test/java/io/flowtree/jobs/McpToolDiscoveryTest.java
+++ b/flowtree/runtime/src/test/java/io/flowtree/jobs/McpToolDiscoveryTest.java
@@ -543,6 +543,32 @@ public class McpToolDiscoveryTest extends TestSuiteBase {
 			sendMessageParams.contains("text"));
 		assertTrue("send_message must declare activity in signature",
 			sendMessageParams.contains("activity"));
+		assertTrue("send_message must declare workstream_id in signature so the"
+				+ " parameter is part of the MCP schema and operator-side callers"
+				+ " can still override the token-derived value",
+			sendMessageParams.contains("workstream_id"));
+		assertTrue("send_message must declare job_id in signature for the same"
+				+ " operator-override reason",
+			sendMessageParams.contains("job_id"));
+		// workstream_id and job_id must be OPTIONAL on send_message so a
+		// job-scoped agent call with only {text, activity} succeeds — the
+		// in-flight request's HMAC temp token then supplies the workstream
+		// and job automatically. The retrospective opencode/MiniMax failure
+		// (silent agent after a first send_message returning
+		// "workstream_id is required ...") is prevented from regressing by
+		// keeping these parameters defaulted in the function signature.
+		assertTrue("send_message workstream_id must be optional (default value"
+				+ " present) so job-scoped agents can call with only {text, activity}",
+			McpToolDiscovery.isOptionalToolParameter(
+				serverFile, "send_message", "workstream_id"));
+		assertTrue("send_message job_id must be optional (default value"
+				+ " present) so job-scoped agents do not have to supply it",
+			McpToolDiscovery.isOptionalToolParameter(
+				serverFile, "send_message", "job_id"));
+		assertTrue("send_message activity must be optional (default value"
+				+ " present) — primary-phase calls omit it",
+			McpToolDiscovery.isOptionalToolParameter(
+				serverFile, "send_message", "activity"));
 
 		List<String> workstreamContextParams =
 			McpToolDiscovery.discoverToolParameters(serverFile, "workstream_context");
@@ -641,5 +667,81 @@ public class McpToolDiscoveryTest extends TestSuiteBase {
 			updateParams.contains("required_labels"));
 		assertTrue("workstream_update_config must declare dependent_repos parameter",
 			updateParams.contains("dependent_repos"));
+	}
+
+	/**
+	 * Unit test for {@link McpToolDiscovery#isOptionalToolParameter}: a
+	 * multi-line signature must report {@code true} for parameters declared
+	 * with a default value and {@code false} for parameters without one.
+	 * This is the helper that the {@code send_message} optionality assertion
+	 * above relies on, so a regression in the regex would otherwise silently
+	 * weaken that test.
+	 */
+	@Test(timeout = 30000)
+	public void isOptionalToolParameterIdentifiesDefaultsInMultiLineSignature() throws IOException {
+		Path tempFile = Files.createTempFile("mcp_optional_", ".py");
+		try {
+			Files.writeString(tempFile, String.join("\n",
+				"from mcp.server.fastmcp import FastMCP",
+				"mcp = FastMCP(\"test\")",
+				"",
+				"@mcp.tool()",
+				"def example_tool(",
+				"    required_text: str,",
+				"    workstream_id: str = \"\",",
+				"    activity: str = \"\",",
+				"    limit: int = 10,",
+				") -> dict:",
+				"    return {}",
+				""), StandardCharsets.UTF_8);
+
+			assertFalse("required_text has no default — must be required",
+				McpToolDiscovery.isOptionalToolParameter(
+					tempFile, "example_tool", "required_text"));
+			assertTrue("workstream_id defaults to empty string — must be optional",
+				McpToolDiscovery.isOptionalToolParameter(
+					tempFile, "example_tool", "workstream_id"));
+			assertTrue("activity defaults to empty string — must be optional",
+				McpToolDiscovery.isOptionalToolParameter(
+					tempFile, "example_tool", "activity"));
+			assertTrue("limit defaults to 10 — must be optional",
+				McpToolDiscovery.isOptionalToolParameter(
+					tempFile, "example_tool", "limit"));
+			assertFalse("missing parameter must return false",
+				McpToolDiscovery.isOptionalToolParameter(
+					tempFile, "example_tool", "does_not_exist"));
+		} finally {
+			Files.deleteIfExists(tempFile);
+		}
+	}
+
+	/**
+	 * Single-line signatures are equally supported by
+	 * {@link McpToolDiscovery#isOptionalToolParameter} — some MCP servers
+	 * use a compact one-line form for tools with few parameters and the
+	 * discovery helper must not silently treat them as required.
+	 */
+	@Test(timeout = 30000)
+	public void isOptionalToolParameterIdentifiesDefaultsInSingleLineSignature() throws IOException {
+		Path tempFile = Files.createTempFile("mcp_optional_inline_", ".py");
+		try {
+			Files.writeString(tempFile, String.join("\n",
+				"from mcp.server.fastmcp import FastMCP",
+				"mcp = FastMCP(\"test\")",
+				"",
+				"@mcp.tool()",
+				"def inline_tool(name: str, namespace: str = \"default\") -> dict:",
+				"    return {}",
+				""), StandardCharsets.UTF_8);
+
+			assertFalse("name has no default — must be required",
+				McpToolDiscovery.isOptionalToolParameter(
+					tempFile, "inline_tool", "name"));
+			assertTrue("namespace defaults to \"default\" — must be optional",
+				McpToolDiscovery.isOptionalToolParameter(
+					tempFile, "inline_tool", "namespace"));
+		} finally {
+			Files.deleteIfExists(tempFile);
+		}
 	}
 }

--- a/tools/mcp/manager/server.py
+++ b/tools/mcp/manager/server.py
@@ -3279,6 +3279,13 @@ def _resolve_branch_context(
 ) -> tuple[str, str, Optional[dict]]:
     """Resolve repo_url and branch from workstream_id if needed.
 
+    When neither ``workstream_id`` nor ``repo_url`` is supplied, falls back
+    to the workstream identified by the in-flight request's HMAC temp token
+    (see :func:`_get_token_workstream_id`). This lets job-scoped callers
+    (Claude Code / opencode agents) invoke branch-aware tools like
+    :func:`memory_store` with only the content payload — the workstream the
+    job is bound to is inferred from the bearer.
+
     Args:
         workstream_id: Workstream to look up repo/branch from.
         repo_url: Explicit repository URL.
@@ -3303,8 +3310,16 @@ def _resolve_branch_context(
         repo_url = repo_url or ws.get("repoUrl", "")
         branch = branch or ws.get("defaultBranch", "")
 
-    if not repo_url and not require_branch:
-        # Try to resolve repo from the token's workstream context
+    # Token-context fallback: when neither the workstream_id arg nor an
+    # explicit repo_url was provided, try the workstream bound to the
+    # in-flight request's HMAC temp token. This used to fire only for
+    # ``require_branch=False`` callers; extending it to the strict
+    # ``require_branch=True`` path means job-scoped tools like
+    # :func:`memory_store` can be called with just the content payload —
+    # the workstream the job runs on supplies the repo/branch automatically
+    # via the temp token's payload. Explicit ``workstream_id`` /
+    # ``repo_url`` arguments still win when provided (override path).
+    if not repo_url and not workstream_id:
         token_ws_id = _get_token_workstream_id()
         if token_ws_id:
             ws = _find_workstream(token_ws_id)
@@ -3321,12 +3336,17 @@ def _resolve_branch_context(
         if require_branch:
             next_steps = [
                 "Provide repo_url and branch directly, or",
-                "Provide workstream_id to resolve them from the workstream config",
+                "Provide workstream_id to resolve them from the workstream config, or",
+                "Call from a job session whose HMAC token resolves to a"
+                " registered workstream",
             ]
         else:
             next_steps = [
                 "Provide repo_url directly, or",
-                "Provide workstream_id to resolve the repo URL from the workstream config",
+                "Provide workstream_id to resolve the repo URL from the"
+                " workstream config, or",
+                "Call from a job session whose HMAC token resolves to a"
+                " registered workstream",
             ]
         return ("", "", {
             "ok": False,
@@ -3863,8 +3883,11 @@ def memory_store(
 ) -> dict:
     """Store a memory from an external client.
 
-    Either workstream_id or (repo_url + branch) is required to identify
-    the branch context for the memory.
+    Either ``workstream_id`` or (``repo_url`` + ``branch``) is required to
+    identify the branch context for the memory.  When neither is supplied,
+    the workstream bound to the in-flight request's HMAC temp token is
+    used — so a job-scoped agent call with only ``content`` succeeds and
+    stores the memory against the job's workstream branch automatically.
 
     Args:
         content: The text content to store.
@@ -3945,12 +3968,26 @@ def send_message(
     report status updates, results, or errors back to the user who
     initiated this task.
 
+    ``workstream_id`` and ``job_id`` are both optional. In a job session
+    (Claude Code or opencode launched by the controller) the in-flight
+    request's HMAC temp token already binds the call to a specific
+    workstream and job, and both are derived from the bearer
+    automatically — so a call with just ``{text, activity}`` posts to the
+    correct workstream thread. Explicit values, when supplied, override
+    the token-derived ones (the override path is preserved for
+    operator/admin callers that hold a static bearer with no
+    workstream binding).
+
     Args:
         text: The message text to send.
         workstream_id: Workstream to send the message to.  Defaults to
-            the workstream from the auth token when available.
+            the workstream resolved from the in-flight request's HMAC
+            temp token.  Only required when no resolvable token context
+            exists (e.g. a static-token admin call).
         job_id: Job to thread the message under.  Defaults to the job
-            from the auth token when available.
+            resolved from the in-flight request's HMAC temp token.  When
+            absent the message lands at the top of the workstream's
+            channel rather than inside a job thread.
         activity: Optional tag identifying the phase or activity this
             message belongs to (e.g. ``"deduplication"``,
             ``"organizational_placement"``,
@@ -4033,7 +4070,21 @@ def send_message(
             effective_activity or "")
 
     if not effective_ws:
-        return {"ok": False, "error": "workstream_id is required (pass explicitly or use a job token)"}
+        return {
+            "ok": False,
+            "error": (
+                "workstream_id could not be resolved. Pass workstream_id"
+                " explicitly, or call from a job session whose HMAC"
+                " temp token resolves to a registered workstream."
+            ),
+            "next_steps": [
+                "Use workstream_list to find the workstream ID and pass"
+                " workstream_id=<id>",
+                "If calling from a job session, verify the bearer token"
+                " is an armt_tmp_ HMAC token (a static admin bearer"
+                " carries no workstream binding)",
+            ],
+        }
 
     if effective_activity:
         err = _check_length(effective_activity, "activity", MAX_SHORT_STRING_LEN)

--- a/tools/mcp/manager/test_server.py
+++ b/tools/mcp/manager/test_server.py
@@ -2592,8 +2592,48 @@ class TestMemoryStore(unittest.TestCase):
 
     def test_requires_branch_context(self):
         _grant_all_scopes()
-        result = server.memory_store(content="test")
+        # Make sure no leftover thread-local / ContextVar / per-request
+        # bearer survives from another test class — otherwise the new
+        # token fallback in _resolve_branch_context would resolve here.
+        server._set_token_context("", "")
+        server._request_workstream_id.set(None)
+        server._request_job_id.set(None)
+        with patch.object(server.mcp, "get_context",
+                          side_effect=LookupError("no active request")):
+            result = server.memory_store(content="test")
         self.assertFalse(result["ok"])
+
+    @patch.object(server, "_find_workstream")
+    @patch.object(server, "_get_memory_client")
+    def test_store_resolves_repo_branch_from_token_workstream(
+            self, mock_client_fn, mock_find_ws):
+        """Regression: memory_store with only ``content`` and a valid token
+        context must resolve repo_url and branch from the workstream the
+        temp token is bound to. This mirrors the
+        :func:`send_message` fix — job-scoped tools should accept a minimal
+        payload because the workstream is already implicit in the bearer."""
+        _grant_all_scopes()
+        # Simulate the auth middleware having decoded a temp token bound to
+        # workstream ``ws-token``.
+        server._set_token_context("ws-token", "job-token")
+        mock_find_ws.return_value = {
+            "workstreamId": "ws-token",
+            "repoUrl": "https://github.com/org/repo",
+            "defaultBranch": "feature/x",
+        }
+        client = MagicMock()
+        client.store.return_value = {"id": "auto-resolved"}
+        mock_client_fn.return_value = client
+
+        # No workstream_id, no repo_url, no branch — only content.
+        result = server.memory_store(content="Note from a job session")
+        self.assertTrue(result["ok"], msg=result.get("error"))
+        call_kwargs = client.store.call_args[1]
+        self.assertEqual(call_kwargs["repo_url"],
+                         "https://github.com/org/repo")
+        self.assertEqual(call_kwargs["branch"], "feature/x")
+        # Clean up to avoid leaking state into sibling tests.
+        server._set_token_context("", "")
 
     def test_rejects_oversized_content(self):
         _grant_all_scopes()
@@ -2875,6 +2915,162 @@ class TestPerRequestTokenDecoding(unittest.TestCase):
         self.assertIn("/api/workstreams/ws-A/jobs/job-7/messages",
                       called_path)
         self.assertNotIn("ws-STALE", called_path)
+
+
+# -----------------------------------------------------------------------
+# send_message workstream_id is optional when a temp token resolves it
+# -----------------------------------------------------------------------
+
+
+class TestSendMessageWorkstreamIdOptional(unittest.TestCase):
+    """Regression tests for the silent-opencode fix: ``send_message`` must
+    accept a call with only ``{text, activity}`` when the in-flight request's
+    HMAC temp token resolves to a workstream and job. The reported failure
+    mode was the agent's very first ``send_message`` call returning
+    ``"workstream_id is required ..."`` and the agent then giving up on
+    operator status updates for the entire session. The fix ensures that
+    token-based resolution is the default path; the explicit
+    ``workstream_id`` argument remains an operator-side override.
+    """
+
+    def setUp(self):
+        # Clear any leftover ContextVar / thread-local state so the
+        # resolution paths are tested in isolation. The base behaviour
+        # of opencode primary-phase jobs is "no prior state on the
+        # server-task" since the streamable-HTTP transport is stateless.
+        server._request_workstream_id.set(None)
+        server._request_job_id.set(None)
+        if hasattr(server._thread_local, "workstream_id"):
+            del server._thread_local.workstream_id
+        if hasattr(server._thread_local, "job_id"):
+            del server._thread_local.job_id
+
+    def tearDown(self):
+        server._request_workstream_id.set(None)
+        server._request_job_id.set(None)
+        if hasattr(server._thread_local, "workstream_id"):
+            del server._thread_local.workstream_id
+        if hasattr(server._thread_local, "job_id"):
+            del server._thread_local.job_id
+
+    @staticmethod
+    def _fake_context_with_bearer(token_value):
+        """Build a stand-in MCP context whose request carries ``token_value``
+        as its Bearer header — the same shape as a real opencode/Claude
+        Code stateless-HTTP request."""
+        headers = {}
+        if token_value is not None:
+            headers["authorization"] = "Bearer " + token_value
+        fake_request = MagicMock()
+        fake_request.headers = headers
+        fake_request_context = MagicMock()
+        fake_request_context.request = fake_request
+        fake_ctx = MagicMock()
+        fake_ctx.request_context = fake_request_context
+        return fake_ctx
+
+    @patch.object(server, "SHARED_SECRET", "test-secret")
+    @patch.object(server, "_controller_post")
+    def test_resolves_workstream_from_temp_token_with_only_text(self, mock_post):
+        """The headline regression: a job session's ``send_message`` call with
+        only ``text`` (no workstream_id, no job_id) must succeed and post to
+        the workstream/job the temp token resolves to.
+        """
+        _grant_all_scopes()
+        token = server._mint_temp_token("ws-A", "job-7", ttl_seconds=60)
+        mock_post.return_value = {"ok": True}
+        with patch.object(server.mcp, "get_context",
+                          return_value=self._fake_context_with_bearer(token)):
+            result = server.send_message(text="Hello from opencode")
+        self.assertTrue(result["ok"], msg=result.get("error"))
+        mock_post.assert_called_once()
+        called_path = mock_post.call_args[0][0]
+        self.assertIn("/api/workstreams/ws-A/jobs/job-7/messages",
+                      called_path)
+
+    @patch.object(server, "SHARED_SECRET", "test-secret")
+    @patch.object(server, "_controller_post")
+    def test_text_and_activity_only_resolves_via_token(self, mock_post):
+        """A call with ``{text, activity}`` only — the exact shape an
+        opencode agent emits during its first status update — must succeed
+        when the bearer is a valid temp token."""
+        _grant_all_scopes()
+        token = server._mint_temp_token("ws-B", "job-9", ttl_seconds=60)
+        mock_post.return_value = {"ok": True}
+        with patch.object(server.mcp, "get_context",
+                          return_value=self._fake_context_with_bearer(token)):
+            result = server.send_message(
+                text="Starting work", activity="primary")
+        self.assertTrue(result["ok"], msg=result.get("error"))
+        body = mock_post.call_args[0][1]
+        self.assertEqual(body["text"], "Starting work")
+        self.assertEqual(body["activity"], "primary")
+        called_path = mock_post.call_args[0][0]
+        self.assertIn("ws-B", called_path)
+        self.assertIn("job-9", called_path)
+
+    @patch.object(server, "SHARED_SECRET", "test-secret")
+    @patch.object(server, "_controller_post")
+    def test_explicit_workstream_id_overrides_token(self, mock_post):
+        """The override path: an explicit workstream_id still wins when
+        supplied, even if the bearer resolves to a different workstream.
+        This preserves the operator-side ability to route messages
+        deliberately."""
+        _grant_all_scopes()
+        token = server._mint_temp_token("ws-TOKEN", "job-TOKEN", ttl_seconds=60)
+        mock_post.return_value = {"ok": True}
+        with patch.object(server.mcp, "get_context",
+                          return_value=self._fake_context_with_bearer(token)):
+            result = server.send_message(
+                text="Routed elsewhere", workstream_id="ws-OVERRIDE")
+        self.assertTrue(result["ok"], msg=result.get("error"))
+        called_path = mock_post.call_args[0][0]
+        self.assertIn("ws-OVERRIDE", called_path)
+        self.assertNotIn("ws-TOKEN", called_path)
+
+    @patch.object(server, "SHARED_SECRET", "test-secret")
+    @patch.object(server, "_controller_post")
+    def test_falls_back_to_thread_local_when_token_decode_fails(
+            self, mock_post):
+        """When the per-request bearer decode finds nothing (e.g. a static
+        admin token on the wire), the legacy ContextVar/thread-local set by
+        the auth middleware is still consulted. This keeps in-process tests
+        and stdio-transport callers working."""
+        _grant_all_scopes()
+        server._set_token_context("ws-LOCAL", "job-LOCAL")
+        mock_post.return_value = {"ok": True}
+        # No request context → per-request decode returns ``no_context``;
+        # the call must still resolve via the thread-local fallback.
+        with patch.object(server.mcp, "get_context",
+                          side_effect=LookupError("no active request")):
+            result = server.send_message(text="Fallback path")
+        self.assertTrue(result["ok"], msg=result.get("error"))
+        called_path = mock_post.call_args[0][0]
+        self.assertIn("ws-LOCAL", called_path)
+        self.assertIn("job-LOCAL", called_path)
+
+    @patch.object(server, "_controller_post")
+    def test_genuinely_unresolvable_call_returns_clear_error(self, mock_post):
+        """When there is no explicit workstream_id, no resolvable bearer,
+        and no ContextVar/thread-local context, the call must error with a
+        message that names both the override path and the token path so
+        the caller can fix the missing context. This is the genuinely-
+        unresolvable case — not the common opencode failure mode the
+        token-fallback fix addresses."""
+        _grant_all_scopes()
+        # Explicitly clear any leftover state so this is truly unresolvable.
+        server._set_token_context("", "")
+        # No MCP context at all (the typical out-of-request test path).
+        with patch.object(server.mcp, "get_context",
+                          side_effect=LookupError("no active request")):
+            result = server.send_message(text="Nowhere to go")
+        self.assertFalse(result["ok"])
+        self.assertIn("workstream_id", result["error"])
+        # The new error message names both the explicit arg and the token
+        # path so the caller knows the two ways to provide context.
+        self.assertIn("token", result["error"].lower())
+        # No POST attempted — the call short-circuits at validation.
+        mock_post.assert_not_called()
 
 
 # -----------------------------------------------------------------------


### PR DESCRIPTION
Opencode-driven primary phases were producing zero operator-facing status updates because the agent's very first send_message call failed with "workstream_id is required (pass explicitly or use a job token)" and the agent then gave up on comms for the rest of the session.

Root cause: opencode's MCP HTTP client (packages/opencode/src/mcp/index.ts) attaches an McpOAuthProvider to every remote entry unless oauth is set to false. When ar-manager returns 401 with WWW-Authenticate: Bearer ... advertising the RFC 9728 protected-resource metadata, opencode initiates Dynamic Client Registration / OAuth flow that ar-manager does not host. The pre-supplied Authorization header from the orchestrator's MCP config is then never sent on tool calls, so send_message's per-request bearer decode returns no_auth_header and the workstream/job context cannot be resolved from the temp token.

Fix:
- OpencodeConfigBuilder.translateMcpServers now emits oauth: false on remote MCP entries that carry an Authorization header, so opencode uses the static bearer verbatim and never starts an OAuth flow. Servers without a pre-supplied Authorization header (Sentry, Linear, etc.) keep opencode's auto-discovery — only the bearer path is opted out.
- send_message error message now names both the explicit-arg path and the token path so a genuinely-unresolvable call points at both fixes.
- Docstring on send_message now states workstream_id and job_id are optional in a job session (token resolves them automatically); the explicit args are the operator-side override.
- _resolve_branch_context now falls back to the token-bound workstream whenever neither workstream_id nor repo_url was supplied (previously only for require_branch=False callers). memory_store, memory_recall, and workstream_context all benefit — a job-scoped agent can call memory_store(content=...) and have repo/branch resolved from the temp token automatically.
- McpToolDiscovery exposes a new isOptionalToolParameter helper used by McpToolDiscoveryTest to assert that workstream_id, job_id, and activity remain optional on send_message (with a unit test covering both multi-line and single-line signature parsing).

Tests added:
- OpencodeConfigBuilderTest covers the new oauth: false guard for Authorization-bearing entries, the lowercase header form, and the no-Authorization servers that must keep opencode's auto-discovery. The end-to-end buildConfigJsonIncludesAllSections test now asserts the field appears in the assembled config too.
- Python TestSendMessageWorkstreamIdOptional covers the headline regression (text-only call resolves via temp token, override path, thread-local fallback, and the genuinely-unresolvable error case).
- Python TestMemoryStore covers the new token-resolved repo/branch path for branch-aware tools.