### PR TITLE
Seed upstream Maven artifacts before first ar-test-runner invocation

### DIFF
--- a/.claude/hooks/lib/mvn_build_check.py
+++ b/.claude/hooks/lib/mvn_build_check.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Decide whether a bash tool call is an "is the build clean?" mvn invocation.
+
+This module is the single source of truth for the soft steer that
+nudges agents toward ``ar-build-validator`` for build-cleanliness
+checks. It is invoked by:
+
+  - .opencode/plugins/warn-mvn-build.ts (opencode, via argv)
+
+The Claude hook ``.claude/hooks/mvn-artifact-staleness.py`` already
+emits a richer staleness report for any artifact-producing Maven
+goal; this module is the opencode-side counterpart that produces a
+short, output-mutation-friendly steer instead. Both hooks coexist:
+the Claude staleness report stays as a full table injected as
+``additionalContext``; this short note is what opencode appends to
+the bash output stream after the command runs.
+
+Two CLI entry points, mirroring ``mvn_test_check.py``:
+
+  python3 mvn_build_check.py <command>
+      Used by the .ts adapter. Returns the Decision as a JSON object
+      on stdout, exit 0 always. The .ts adapter does the
+      harness-native rendering (append-to-output on warn).
+
+  python3 mvn_build_check.py --stdin
+      Reserved for a future Claude-Code shell adapter if one is
+      ever needed. Reads a Claude-Code-style hook payload from
+      stdin and renders the steer (no-op for now; the existing
+      staleness hook already covers Claude).
+
+The Decision shape (always JSON):
+
+    {
+      "action":  "warn" | "allow",
+      "reason":  "str",   # unused (we never block here)
+      "context": "str",   # injected into the model's next turn on warn
+      "stderr":  "str",   # printed to stderr for the human
+    }
+
+The intent of the steer is light-touch: it never blocks, never
+modifies command flags, and never interferes with valid uses of
+``mvn install -DskipTests`` (e.g., dependency seeding, packaging
+for downstream consumers, CI setup). It only reminds the agent
+that the structured ``ar-build-validator`` MCP tool is a better
+fit than ``mvn -q | tail`` for "is the build clean?" checks.
+"""
+
+import json
+import re
+import shlex
+import sys
+
+
+# Maven lifecycle goals that produce / install / compile artifacts.
+# This list mirrors ``mvn-artifact-staleness.py``'s ``ARTIFACT_GOALS``.
+ARTIFACT_GOALS = frozenset({
+    "compile",
+    "test-compile",
+    "testCompile",
+    "process-classes",
+    "process-test-classes",
+    "package",
+    "verify",
+    "install",
+    "deploy",
+})
+
+
+# Tokens that name a Maven launcher. ``./mvnw`` and ``mvnw`` are
+# treated the same as ``mvn``.
+MVN_TOKENS = frozenset({"mvn", "mvnw", "./mvnw", "mvn.cmd"})
+
+
+WARN_NOTE = (
+    "This invocation runs an artifact-producing Maven goal "
+    "({goals}). For a structured \"is the build clean?\" check, prefer "
+    "the ar-build-validator MCP tool — it returns per-check pass/fail "
+    "and structured violation counts, instead of free-form log tail.\n\n"
+    "  mcp__ar-build-validator__start_validation\n"
+    "    checks: [\"checkstyle\"]               # fastest: no build at all\n"
+    "    # OR omit checks for the default suite (checkstyle, code_policy,\n"
+    "    # test_timeouts, duplicate_code), which runs `mvn install "
+    "-DskipTests` once and then each check.\n\n"
+    "Use `skip_build: true` when the project is already compiled and "
+    "you only changed source files. Bare `mvn install`/`mvn compile` is "
+    "fine when you genuinely need to seed local artifacts or build "
+    "downstream artifacts — this note is informational only and does "
+    "not block the command."
+)
+
+
+def _detect_artifact_goals_in_tokens(tokens):
+    """Return artifact goals found in a token list (one shell segment)."""
+    if not tokens:
+        return set()
+    has_mvn = any(
+        t in MVN_TOKENS or t.endswith("/mvn") or t.endswith("/mvnw")
+        for t in tokens
+    )
+    if not has_mvn:
+        return set()
+    return {t for t in tokens if t in ARTIFACT_GOALS}
+
+
+def detect_artifact_goals(command):
+    """Return the set of artifact-producing Maven goals in ``command``.
+
+    The command is split into shell segments using a conservative
+    splitter so chained commands like ``npm install && mvn install``
+    correctly attribute the ``install`` goal to the ``mvn`` segment
+    rather than the ``npm`` one. Each segment is tokenised with
+    :mod:`shlex`; segments that fail to parse are split on whitespace
+    as a fallback (the original ``mvn-artifact-staleness.py``
+    behaviour).
+    """
+    if not command:
+        return set()
+    found = set()
+    for segment in re.split(r"(?:\|\||&&|[;&|\n])", command):
+        try:
+            tokens = shlex.split(segment)
+        except ValueError:
+            tokens = segment.split()
+        found.update(_detect_artifact_goals_in_tokens(tokens))
+    return found
+
+
+def decide(command):
+    """Return a Decision dict for a command string.
+
+    A non-empty set of artifact goals produces ``action="warn"`` with
+    the steer message in ``context`` and ``stderr``. Anything else
+    produces ``action="allow"`` with empty fields.
+
+    The function is intentionally pure: same input, same output.
+    """
+    goals = detect_artifact_goals(command or "")
+    if not goals:
+        return {"action": "allow", "reason": "", "context": "", "stderr": ""}
+
+    note = WARN_NOTE.format(goals=", ".join(sorted(goals)))
+    return {
+        "action": "warn",
+        "reason": "",
+        "context": note,
+        "stderr": note,
+    }
+
+
+# --------------------------------------------------------------------- #
+# CLI entry points
+# --------------------------------------------------------------------- #
+
+
+def _read_stdin_command():
+    """Read a Claude-Code-style hook payload from stdin."""
+    raw = sys.stdin.read()
+    try:
+        payload = json.loads(raw)
+    except Exception:
+        return ""
+    return (payload.get("tool_input", {}) or {}).get("command", "") or ""
+
+
+def _render_harness_native(decision):
+    """Render a Decision in the Claude Code hook contract.
+
+    Always exits 0 — this hook never blocks. On warn, emits both the
+    stderr banner (for the human) and a ``hookSpecificOutput`` JSON
+    block on stdout (for the model's next turn).
+    """
+    action = decision.get("action")
+    context = decision.get("context", "") or ""
+    stderr_msg = decision.get("stderr", "") or ""
+
+    if action == "warn":
+        if stderr_msg:
+            sys.stderr.write(stderr_msg + "\n")
+        print(json.dumps({
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "additionalContext": context,
+            }
+        }))
+        sys.exit(0)
+
+    sys.exit(0)
+
+
+def main(argv=None):
+    argv = list(sys.argv[1:] if argv is None else argv)
+    if argv and argv[0] == "--stdin":
+        command = _read_stdin_command()
+        _render_harness_native(decide(command))
+        return
+
+    if not argv:
+        sys.stderr.write("usage: mvn_build_check.py <command> | --stdin\n")
+        sys.exit(2)
+
+    command = argv[0]
+    print(json.dumps(decide(command)))
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/lib/test_mvn_build_check.py
+++ b/.claude/hooks/lib/test_mvn_build_check.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Unit tests for mvn_build_check.py.
+
+Covers:
+  - decide() returns warn for every artifact-producing goal we care about
+  - decide() returns warn for a goal still surfaces when -DskipTests
+    is present (the steer is informational, the agent may still be
+    seeding deps legitimately)
+  - decide() returns allow for non-Maven commands and for Maven
+    invocations that don't trigger an artifact goal
+  - chained commands attribute goals to the correct segment
+  - the CLI argv mode emits a Decision JSON on stdout
+
+Run from the repo root::
+
+    python3 -m unittest .claude/hooks/lib/test_mvn_build_check.py -v
+"""
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import unittest
+
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+CORE_PATH = os.path.join(HERE, "mvn_build_check.py")
+
+
+def _load_core():
+    spec = importlib.util.spec_from_file_location("mvn_build_check", CORE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class DecideFunctionTests(unittest.TestCase):
+    """``decide(command)`` shape contract."""
+
+    def setUp(self):
+        self.core = _load_core()
+
+    def test_empty_command_is_allow(self):
+        d = self.core.decide("")
+        self.assertEqual("allow", d["action"])
+        self.assertEqual("", d["context"])
+
+    def test_whitespace_command_is_allow(self):
+        d = self.core.decide("   \t  ")
+        self.assertEqual("allow", d["action"])
+
+    def test_mvn_install_warns(self):
+        d = self.core.decide("mvn install")
+        self.assertEqual("warn", d["action"])
+        self.assertIn("ar-build-validator", d["context"])
+        self.assertIn("install", d["context"])
+
+    def test_mvn_compile_warns(self):
+        d = self.core.decide("mvn compile")
+        self.assertEqual("warn", d["action"])
+        self.assertIn("compile", d["context"])
+
+    def test_mvn_package_warns(self):
+        d = self.core.decide("mvn package")
+        self.assertEqual("warn", d["action"])
+        self.assertIn("package", d["context"])
+
+    def test_mvn_install_with_skip_tests_still_warns(self):
+        # We DO warn here, but the steer text explicitly says this is
+        # informational and does not block — the agent is allowed to
+        # proceed when seeding deps is the intent.
+        d = self.core.decide("mvn install -DskipTests")
+        self.assertEqual("warn", d["action"])
+        self.assertIn("ar-build-validator", d["context"])
+        self.assertIn("does not block", d["context"])
+
+    def test_mvn_install_with_pl_and_am_warns(self):
+        # The seed pattern emitted by ar-test-runner's preflight is
+        # `mvn -pl <m> -am install -DskipTests -B`. We warn on it too,
+        # but the agent's preflight runs out-of-band (it's the MCP
+        # tool's own subprocess, not a bash tool call), so this only
+        # affects bash invocations the agent issues directly.
+        d = self.core.decide(
+            "mvn -pl engine/utils -am install -DskipTests -B")
+        self.assertEqual("warn", d["action"])
+
+    def test_mvn_test_alone_is_allow(self):
+        # `test` is NOT in ARTIFACT_GOALS — it's handled by the
+        # block-mvn-test-direct hook, not this one. Avoid double-warn.
+        d = self.core.decide("mvn test")
+        self.assertEqual("allow", d["action"])
+
+    def test_mvn_version_is_allow(self):
+        d = self.core.decide("mvn -version")
+        self.assertEqual("allow", d["action"])
+
+    def test_mvn_help_is_allow(self):
+        d = self.core.decide("mvn help:effective-pom")
+        self.assertEqual("allow", d["action"])
+
+    def test_non_mvn_command_is_allow(self):
+        d = self.core.decide("ls -la")
+        self.assertEqual("allow", d["action"])
+
+    def test_echo_with_mvn_install_is_allow(self):
+        # `echo "mvn install"` does not invoke mvn.
+        d = self.core.decide('echo "mvn install"')
+        self.assertEqual("allow", d["action"])
+
+    def test_chained_mvn_install_after_npm_install_attributes_to_mvn(self):
+        # `npm install` should NOT trigger the warn (no mvn in that
+        # segment). The second segment has `mvn install`, which does.
+        d = self.core.decide("npm install && mvn install -DskipTests")
+        self.assertEqual("warn", d["action"])
+
+    def test_chained_npm_install_alone_is_allow(self):
+        d = self.core.decide("npm install && echo done")
+        self.assertEqual("allow", d["action"])
+
+    def test_mvnw_install_warns(self):
+        # The wrapper script counts as mvn for steering purposes.
+        d = self.core.decide("./mvnw install -DskipTests")
+        self.assertEqual("warn", d["action"])
+
+    def test_unparseable_quoting_falls_back_to_whitespace_split(self):
+        # An unbalanced quote forces shlex to raise; the fallback
+        # splitter should still detect a real mvn install.
+        d = self.core.decide('mvn install "unterminated')
+        self.assertEqual("warn", d["action"])
+
+
+class DetectGoalsTests(unittest.TestCase):
+    """``detect_artifact_goals(command)`` returns the right goals."""
+
+    def setUp(self):
+        self.core = _load_core()
+
+    def test_returns_empty_for_non_mvn(self):
+        self.assertEqual(set(), self.core.detect_artifact_goals("ls"))
+
+    def test_returns_install_goal(self):
+        self.assertEqual({"install"},
+                         self.core.detect_artifact_goals("mvn install"))
+
+    def test_returns_compile_and_package(self):
+        self.assertEqual(
+            {"compile", "package"},
+            self.core.detect_artifact_goals("mvn compile package -X"),
+        )
+
+    def test_clean_alone_is_not_artifact_producing(self):
+        # `clean` removes artifacts; it doesn't produce them. The
+        # steer does NOT fire for a pure clean invocation.
+        self.assertEqual(set(),
+                         self.core.detect_artifact_goals("mvn clean"))
+
+    def test_clean_install_returns_install(self):
+        self.assertEqual({"install"},
+                         self.core.detect_artifact_goals("mvn clean install"))
+
+
+class CliEntryPointTests(unittest.TestCase):
+    """``mvn_build_check.py <command>`` writes the Decision JSON to stdout."""
+
+    def setUp(self):
+        self.core = _load_core()
+
+    def _run_argv(self, command):
+        result = subprocess.run(
+            [sys.executable, CORE_PATH, command],
+            capture_output=True, text=True, check=False)
+        return result
+
+    def test_argv_warn_emits_json(self):
+        result = self._run_argv("mvn install")
+        self.assertEqual(0, result.returncode)
+        d = json.loads(result.stdout)
+        self.assertEqual("warn", d["action"])
+        self.assertIn("ar-build-validator", d["context"])
+
+    def test_argv_allow_emits_json(self):
+        result = self._run_argv("ls")
+        self.assertEqual(0, result.returncode)
+        d = json.loads(result.stdout)
+        self.assertEqual("allow", d["action"])
+        self.assertEqual("", d["context"])
+
+    def test_argv_handles_complex_quoting(self):
+        result = self._run_argv("mvn install -DskipTests -Dxx='hi'")
+        self.assertEqual(0, result.returncode)
+        d = json.loads(result.stdout)
+        self.assertEqual("warn", d["action"])
+
+    def test_no_argv_exits_with_error(self):
+        result = subprocess.run(
+            [sys.executable, CORE_PATH], capture_output=True, text=True)
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("usage:", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -52,6 +52,7 @@
     "./plugins/block-mvn-test-direct.ts",
     "./plugins/block-git-commit.ts",
     "./plugins/block-git-worktree.ts",
-    "./plugins/warn-git-log.ts"
+    "./plugins/warn-git-log.ts",
+    "./plugins/warn-mvn-build.ts"
   ]
 }

--- a/.opencode/plugins/__tests__/warn-mvn-build.smoke.cjs
+++ b/.opencode/plugins/__tests__/warn-mvn-build.smoke.cjs
@@ -1,0 +1,101 @@
+// .opencode/plugins/__tests__/warn-mvn-build.smoke.cjs
+//
+// Plain-Node smoke test for the warn-mvn-build opencode adapter wiring.
+// Exercises the Python shared core (mvn_build_check.py) via the same
+// argv path the .ts plugin uses and verifies the input-shape
+// expectations the .ts plugin relies on. The .ts plugin itself is
+// loaded by opencode via Bun at startup and is verified at that point.
+//
+// Run from the repo root:
+//   node .opencode/plugins/__tests__/warn-mvn-build.smoke.cjs
+
+const { spawnSync } = require("node:child_process")
+const path = require("node:path")
+const fs = require("node:fs")
+
+const HERE = __dirname
+const CORE = path.resolve(HERE, "..", "..", "..", ".claude", "hooks", "lib", "mvn_build_check.py")
+
+if (!fs.existsSync(CORE)) {
+  console.error("shared core not found at", CORE)
+  process.exit(2)
+}
+
+let failures = 0
+function expect(cond, msg) {
+  if (!cond) {
+    console.error("  FAIL:", msg)
+    failures++
+  }
+}
+
+function callCore(command) {
+  const r = spawnSync("python3", [CORE, command], { encoding: "utf-8", timeout: 5000 })
+  if (r.status !== 0) {
+    return { action: "allow", reason: "", context: "", stderr: `core exit ${r.status}` }
+  }
+  try {
+    return JSON.parse(r.stdout)
+  } catch {
+    return { action: "allow", reason: "", context: "", stderr: "core returned non-JSON" }
+  }
+}
+
+console.log("== tool.execute.after: warn path for bare 'mvn install' ==")
+{
+  const d = callCore("mvn install")
+  expect(d.action === "warn", "mvn install → warn")
+  expect(d.context.includes("ar-build-validator"), "warn context steers toward ar-build-validator")
+  expect(d.context.includes("does not block"), "warn note clarifies that the command is not blocked")
+}
+
+console.log("== tool.execute.after: warn path for 'mvn install -DskipTests' (the preflight seed pattern) ==")
+{
+  const d = callCore("mvn install -DskipTests")
+  // We DO warn here even with -DskipTests — the steer is informational
+  // and explicitly tells the agent this does not block the command.
+  // Legitimate dependency-seeding invocations still run exactly as
+  // written; the model just sees a small note in the bash output.
+  expect(d.action === "warn", "mvn install -DskipTests → warn (informational only)")
+  expect(d.context.includes("ar-build-validator"), "skipTests path still mentions ar-build-validator")
+}
+
+console.log("== tool.execute.after: warn path for ar-test-runner-style preflight seed ==")
+{
+  const d = callCore("mvn -pl engine/utils -am install -DskipTests -B")
+  expect(d.action === "warn", "preflight seed pattern → warn")
+}
+
+console.log("== tool.execute.after: allow path for 'mvn test' ==")
+{
+  // `mvn test` is the responsibility of block-mvn-test-direct, not
+  // this hook. We must not double-warn — and `test` is not in the
+  // artifact goals list, so the steer correctly stays silent.
+  const d = callCore("mvn test")
+  expect(d.action === "allow", "mvn test → allow (handled by block-mvn-test-direct)")
+}
+
+console.log("== tool.execute.after: allow path for non-mvn commands ==")
+{
+  expect(callCore("ls -la").action === "allow", "ls → allow")
+  expect(callCore("git status").action === "allow", "git status → allow")
+  expect(callCore("npm install").action === "allow", "npm install → allow (no mvn token)")
+}
+
+console.log("== tool.execute.after: chained-command attribution ==")
+{
+  const d = callCore("npm install && mvn install")
+  expect(d.action === "warn", "second segment 'mvn install' → warn even after npm install")
+}
+
+console.log("== Core is fault-tolerant on bad input ==")
+{
+  expect(callCore("").action === "allow", "empty → allow")
+  expect(callCore("   ").action === "allow", "whitespace → allow")
+}
+
+if (failures > 0) {
+  console.error(`\n${failures} assertion(s) failed`)
+  process.exit(1)
+}
+console.log("\nAll warn-mvn-build adapter wiring assertions passed.")

--- a/.opencode/plugins/__tests__/warn-mvn-build.test.ts
+++ b/.opencode/plugins/__tests__/warn-mvn-build.test.ts
@@ -1,0 +1,187 @@
+// .opencode/plugins/__tests__/warn-mvn-build.test.ts
+//
+// Self-contained test for the warn-mvn-build opencode adapter. We
+// don't launch opencode itself — we just exercise the plugin's
+// handlers directly with synthetic input/output, after first calling
+// the plugin factory.
+//
+// Run with:
+//   bun test .opencode/plugins/__tests__/warn-mvn-build.test.ts
+//   # or
+//   npx tsx .opencode/plugins/__tests__/warn-mvn-build.test.ts
+//
+// Requires Python 3 on PATH (the plugin shells out to the shared core).
+
+import { spawnSync } from "node:child_process"
+import * as path from "node:path"
+import { fileURLToPath, pathToFileURL } from "node:url"
+import * as fs from "node:fs"
+
+const HERE = path.dirname(fileURLToPath(import.meta.url))
+const PLUGIN_PATH = path.resolve(HERE, "..", "warn-mvn-build.ts")
+const PYTHON_HERE = path.resolve(HERE, "..", "..", "..", ".claude", "hooks", "lib")
+const PYTHON_CORE = path.join(PYTHON_HERE, "mvn_build_check.py")
+
+if (!fs.existsSync(PYTHON_CORE)) {
+  throw new Error(`shared core not found at ${PYTHON_CORE}`)
+}
+const py = spawnSync("python3", [PYTHON_CORE, "mvn install"], { encoding: "utf-8" })
+if (py.status !== 0) {
+  throw new Error(`python3 not usable: status=${py.status} stderr=${py.stderr}`)
+}
+
+type Hooks = {
+  "tool.execute.before"?: (
+    input: { tool: string; sessionID: string; callID: string },
+    output: { args: unknown },
+  ) => Promise<void>
+  "tool.execute.after"?: (
+    input: { tool: string; sessionID: string; callID: string; args: unknown },
+    output: { title: string; output: string; metadata: unknown },
+  ) => Promise<void>
+}
+type PluginFactory = (input?: unknown) => Promise<Hooks>
+
+async function loadPlugin(): Promise<PluginFactory> {
+  const mod = (await import(pathToFileURL(PLUGIN_PATH).href)) as { WarnMvnBuildPlugin: PluginFactory }
+  return mod.WarnMvnBuildPlugin
+}
+
+const sessionID = "test-session"
+let nextCallID = 0
+function callID(): string {
+  nextCallID += 1
+  return `test-call-${nextCallID}`
+}
+
+let failures = 0
+function expect(cond: unknown, msg: string): void {
+  if (!cond) {
+    console.error(`  FAIL: ${msg}`)
+    failures++
+  }
+}
+
+async function run(): Promise<void> {
+  const factory = await loadPlugin()
+  const hooks = await factory()
+
+  // -- tool.execute.before ---------------------------------------------------
+
+  // 1. `mvn install` must NOT throw (this hook only warns).
+  {
+    const before = hooks["tool.execute.before"]!
+    let threw: Error | null = null
+    try {
+      await before({ tool: "bash", sessionID, callID: callID() }, { args: { command: "mvn install" } })
+    } catch (e) {
+      threw = e as Error
+    }
+    expect(threw === null, "warn hook must NEVER throw on a warn-worthy command")
+  }
+
+  // 2. `mvn -version` is allow; .before is a no-op.
+  {
+    const before = hooks["tool.execute.before"]!
+    let threw: Error | null = null
+    try {
+      await before({ tool: "bash", sessionID, callID: callID() }, { args: { command: "mvn -version" } })
+    } catch (e) {
+      threw = e as Error
+    }
+    expect(threw === null, "mvn -version must NOT throw")
+  }
+
+  // 3. Non-bash tools must be ignored entirely.
+  {
+    const before = hooks["tool.execute.before"]!
+    let threw: Error | null = null
+    try {
+      await before({ tool: "read", sessionID, callID: callID() }, { args: { filePath: "/etc/passwd" } })
+    } catch (e) {
+      threw = e as Error
+    }
+    expect(threw === null, "non-bash tool should be a no-op")
+  }
+
+  // -- tool.execute.after ----------------------------------------------------
+
+  // 4. `mvn install` triggers warn → context appended.
+  {
+    const before = hooks["tool.execute.before"]!
+    const after = hooks["tool.execute.after"]!
+    const id = callID()
+    await before({ tool: "bash", sessionID, callID: id }, { args: { command: "mvn install" } })
+    const out = { title: "bash", output: "(real mvn output here)", metadata: {} }
+    await after({ tool: "bash", sessionID, callID: id, args: { command: "mvn install" } }, out)
+    expect(out.output.includes("[ar-hooks/warn-mvn-build]"), "warn path should append the [ar-hooks/warn-mvn-build] prefix")
+    expect(out.output.includes("ar-build-validator"), "warn note should steer toward ar-build-validator")
+    expect(out.output.includes("does not block"), "warn note should clarify it does not block the command")
+    expect(out.output.startsWith("(real mvn output here)"), "original output must be preserved")
+  }
+
+  // 5. `mvn install -DskipTests` ALSO warns (informational only).
+  {
+    const before = hooks["tool.execute.before"]!
+    const after = hooks["tool.execute.after"]!
+    const id = callID()
+    await before({ tool: "bash", sessionID, callID: id }, { args: { command: "mvn install -DskipTests" } })
+    const out = { title: "bash", output: "BUILD SUCCESS", metadata: {} }
+    await after({ tool: "bash", sessionID, callID: id, args: { command: "mvn install -DskipTests" } }, out)
+    expect(out.output.includes("ar-build-validator"), "skipTests path still mentions ar-build-validator")
+    expect(out.output.startsWith("BUILD SUCCESS"), "original output preserved on warn for skipTests")
+  }
+
+  // 6. `mvn test` is allow (block-mvn-test-direct handles it).
+  {
+    const before = hooks["tool.execute.before"]!
+    const after = hooks["tool.execute.after"]!
+    const id = callID()
+    await before({ tool: "bash", sessionID, callID: id }, { args: { command: "mvn test" } })
+    const out = { title: "bash", output: "original", metadata: {} }
+    await after({ tool: "bash", sessionID, callID: id, args: { command: "mvn test" } }, out)
+    expect(out.output === "original", "mvn test → allow → output unchanged")
+  }
+
+  // 7. Non-mvn commands are allow.
+  {
+    const before = hooks["tool.execute.before"]!
+    const after = hooks["tool.execute.after"]!
+    const id = callID()
+    await before({ tool: "bash", sessionID, callID: id }, { args: { command: "ls -la" } })
+    const out = { title: "bash", output: "original", metadata: {} }
+    await after({ tool: "bash", sessionID, callID: id, args: { command: "ls -la" } }, out)
+    expect(out.output === "original", "ls -la → allow → output unchanged")
+  }
+
+  // 8. Non-bash tools are a no-op for .after too.
+  {
+    const after = hooks["tool.execute.after"]!
+    const out = { title: "read", output: "original", metadata: {} }
+    await after({ tool: "read", sessionID, callID: callID(), args: { filePath: "/etc/passwd" } }, out)
+    expect(out.output === "original", "non-bash tool should be a no-op for .after")
+  }
+
+  // 9. Cache miss in .after should still work (the slow path).
+  {
+    const after = hooks["tool.execute.after"]!
+    const out = { title: "bash", output: "BUILD SUCCESS", metadata: {} }
+    // Use a callID that .before was never called with.
+    await after(
+      { tool: "bash", sessionID, callID: "never-seen-before", args: { command: "mvn install" } },
+      out,
+    )
+    expect(out.output.includes("ar-build-validator"), "cache-miss slow path should still produce the warn note")
+  }
+
+  if (failures > 0) {
+    console.error(`\n${failures} assertion(s) failed`)
+    process.exit(1)
+  }
+  console.log("All warn-mvn-build plugin adapter assertions passed.")
+}
+
+run().catch((e) => {
+  console.error("test runner crashed:", e)
+  process.exit(1)
+})

--- a/.opencode/plugins/warn-mvn-build.ts
+++ b/.opencode/plugins/warn-mvn-build.ts
@@ -1,0 +1,160 @@
+// .opencode/plugins/warn-mvn-build.ts
+//
+// opencode adapter for the "soft steer toward ar-build-validator"
+// policy on artifact-producing Maven invocations (`mvn install`,
+// `mvn compile`, `mvn package`, ...).
+//
+// The decision logic lives in the shared core
+//   .claude/hooks/lib/mvn_build_check.py
+// which is the single source of truth. This plugin is the opencode
+// counterpart to the Claude staleness hook
+// (.claude/hooks/mvn-artifact-staleness.py): both fire when an mvn
+// invocation will (re-)build artifacts, but they render the steer
+// differently for their host harness.
+//
+// Behavior:
+//   - never throws (this is a warn hook, not a block hook)
+//   - on "warn" the steer text is appended to the bash tool output
+//     so the model sees it alongside the actual command result
+//   - on "allow" the output is left exactly as the bash tool
+//     produced it (no observable side effect on the agent)
+//
+// False-positive safety: the steer never modifies command flags
+// and never blocks. `mvn install -DskipTests` invocations used for
+// dependency seeding (e.g., to set up the local Maven repository
+// before a downstream tool runs) still execute exactly as written
+// and produce their normal output; the steer just appends a note
+// reminding the agent that `ar-build-validator` exists for the
+// "is the build clean?" case.
+//
+// Performance: same callID cache pattern as block-mvn-test-direct.ts
+// so the python3 subprocess runs at most once per bash tool call.
+//
+// See docs/plans/OPENCODE_HOOKS.md for the architecture.
+
+import type { Plugin } from "@opencode-ai/plugin"
+import { spawnSync } from "node:child_process"
+import * as path from "node:path"
+import { fileURLToPath } from "node:url"
+
+// The shared core. Resolved relative to this file so the plugin works
+// regardless of the cwd opencode was launched from.
+const HERE = path.dirname(fileURLToPath(import.meta.url))
+const CORE = path.resolve(
+  HERE,
+  "..",
+  "..",
+  ".claude",
+  "hooks",
+  "lib",
+  "mvn_build_check.py",
+)
+
+interface Decision {
+  action: "warn" | "allow"
+  reason: string
+  context: string
+  stderr: string
+}
+
+// Module-level callID → Decision cache. Same shape as block-mvn-test-direct.ts;
+// see that file for the rationale.
+const decisionCache = new Map<string, Decision>()
+
+/**
+ * Call the shared core. Returns a Decision object. On any internal
+ * error (Python missing, core crashed, bad JSON), returns an "allow"
+ * Decision so a hook malfunction can never affect legitimate work.
+ */
+function callCore(command: string): Decision {
+  const result = spawnSync("python3", [CORE, command], {
+    encoding: "utf-8",
+    timeout: 5_000,
+  })
+
+  if (result.error) {
+    return { action: "allow", reason: "", context: "", stderr: `core spawn failed: ${result.error.message}` }
+  }
+  if (result.status !== 0) {
+    return { action: "allow", reason: "", context: "", stderr: `core exited ${result.status}: ${result.stderr}` }
+  }
+
+  try {
+    return JSON.parse(result.stdout) as Decision
+  } catch (e) {
+    return { action: "allow", reason: "", context: "", stderr: `core returned non-JSON: ${String(e)}` }
+  }
+}
+
+/**
+ * Best-effort logging. If logging fails for any reason we just
+ * swallow it — a logging failure must never affect the policy
+ * decision.
+ */
+function logDecision(decision: Decision): void {
+  if (!decision.stderr) return
+  // eslint-disable-next-line no-console
+  console.error(`[ar-hooks/warn-mvn-build] ${decision.stderr.trim()}`)
+}
+
+/**
+ * Extract the bash command from a `bash` tool's args object.
+ * Returns an empty string when ``command`` is missing — the core
+ * treats that as "allow".
+ */
+function extractBashCommand(args: unknown): string {
+  if (!args || typeof args !== "object") return ""
+  const obj = args as { command?: unknown }
+  return typeof obj.command === "string" ? obj.command : ""
+}
+
+export const WarnMvnBuildPlugin: Plugin = async () => {
+  return {
+    "tool.execute.before": async (input, output) => {
+      if (input.tool !== "bash") return
+
+      const command = extractBashCommand(output.args)
+      if (!command) return
+
+      const decision = callCore(command)
+      // Populate the cache so .after for the same callID can re-use
+      // the Decision without a second subprocess spawn.
+      decisionCache.set(input.callID, decision)
+      logDecision(decision)
+
+      // This hook never blocks. The warn case is rendered in .after
+      // so the model sees the note alongside the actual mvn output.
+    },
+
+    "tool.execute.after": async (input, output) => {
+      if (input.tool !== "bash") return
+
+      const cached = decisionCache.get(input.callID)
+      if (cached !== undefined) {
+        // Fast path: .before ran for this callID and we have its
+        // Decision cached. Consume-and-delete so the Map doesn't
+        // grow without bound.
+        decisionCache.delete(input.callID)
+        if (cached.action === "warn") {
+          const note = cached.context || cached.stderr
+          if (note) {
+            output.output = `${output.output}\n\n[ar-hooks/warn-mvn-build] ${note}`
+          }
+        }
+        return
+      }
+
+      // Slow path: no cache entry. Re-run the core to stay correct.
+      const command = extractBashCommand(input.args)
+      if (!command) return
+
+      const decision = callCore(command)
+      if (decision.action === "warn") {
+        const note = decision.context || decision.stderr
+        if (note) {
+          output.output = `${output.output}\n\n[ar-hooks/warn-mvn-build] ${note}`
+        }
+      }
+    },
+  }
+}

--- a/docs/plans/OPENCODE_HOOKS.md
+++ b/docs/plans/OPENCODE_HOOKS.md
@@ -669,6 +669,16 @@ for the PoC. Captured here so they don't get lost.
 
 ## 7. Changelog
 
+- 2026-06-04: Added `.opencode/plugins/warn-mvn-build.ts` + shared
+  core `.claude/hooks/lib/mvn_build_check.py` to cover the
+  ar-build-validator steer that was previously Claude-only via
+  `.claude/hooks/mvn-artifact-staleness.py`. Detects artifact-producing
+  mvn goals (`install`, `compile`, `package`, …) in the bash tool's
+  `command` string and appends a soft note pointing at the
+  `ar-build-validator` MCP tool. Never blocks — the steer text
+  explicitly says so — and never modifies command flags. Closes the
+  opencode-side gap identified by the test-runner-preflight retro.
+
 - 2026-06-04: Class A migration landed. Added
   `.claude/hooks/lib/git_command_check.py` (shared core for the three
   Class A policies), 26 unit tests, and a `.opencode/plugins/_lib/command_pattern.ts`

--- a/tools/mcp/test-runner/README.md
+++ b/tools/mcp/test-runner/README.md
@@ -10,6 +10,42 @@ An MCP server for running and managing Almost Realism test executions. This serv
 - **Selective Testing**: Run specific classes or methods
 - **Result Parsing**: Parse surefire XML reports for detailed results
 - **Output Capture**: Access console output with filtering options
+- **Preflight Seeding**: On the first invocation in a fresh worktree, the
+  upstream `ar-*` module artifacts for the target Maven module are seeded
+  into `~/.m2/repository/` automatically. This avoids the previous
+  fail→install→retry cycle that pushed agents toward bash `mvn install`.
+  Subsequent invocations skip the seed (idempotent).
+
+## Preflight Seeding
+
+Maven's `mvn test -pl <module>` (without `-am`) assumes the upstream
+modules' jars are already installed in `~/.m2`. In a fresh worktree
+they aren't — the first test invocation used to fail with an
+unresolvable-dependency error, forcing the agent to drop to bash
+`mvn install` to seed them.
+
+The test runner now performs that seed itself, lazily, before the
+first test invocation. Implementation: `preflight.py`.
+
+The flow per `start_test_run`:
+
+1. Parse the target module's `pom.xml` for direct `<dependency>`
+   entries with `<groupId>org.almostrealism</groupId>`.
+2. Look for each artifact's `.jar` in `~/.m2/repository/...`.
+3. If every direct dep is already present, **skip** the seed (a few
+   milliseconds of inspection).
+4. Otherwise, run `mvn -pl <module> -am install -DskipTests -B` from
+   the project root. `-am` ensures Maven builds the entire upstream
+   reactor chain — so the next test invocation has everything it needs.
+
+The seed's stdout/stderr is captured in the run's `output.txt`
+between two `PREFLIGHT:` banners, so an agent inspecting
+`get_run_output` sees clearly what was done.
+
+When the seed itself fails (e.g., a build error in an upstream
+module), the run is marked `failed` immediately and no Maven test
+process is launched — the agent gets a fast, accurate failure
+instead of a redundant dependency-resolution error from `mvn test`.
 
 ## Installation
 

--- a/tools/mcp/test-runner/preflight.py
+++ b/tools/mcp/test-runner/preflight.py
@@ -1,0 +1,427 @@
+"""Preflight seeding of upstream module artifacts for ar-test-runner.
+
+When ar-test-runner is invoked for a module in a fresh worktree, the
+upstream ``ar-*`` artifacts referenced by that module's ``pom.xml`` may
+not yet be installed in ``~/.m2/repository/``. Maven invokes
+``mvn test -pl <module>`` without ``-am``, so it will not build the
+upstream chain — the test run fails immediately with an unresolvable
+dependency, and the agent falls back to ``bash mvn install`` to seed
+the local repo manually.
+
+This module closes that gap. It exposes two functions that
+``server.py`` calls before launching a test invocation:
+
+* :func:`find_missing_upstream_artifacts` — pure inspection: parses the
+  target module's ``pom.xml``, lists the direct ``org.almostrealism``
+  dependencies, and returns the artifacts that are not present in the
+  local Maven repository.
+
+* :func:`seed_upstream_artifacts` — when any direct ``org.almostrealism``
+  dependency is missing, runs
+  ``mvn -pl <module> -am install -DskipTests -B`` from the project root
+  so Maven builds and installs the entire upstream chain. When all
+  direct dependencies are already present in ``~/.m2``, it is a no-op
+  (idempotent).
+
+The check is intentionally lightweight: it only verifies the direct
+dependencies, not the full transitive closure. ``-am`` ensures that
+once we seed for a module, Maven walks the full reactor — so the
+direct-deps check is a sufficient "has this module's chain been
+built?" heuristic.
+
+The functions are pure with respect to the filesystem and the
+``subprocess`` call (no global state, no caching). The caller is
+responsible for serialising preflight calls if it cares about
+avoiding redundant concurrent installs.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Optional
+from xml.etree import ElementTree
+
+# All ``ar-*`` modules in this project live under this group id.
+AR_GROUP_ID = "org.almostrealism"
+
+# Default location of the user's local Maven repository.
+DEFAULT_M2_REPOSITORY = Path.home() / ".m2" / "repository"
+
+
+@dataclass
+class MissingArtifact:
+    """A direct ``org.almostrealism`` dependency that is absent from ``~/.m2``.
+
+    Fields:
+        artifact_id: The Maven ``artifactId`` (e.g. ``ar-utils``).
+        version: The Maven ``version`` resolved from the dependency
+            declaration.
+        expected_path: The absolute path where the ``.jar`` would live
+            if it had been installed. Useful for diagnostic logging.
+    """
+
+    artifact_id: str
+    version: str
+    expected_path: Path
+
+
+@dataclass
+class PreflightResult:
+    """Outcome of a single :func:`seed_upstream_artifacts` invocation.
+
+    Fields:
+        action: One of ``"skipped"`` (all artifacts already present),
+            ``"seeded"`` (mvn install ran and succeeded), or
+            ``"failed"`` (mvn install ran and exited non-zero).
+        missing: Artifacts found to be missing when the check ran.
+            When ``action == "skipped"`` this is empty.
+        command: The exact mvn command that was executed (or would
+            have been), as a list of arguments. Empty list when no
+            command was run.
+        exit_code: The mvn process exit code, or ``None`` when no
+            command was run.
+        duration_seconds: Wall-clock time of the mvn invocation
+            (``0.0`` when skipped).
+        reason: A short human-readable summary; useful for logging.
+    """
+
+    action: str
+    missing: list = field(default_factory=list)
+    command: list = field(default_factory=list)
+    exit_code: Optional[int] = None
+    duration_seconds: float = 0.0
+    reason: str = ""
+
+
+# --------------------------------------------------------------------- #
+# POM helpers
+# --------------------------------------------------------------------- #
+
+
+def _strip_ns(tag: str) -> str:
+    """Drop the XML namespace prefix from an ElementTree tag."""
+    return tag.split("}", 1)[-1] if "}" in tag else tag
+
+
+def _child_text(element, name: str) -> Optional[str]:
+    """Return the text of the first child element named ``name`` (namespace-agnostic)."""
+    for child in element:
+        if _strip_ns(child.tag) == name:
+            return (child.text or "").strip() or None
+    return None
+
+
+def _parent_element(root):
+    """Return the ``<parent>`` child of a ``<project>`` root, or ``None``."""
+    for child in root:
+        if _strip_ns(child.tag) == "parent":
+            return child
+    return None
+
+
+def read_project_version(pom_path: Path) -> Optional[str]:
+    """Resolve the project version declared in ``pom_path``.
+
+    Handles parent inheritance: if ``<version>`` is missing on the
+    module itself, looks at ``<parent><version>`` instead.
+
+    Args:
+        pom_path: Path to a ``pom.xml`` file.
+
+    Returns:
+        The version string, or ``None`` if neither the project nor
+        its parent declares one.
+    """
+    try:
+        root = ElementTree.parse(str(pom_path)).getroot()
+    except (ElementTree.ParseError, OSError):
+        return None
+    version = _child_text(root, "version")
+    if version:
+        return version
+    parent = _parent_element(root)
+    if parent is not None:
+        return _child_text(parent, "version")
+    return None
+
+
+def _dependency_elements(root) -> list:
+    """Yield each ``<dependency>`` element under ``<dependencies>``.
+
+    Only the direct module-level ``<dependencies>`` block is consulted
+    — ``<dependencyManagement>`` is intentionally ignored because it
+    declares versions, not actual dependencies of this module.
+    """
+    deps = []
+    for child in root:
+        if _strip_ns(child.tag) != "dependencies":
+            continue
+        for dep in child:
+            if _strip_ns(dep.tag) == "dependency":
+                deps.append(dep)
+    return deps
+
+
+def read_ar_dependencies(pom_path: Path,
+                         fallback_version: Optional[str] = None) -> list:
+    """Return ``(artifactId, version)`` for every direct ``org.almostrealism`` dep.
+
+    Args:
+        pom_path: Path to the module's ``pom.xml``.
+        fallback_version: Version to assume when a ``<dependency>``
+            omits ``<version>`` (Maven would normally resolve it via
+            ``<dependencyManagement>``; we treat it as the project
+            version because every internal ``ar-*`` module shares the
+            same version in this repo).
+
+    Returns:
+        A list of ``(artifactId, version)`` tuples. The list is
+        deduplicated while preserving the declaration order.
+    """
+    try:
+        root = ElementTree.parse(str(pom_path)).getroot()
+    except (ElementTree.ParseError, OSError):
+        return []
+
+    seen = set()
+    result = []
+    for dep in _dependency_elements(root):
+        group_id = _child_text(dep, "groupId")
+        if group_id != AR_GROUP_ID:
+            continue
+        artifact_id = _child_text(dep, "artifactId")
+        if not artifact_id:
+            continue
+        version = _child_text(dep, "version") or fallback_version
+        if not version:
+            continue
+        key = (artifact_id, version)
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(key)
+    return result
+
+
+# --------------------------------------------------------------------- #
+# Local Maven repository inspection
+# --------------------------------------------------------------------- #
+
+
+def _resolve_repository(repository: Optional[Path]) -> Path:
+    """Resolve a repository path, honoring the module-level default.
+
+    Looking up :data:`DEFAULT_M2_REPOSITORY` at call time (rather than
+    using it as a default argument) lets tests replace the module
+    attribute without having to thread the override through every
+    caller.
+    """
+    return DEFAULT_M2_REPOSITORY if repository is None else repository
+
+
+def artifact_jar_path(repository: Path, group_id: str, artifact_id: str,
+                       version: str) -> Path:
+    """Return the absolute path where Maven would install the artifact's jar."""
+    base = repository.joinpath(*group_id.split("."), artifact_id, version)
+    return base / f"{artifact_id}-{version}.jar"
+
+
+def find_missing_upstream_artifacts(
+        project_root: Path,
+        module: str,
+        repository: Optional[Path] = None) -> list:
+    """Return the direct ``org.almostrealism`` deps not installed in ``~/.m2``.
+
+    Args:
+        project_root: Absolute path to the project root (the directory
+            containing the reactor ``pom.xml``).
+        module: Maven module path relative to the project root
+            (e.g. ``engine/utils``, ``flowtree/runtime``).
+        repository: The local Maven repository to inspect. Defaults to
+            ``~/.m2/repository``. Tests pass a sandbox directory. When
+            ``None``, the value of :data:`DEFAULT_M2_REPOSITORY` is
+            consulted at call time, so monkey-patching the attribute
+            in tests works without threading an override through every
+            caller.
+
+    Returns:
+        A possibly-empty list of :class:`MissingArtifact`. An empty
+        list means every direct AR dependency is already installed,
+        so a preflight ``mvn install`` is not needed.
+
+        Returns an empty list when the module's pom cannot be read at
+        all — the caller can detect that case by inspecting whether
+        the path exists before calling this function. The intent is
+        that "no parseable pom" is treated as "no preflight required";
+        Maven itself will report any genuine module-resolution error
+        with a clear message when the test launches.
+    """
+    repository = _resolve_repository(repository)
+    module_pom = Path(project_root) / module / "pom.xml"
+    if not module_pom.exists():
+        return []
+
+    root_pom = Path(project_root) / "pom.xml"
+    project_version = (read_project_version(root_pom)
+                       or read_project_version(module_pom))
+    deps = read_ar_dependencies(module_pom, fallback_version=project_version)
+
+    missing = []
+    for artifact_id, version in deps:
+        jar = artifact_jar_path(repository, AR_GROUP_ID, artifact_id, version)
+        if not jar.is_file():
+            missing.append(MissingArtifact(
+                artifact_id=artifact_id,
+                version=version,
+                expected_path=jar,
+            ))
+    return missing
+
+
+# --------------------------------------------------------------------- #
+# Seeding
+# --------------------------------------------------------------------- #
+
+
+def build_seed_command(module: str) -> list:
+    """Return the Maven command used to seed a module's upstream chain.
+
+    The ``-am`` (also-make) flag tells Maven to build all reactor
+    modules that the target depends on, transitively. ``-DskipTests``
+    keeps the seed fast — we only need the jars on disk, not the
+    test suite.
+    """
+    return ["mvn", "-pl", module, "-am", "install", "-DskipTests", "-B"]
+
+
+def _run_seed_command(
+        command: list,
+        project_root: Path,
+        output_writer: Optional[Callable[[str], None]] = None,
+        runner: Optional[Callable[[list, Path, Optional[Callable[[str], None]]], int]] = None,
+) -> tuple[int, float]:
+    """Execute the seed command, capturing output through ``output_writer``.
+
+    Args:
+        command: Argument vector to launch.
+        project_root: Working directory for the subprocess.
+        output_writer: Optional callable invoked once per output chunk.
+        runner: Optional override for the subprocess driver. Used by
+            tests to avoid spawning a real Maven process.
+
+    Returns:
+        ``(exit_code, duration_seconds)``.
+    """
+    start = time.monotonic()
+    if runner is not None:
+        exit_code = runner(command, project_root, output_writer)
+    else:
+        exit_code = _default_runner(command, project_root, output_writer)
+    duration = time.monotonic() - start
+    return exit_code, duration
+
+
+def _default_runner(
+        command: list,
+        project_root: Path,
+        output_writer: Optional[Callable[[str], None]],
+) -> int:
+    """Real subprocess driver used in production.
+
+    Streams stdout (with stderr merged) to ``output_writer`` line by
+    line so a watcher reading the run's ``output.txt`` can follow the
+    seed in real time.
+    """
+    env = os.environ.copy()
+    # AR_HARDWARE_LIBS is auto-detected by the system; never inject it.
+    env.pop("AR_HARDWARE_LIBS", None)
+
+    process = subprocess.Popen(
+        command,
+        cwd=str(project_root),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        env=env,
+    )
+    try:
+        if process.stdout is not None:
+            for raw in process.stdout:
+                if output_writer is not None:
+                    try:
+                        output_writer(raw.decode("utf-8", errors="replace"))
+                    except Exception:
+                        # An output-writer failure must never break the seed.
+                        pass
+    finally:
+        process.wait()
+    return process.returncode
+
+
+def seed_upstream_artifacts(
+        project_root: Path,
+        module: str,
+        output_writer: Optional[Callable[[str], None]] = None,
+        repository: Optional[Path] = None,
+        runner: Optional[Callable[[list, Path, Optional[Callable[[str], None]]], int]] = None,
+) -> PreflightResult:
+    """Install upstream ``ar-*`` artifacts for ``module`` when any are missing.
+
+    The check-then-install sequence is:
+
+    1. Parse the module's ``pom.xml`` for direct ``org.almostrealism``
+       dependencies.
+    2. For each, look for the corresponding ``.jar`` in ``repository``.
+    3. If none are missing, return a ``"skipped"`` result without
+       launching any subprocess.
+    4. Otherwise, run ``mvn -pl <module> -am install -DskipTests -B``
+       from ``project_root``. ``-am`` ensures the entire upstream
+       chain is built and installed.
+
+    Args:
+        project_root: Project root (contains the reactor ``pom.xml``).
+        module: Module path relative to the project root.
+        output_writer: Optional callable invoked with each output
+            chunk emitted by Maven, so a caller can persist the
+            seed log alongside the test output.
+        repository: Local Maven repository to consult. Defaults to
+            :data:`DEFAULT_M2_REPOSITORY` (looked up at call time so
+            tests can monkey-patch it).
+        runner: Optional subprocess driver override; tests use this
+            to avoid actually running Maven.
+
+    Returns:
+        A :class:`PreflightResult` describing what happened.
+    """
+    project_root = Path(project_root)
+    repository = _resolve_repository(repository)
+    missing = find_missing_upstream_artifacts(project_root, module, repository)
+
+    if not missing:
+        return PreflightResult(
+            action="skipped",
+            reason="All direct org.almostrealism dependencies already installed",
+        )
+
+    command = build_seed_command(module)
+    exit_code, duration = _run_seed_command(
+        command, project_root, output_writer=output_writer, runner=runner)
+
+    action = "seeded" if exit_code == 0 else "failed"
+    if exit_code == 0:
+        reason = (f"Seeded {len(missing)} missing upstream artifact(s) "
+                  f"in {duration:.1f}s")
+    else:
+        reason = (f"mvn install exited with code {exit_code} "
+                  f"after {duration:.1f}s")
+    return PreflightResult(
+        action=action,
+        missing=missing,
+        command=command,
+        exit_code=exit_code,
+        duration_seconds=duration,
+        reason=reason,
+    )

--- a/tools/mcp/test-runner/server.py
+++ b/tools/mcp/test-runner/server.py
@@ -39,6 +39,12 @@ if _COMMON_DIR not in sys.path:
     sys.path.insert(0, _COMMON_DIR)
 from polling import block_until_terminal, resolve_block_timeout  # noqa: E402
 
+# Preflight seeding of upstream module artifacts. Lives alongside server.py
+# so the import is cheap and unambiguous regardless of where python is launched
+# from. See preflight.py for the full rationale.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import preflight  # noqa: E402
+
 # Configuration - derive project root from script location (tools/mcp/test-runner/server.py -> project root)
 PROJECT_ROOT = Path(__file__).parent.parent.parent.parent.resolve()
 RUNS_DIR = Path(__file__).parent / "runs"
@@ -117,6 +123,116 @@ class TestRunner:
     def generate_run_id(self) -> str:
         """Generate a short unique run ID."""
         return uuid.uuid4().hex[:8]
+
+    def _write_preflight_section(self, output_file: Path, header: str,
+                                  body: str = "") -> None:
+        """Write a clearly-delimited preflight section to the run's output file.
+
+        The banner mirrors the section markers used by ar-build-validator
+        so an agent scrolling through ``output.txt`` can immediately see
+        which steps are preflight vs. test execution.
+        """
+        with open(output_file, "a") as handle:
+            handle.write(f"\n{'=' * 60}\n")
+            handle.write(f"[ar-test-runner] PREFLIGHT: {header}\n")
+            handle.write(f"{'=' * 60}\n")
+            if body:
+                if not body.endswith("\n"):
+                    body = body + "\n"
+                handle.write(body)
+            handle.write("\n")
+
+    def _run_preflight(self, run_id: str, run_dir: Path,
+                       module: str) -> "preflight.PreflightResult":
+        """Run the upstream-artifact preflight and persist its output.
+
+        Returns the :class:`preflight.PreflightResult` produced by
+        :func:`preflight.seed_upstream_artifacts`. Output emitted by
+        Maven during the seed is appended to ``run_dir/output.txt`` so
+        ``get_run_output`` shows it alongside (and before) the test run
+        output.
+
+        Failures inside the preflight helper itself (for example, a
+        ``pom.xml`` that fails to parse for a reason the helper does
+        not already swallow) are reported as a synthetic ``"failed"``
+        result so the caller can short-circuit cleanly without
+        spawning Maven on a broken setup.
+        """
+        output_file = run_dir / "output.txt"
+
+        try:
+            missing = preflight.find_missing_upstream_artifacts(
+                PROJECT_ROOT, module)
+        except Exception as exc:  # noqa: BLE001
+            # TODO(review): Inspection failures short-circuit the run (action="failed") which
+            # mirrors seed failures, but the find_missing_upstream_artifacts function already
+            # returns [] on all expected filesystem errors — so this branch only fires on
+            # truly unexpected exceptions. Consider whether those should fall through (attempt
+            # the test anyway) rather than hard-fail the entire run.
+            result = preflight.PreflightResult(
+                action="failed",
+                reason=f"preflight inspection failed: {exc}",
+            )
+            self._write_preflight_section(
+                output_file,
+                "INSPECTION FAILED",
+                f"Could not determine upstream dependencies: {exc}\n"
+                "The test invocation is aborted due to this inspection error.",
+            )
+            return result
+
+        if not missing:
+            self._write_preflight_section(
+                output_file,
+                "skipped (upstream artifacts present)",
+                f"All direct org.almostrealism dependencies of {module}\n"
+                "are already installed in ~/.m2; no seed needed.",
+            )
+            return preflight.PreflightResult(
+                action="skipped",
+                reason="All direct org.almostrealism dependencies already installed",
+            )
+
+        missing_summary = ", ".join(
+            f"{m.artifact_id}:{m.version}" for m in missing[:8])
+        if len(missing) > 8:
+            missing_summary += f", ... (+{len(missing) - 8} more)"
+        self._write_preflight_section(
+            output_file,
+            f"seeding {len(missing)} upstream artifact(s)",
+            f"Missing direct dependencies for {module}: {missing_summary}\n"
+            f"Running: {' '.join(preflight.build_seed_command(module))}\n"
+            "(This makes the FIRST ar-test-runner call in a fresh worktree "
+            "self-sufficient — subsequent calls skip this step.)",
+        )
+
+        def _writer(chunk: str) -> None:
+            try:
+                with open(output_file, "a") as handle:
+                    handle.write(chunk)
+            except OSError:
+                # An output-write failure must never break the preflight.
+                pass
+
+        result = preflight.seed_upstream_artifacts(
+            PROJECT_ROOT, module, output_writer=_writer)
+
+        if result.action == "seeded":
+            self._write_preflight_section(
+                output_file,
+                f"seeded {len(result.missing)} artifact(s) in "
+                f"{result.duration_seconds:.1f}s",
+                "Test invocation will now proceed.",
+            )
+        elif result.action == "failed":
+            self._write_preflight_section(
+                output_file,
+                f"FAILED (mvn install exited {result.exit_code})",
+                "The upstream artifacts could not be installed. The test "
+                "invocation is skipped because Maven would fail with the "
+                "same dependency-resolution error.",
+            )
+        return result
 
     def cleanup_old_runs(self):
         """Remove oldest runs if we exceed MAX_RUNS."""
@@ -213,7 +329,26 @@ class TestRunner:
         return cmd
 
     def start_run(self, config: RunConfig) -> tuple[str, str]:
-        """Start a new test run. Returns (run_id, command)."""
+        """Start a new test run. Returns (run_id, command).
+
+        The first time this is invoked in a fresh worktree, the
+        upstream ``ar-*`` modules referenced by ``config.module`` may
+        not yet be installed in ``~/.m2/repository/``. To avoid the
+        previous fail→install→retry cycle (which pushes agents toward
+        bash ``mvn``), the run launches a preflight step that seeds
+        any missing upstream artifacts via
+        ``mvn -pl <module> -am install -DskipTests``. The preflight is
+        a no-op when every direct ``org.almostrealism`` dependency is
+        already present, so subsequent calls in the same worktree pay
+        only an inspection cost (a few milliseconds).
+
+        When the preflight install fails the run is short-circuited:
+        the run is marked ``failed`` with the preflight banner left
+        in ``output.txt``, and no Maven test process is launched. The
+        agent sees a clear ``status == "failed"`` with the seed log
+        attached, instead of a duplicate dependency-resolution error
+        from the test invocation.
+        """
         self.cleanup_old_runs()
 
         run_id = self.generate_run_id()
@@ -237,6 +372,33 @@ class TestRunner:
                 iset_output_dir = part[len(iset_prefix):]
                 break
 
+        # Touch the output file so the preflight banner has somewhere to land.
+        output_file = run_dir / "output.txt"
+        output_file.write_text("")
+
+        # Preflight: install missing upstream artifacts. Synchronous because
+        # it must finish before the test process launches against the same
+        # module. Skipped path is a few-millisecond pom scan; only the
+        # genuinely-uninstalled case blocks for the duration of mvn install.
+        preflight_result = self._run_preflight(run_id, run_dir, config.module)
+        if preflight_result.action == "failed":
+            # Short-circuit: mark the run failed and return early. The
+            # preflight banner already explains the failure in output.txt.
+            metadata = RunMetadata(
+                run_id=run_id,
+                config=asdict(config),
+                status="failed",
+                started_at=datetime.now().isoformat(),
+                completed_at=datetime.now().isoformat(),
+                exit_code=preflight_result.exit_code,
+                command=cmd_str,
+                jmx_monitoring=config.jmx_monitoring,
+                instruction_set_output_dir=iset_output_dir,
+                repetitions=config.repetitions,
+            )
+            self._save_metadata(run_id, metadata)
+            return run_id, cmd_str
+
         # Multi-invocation path: delegate to _watch_repetitions thread
         if config.repetitions > 1:
             metadata = RunMetadata(
@@ -252,9 +414,6 @@ class TestRunner:
                 invocations=[]
             )
             self._save_metadata(run_id, metadata)
-
-            # Touch empty output file
-            (run_dir / "output.txt").write_text("")
 
             # Start timeout timer (applies to entire run)
             if config.timeout_minutes:
@@ -290,9 +449,9 @@ class TestRunner:
             instruction_set_output_dir=iset_output_dir
         )
 
-        # Start process
-        output_file = run_dir / "output.txt"
-        with open(output_file, "w") as f:
+        # Start process. The preflight banner is already in output.txt;
+        # open in append mode so mvn output follows it instead of clobbering it.
+        with open(output_file, "a") as f:
             process = subprocess.Popen(
                 cmd,
                 stdout=f,

--- a/tools/mcp/test-runner/server.py
+++ b/tools/mcp/test-runner/server.py
@@ -164,13 +164,13 @@ class TestRunner:
             missing = preflight.find_missing_upstream_artifacts(
                 PROJECT_ROOT, module)
         except Exception as exc:  # noqa: BLE001
-            # TODO(review): Inspection failures short-circuit the run (action="failed") which
-            # mirrors seed failures, but the find_missing_upstream_artifacts function already
-            # returns [] on all expected filesystem errors — so this branch only fires on
-            # truly unexpected exceptions. Consider whether those should fall through (attempt
-            # the test anyway) rather than hard-fail the entire run.
+            # Inspection failures short-circuit the run (action="failed"), mirroring seed failures.
+            # find_missing_upstream_artifacts already returns [] on expected filesystem errors, so this
+            # branch should only fire on truly unexpected exceptions.
+            # If that behavior is undesirable, consider letting the test invocation proceed instead.
             result = preflight.PreflightResult(
                 action="failed",
+                exit_code=1,
                 reason=f"preflight inspection failed: {exc}",
             )
             self._write_preflight_section(

--- a/tools/mcp/test-runner/test_preflight.py
+++ b/tools/mcp/test-runner/test_preflight.py
@@ -1,0 +1,445 @@
+"""Unit tests for the ar-test-runner preflight seeding helper.
+
+These tests cover the preflight module's three public guarantees:
+
+1. **Pom parsing** is correct. The helper finds every direct
+   ``org.almostrealism`` dependency declared in a module's
+   ``pom.xml`` and resolves the version (either explicit on the
+   dependency or inherited from the project version).
+2. **Missing-artifact detection** is accurate. When at least one
+   direct ``org.almostrealism`` dep is missing from the supplied
+   repository, :func:`find_missing_upstream_artifacts` returns the
+   missing entries; when all are present it returns an empty list.
+3. **Seeding is idempotent and short-circuits cleanly.** The mvn
+   subprocess driver is fully replaceable so the tests can run on
+   any host (no real Maven required). A "seed needed" call invokes
+   the driver exactly once and only when at least one artifact is
+   missing; a "nothing to seed" call returns ``"skipped"`` without
+   touching the driver at all.
+
+Run from the repo root::
+
+    python3 -m unittest tools/mcp/test-runner/test_preflight.py -v
+"""
+
+import os
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+_HERE = Path(__file__).resolve().parent
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
+
+import preflight  # noqa: E402
+
+
+def _write_root_pom(project_root: Path, version: str = "0.74") -> Path:
+    pom = project_root / "pom.xml"
+    pom.write_text(
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<project xmlns="http://maven.apache.org/POM/4.0.0">\n'
+        '    <modelVersion>4.0.0</modelVersion>\n'
+        '    <groupId>org.almostrealism</groupId>\n'
+        '    <artifactId>common</artifactId>\n'
+        f'    <version>{version}</version>\n'
+        '    <packaging>pom</packaging>\n'
+        '</project>\n'
+    )
+    return pom
+
+
+def _write_module_pom(project_root: Path, module: str, *, deps: list,
+                      explicit_version: bool = True) -> Path:
+    """Create a child module pom under ``project_root/module``.
+
+    Args:
+        deps: list of ``(group_id, artifact_id, version_or_None)``.
+            When ``version_or_None`` is ``None`` no ``<version>`` is
+            emitted, exercising the parent-inheritance path.
+    """
+    module_dir = project_root / module
+    module_dir.mkdir(parents=True, exist_ok=True)
+    dep_xml = []
+    for group_id, artifact_id, version in deps:
+        block = ["        <dependency>"]
+        block.append(f"            <groupId>{group_id}</groupId>")
+        block.append(f"            <artifactId>{artifact_id}</artifactId>")
+        if version is not None:
+            block.append(f"            <version>{version}</version>")
+        block.append("        </dependency>")
+        dep_xml.append("\n".join(block))
+    pom = module_dir / "pom.xml"
+    parent_version_line = "        <version>0.74</version>\n" if explicit_version else ""
+    deps_block = "\n".join(dep_xml)
+    pom.write_text(
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<project xmlns="http://maven.apache.org/POM/4.0.0">\n'
+        '    <parent>\n'
+        '        <groupId>org.almostrealism</groupId>\n'
+        '        <artifactId>common</artifactId>\n'
+        f'{parent_version_line}'
+        '    </parent>\n'
+        '    <modelVersion>4.0.0</modelVersion>\n'
+        f'    <artifactId>ar-{module.replace("/", "-")}</artifactId>\n'
+        '    <dependencies>\n'
+        f'{deps_block}\n'
+        '    </dependencies>\n'
+        '</project>\n'
+    )
+    return pom
+
+
+def _install_jar(repository: Path, group_id: str, artifact_id: str,
+                  version: str) -> Path:
+    """Create the on-disk equivalent of ``mvn install`` for one artifact."""
+    base = repository.joinpath(*group_id.split("."), artifact_id, version)
+    base.mkdir(parents=True, exist_ok=True)
+    jar = base / f"{artifact_id}-{version}.jar"
+    jar.write_bytes(b"")
+    return jar
+
+
+class PomParsingTests(unittest.TestCase):
+    """Cover :func:`read_project_version` and :func:`read_ar_dependencies`."""
+
+    def test_read_project_version_from_module(self):
+        with TemporaryDirectory() as tmp:
+            project_root = Path(tmp)
+            _write_root_pom(project_root, version="9.99")
+            self.assertEqual("9.99", preflight.read_project_version(
+                project_root / "pom.xml"))
+
+    def test_read_project_version_falls_back_to_parent(self):
+        with TemporaryDirectory() as tmp:
+            project_root = Path(tmp)
+            _write_root_pom(project_root, version="9.99")
+            # explicit_version=True puts <version>0.74</version> inside the
+            # module's <parent> block. The module itself has no top-level
+            # <version>, so the helper must read the parent's value.
+            _write_module_pom(project_root, "subA",
+                              deps=[], explicit_version=True)
+            version = preflight.read_project_version(
+                project_root / "subA/pom.xml")
+            self.assertEqual("0.74", version)
+
+    def test_read_project_version_returns_none_when_neither_module_nor_parent_has_one(self):
+        with TemporaryDirectory() as tmp:
+            project_root = Path(tmp)
+            _write_root_pom(project_root, version="9.99")
+            # explicit_version=False removes the version from the parent
+            # block too. The module pom carries no version anywhere — the
+            # helper must return None instead of guessing.
+            _write_module_pom(project_root, "subA",
+                              deps=[], explicit_version=False)
+            version = preflight.read_project_version(
+                project_root / "subA/pom.xml")
+            self.assertIsNone(version)
+
+    def test_read_project_version_returns_none_when_missing(self):
+        with TemporaryDirectory() as tmp:
+            pom = Path(tmp) / "pom.xml"
+            pom.write_text(
+                "<project xmlns='http://maven.apache.org/POM/4.0.0'>"
+                "<modelVersion>4.0.0</modelVersion>"
+                "<artifactId>foo</artifactId></project>"
+            )
+            self.assertIsNone(preflight.read_project_version(pom))
+
+    def test_read_project_version_handles_unreadable_pom(self):
+        # Pointing at a directory rather than a file triggers an OSError
+        # which the helper must swallow into None.
+        with TemporaryDirectory() as tmp:
+            self.assertIsNone(preflight.read_project_version(Path(tmp)))
+
+    def test_read_ar_dependencies_collects_direct_org_almostrealism(self):
+        with TemporaryDirectory() as tmp:
+            project_root = Path(tmp)
+            _write_root_pom(project_root)
+            _write_module_pom(project_root, "engine/utils", deps=[
+                ("org.almostrealism", "ar-space", "0.74"),
+                ("org.almostrealism", "ar-chemistry", "0.74"),
+                ("commons-io", "commons-io", "2.11"),
+                ("org.almostrealism", "ar-optimize", "0.74"),
+            ])
+            deps = preflight.read_ar_dependencies(
+                project_root / "engine/utils/pom.xml", fallback_version="0.74")
+            self.assertEqual(
+                [("ar-space", "0.74"), ("ar-chemistry", "0.74"),
+                 ("ar-optimize", "0.74")],
+                deps,
+            )
+
+    def test_read_ar_dependencies_uses_fallback_version_when_omitted(self):
+        with TemporaryDirectory() as tmp:
+            project_root = Path(tmp)
+            _write_root_pom(project_root)
+            _write_module_pom(project_root, "engine/utils", deps=[
+                ("org.almostrealism", "ar-space", None),
+                ("org.almostrealism", "ar-collect", "0.99"),
+            ])
+            deps = preflight.read_ar_dependencies(
+                project_root / "engine/utils/pom.xml", fallback_version="0.74")
+            self.assertIn(("ar-space", "0.74"), deps)
+            self.assertIn(("ar-collect", "0.99"), deps)
+
+    def test_read_ar_dependencies_drops_when_no_version_resolvable(self):
+        with TemporaryDirectory() as tmp:
+            project_root = Path(tmp)
+            _write_root_pom(project_root)
+            _write_module_pom(project_root, "engine/utils", deps=[
+                ("org.almostrealism", "ar-space", None),
+            ])
+            deps = preflight.read_ar_dependencies(
+                project_root / "engine/utils/pom.xml", fallback_version=None)
+            self.assertEqual([], deps)
+
+    def test_read_ar_dependencies_deduplicates(self):
+        with TemporaryDirectory() as tmp:
+            project_root = Path(tmp)
+            _write_root_pom(project_root)
+            _write_module_pom(project_root, "engine/utils", deps=[
+                ("org.almostrealism", "ar-space", "0.74"),
+                ("org.almostrealism", "ar-space", "0.74"),
+            ])
+            deps = preflight.read_ar_dependencies(
+                project_root / "engine/utils/pom.xml", fallback_version="0.74")
+            self.assertEqual([("ar-space", "0.74")], deps)
+
+    def test_read_ar_dependencies_returns_empty_on_unreadable_pom(self):
+        # A non-existent path must not crash the helper.
+        self.assertEqual(
+            [],
+            preflight.read_ar_dependencies(
+                Path("/no/such/path/pom.xml"), fallback_version="0.74"),
+        )
+
+
+class MissingDetectionTests(unittest.TestCase):
+    """Cover :func:`find_missing_upstream_artifacts`."""
+
+    def test_no_missing_when_all_installed(self):
+        with TemporaryDirectory() as tmp:
+            project_root = Path(tmp) / "src"
+            repository = Path(tmp) / "m2"
+            project_root.mkdir()
+            repository.mkdir()
+            _write_root_pom(project_root)
+            _write_module_pom(project_root, "engine/utils", deps=[
+                ("org.almostrealism", "ar-space", "0.74"),
+                ("org.almostrealism", "ar-collect", "0.74"),
+            ])
+            _install_jar(repository, "org.almostrealism", "ar-space", "0.74")
+            _install_jar(repository, "org.almostrealism", "ar-collect", "0.74")
+            missing = preflight.find_missing_upstream_artifacts(
+                project_root, "engine/utils", repository=repository)
+            self.assertEqual([], missing)
+
+    def test_reports_each_missing_artifact_with_expected_path(self):
+        with TemporaryDirectory() as tmp:
+            project_root = Path(tmp) / "src"
+            repository = Path(tmp) / "m2"
+            project_root.mkdir()
+            repository.mkdir()
+            _write_root_pom(project_root)
+            _write_module_pom(project_root, "engine/utils", deps=[
+                ("org.almostrealism", "ar-space", "0.74"),
+                ("org.almostrealism", "ar-collect", "0.74"),
+            ])
+            _install_jar(repository, "org.almostrealism", "ar-space", "0.74")
+            # ar-collect is intentionally NOT installed.
+            missing = preflight.find_missing_upstream_artifacts(
+                project_root, "engine/utils", repository=repository)
+            self.assertEqual(1, len(missing))
+            self.assertEqual("ar-collect", missing[0].artifact_id)
+            self.assertEqual("0.74", missing[0].version)
+            self.assertEqual(
+                repository / "org/almostrealism/ar-collect/0.74/ar-collect-0.74.jar",
+                missing[0].expected_path,
+            )
+
+    def test_returns_empty_when_module_pom_does_not_exist(self):
+        with TemporaryDirectory() as tmp:
+            project_root = Path(tmp) / "src"
+            repository = Path(tmp) / "m2"
+            project_root.mkdir()
+            repository.mkdir()
+            _write_root_pom(project_root)
+            # No module pom written — the helper should return [] so the
+            # caller can fall back gracefully.
+            missing = preflight.find_missing_upstream_artifacts(
+                project_root, "nope/missing", repository=repository)
+            self.assertEqual([], missing)
+
+    def test_module_without_ar_deps_is_treated_as_complete(self):
+        with TemporaryDirectory() as tmp:
+            project_root = Path(tmp) / "src"
+            repository = Path(tmp) / "m2"
+            project_root.mkdir()
+            repository.mkdir()
+            _write_root_pom(project_root)
+            _write_module_pom(project_root, "leaf", deps=[
+                ("commons-io", "commons-io", "2.11"),
+            ])
+            missing = preflight.find_missing_upstream_artifacts(
+                project_root, "leaf", repository=repository)
+            self.assertEqual([], missing)
+
+
+class SeedingTests(unittest.TestCase):
+    """Cover :func:`seed_upstream_artifacts` end-to-end via a stub runner."""
+
+    def test_returns_skipped_and_does_not_call_runner_when_nothing_missing(self):
+        with TemporaryDirectory() as tmp:
+            project_root = Path(tmp) / "src"
+            repository = Path(tmp) / "m2"
+            project_root.mkdir()
+            repository.mkdir()
+            _write_root_pom(project_root)
+            _write_module_pom(project_root, "engine/utils", deps=[
+                ("org.almostrealism", "ar-space", "0.74"),
+            ])
+            _install_jar(repository, "org.almostrealism", "ar-space", "0.74")
+
+            invocations = []
+
+            def fake_runner(cmd, cwd, writer):
+                invocations.append((list(cmd), Path(cwd)))
+                return 0
+
+            result = preflight.seed_upstream_artifacts(
+                project_root, "engine/utils",
+                repository=repository, runner=fake_runner)
+            self.assertEqual("skipped", result.action)
+            self.assertEqual([], invocations,
+                             "runner must not be invoked when nothing is missing")
+            self.assertEqual([], result.command)
+            self.assertIsNone(result.exit_code)
+
+    def test_runs_mvn_install_when_artifact_is_missing(self):
+        with TemporaryDirectory() as tmp:
+            project_root = Path(tmp) / "src"
+            repository = Path(tmp) / "m2"
+            project_root.mkdir()
+            repository.mkdir()
+            _write_root_pom(project_root)
+            _write_module_pom(project_root, "engine/utils", deps=[
+                ("org.almostrealism", "ar-space", "0.74"),
+            ])
+            # ar-space is NOT installed; runner must execute.
+
+            invocations = []
+            captured_writer = []
+
+            def fake_runner(cmd, cwd, writer):
+                invocations.append((list(cmd), Path(cwd)))
+                captured_writer.append(writer)
+                if writer is not None:
+                    writer("simulated mvn install output\n")
+                return 0
+
+            result = preflight.seed_upstream_artifacts(
+                project_root, "engine/utils",
+                repository=repository, runner=fake_runner)
+
+            self.assertEqual("seeded", result.action)
+            self.assertEqual(0, result.exit_code)
+            self.assertEqual(1, len(invocations))
+            cmd, cwd = invocations[0]
+            self.assertEqual(
+                ["mvn", "-pl", "engine/utils", "-am", "install",
+                 "-DskipTests", "-B"],
+                cmd,
+            )
+            self.assertEqual(project_root.resolve(), cwd.resolve())
+            self.assertEqual(["ar-space"],
+                             [m.artifact_id for m in result.missing])
+
+    def test_reports_failed_action_when_runner_returns_nonzero(self):
+        with TemporaryDirectory() as tmp:
+            project_root = Path(tmp) / "src"
+            repository = Path(tmp) / "m2"
+            project_root.mkdir()
+            repository.mkdir()
+            _write_root_pom(project_root)
+            _write_module_pom(project_root, "engine/utils", deps=[
+                ("org.almostrealism", "ar-space", "0.74"),
+            ])
+
+            def fake_runner(cmd, cwd, writer):
+                return 1
+
+            result = preflight.seed_upstream_artifacts(
+                project_root, "engine/utils",
+                repository=repository, runner=fake_runner)
+            self.assertEqual("failed", result.action)
+            self.assertEqual(1, result.exit_code)
+            self.assertIn("exited with code 1", result.reason)
+
+    def test_seed_command_uses_dash_am_to_build_upstream_chain(self):
+        # Sanity check: an agent reading the command should see -am (not -amd
+        # or no flag at all) so the full upstream reactor is built.
+        cmd = preflight.build_seed_command("flowtree/runtime")
+        self.assertIn("-am", cmd)
+        self.assertNotIn("-amd", cmd)
+        self.assertNotIn("--also-make-dependents", cmd)
+        # Tests are skipped so the seed stays fast.
+        self.assertIn("-DskipTests", cmd)
+
+    def test_output_writer_failure_does_not_propagate(self):
+        # The Maven driver is wrapped so output-writer exceptions don't
+        # break the seed. A pure-python regression test for that behaviour:
+        with TemporaryDirectory() as tmp:
+            project_root = Path(tmp) / "src"
+            repository = Path(tmp) / "m2"
+            project_root.mkdir()
+            repository.mkdir()
+            _write_root_pom(project_root)
+            _write_module_pom(project_root, "engine/utils", deps=[
+                ("org.almostrealism", "ar-space", "0.74"),
+            ])
+
+            def writer_that_explodes(_chunk):
+                raise RuntimeError("simulated disk failure")
+
+            def fake_runner(cmd, cwd, writer):
+                # Stub a real driver: emit a chunk through the writer.
+                # _default_runner swallows writer exceptions, but the test
+                # runs without _default_runner so the stub must not propagate
+                # the writer error itself either.
+                try:
+                    writer("some output\n")
+                except Exception:
+                    pass
+                return 0
+
+            result = preflight.seed_upstream_artifacts(
+                project_root, "engine/utils",
+                repository=repository, runner=fake_runner,
+                output_writer=writer_that_explodes)
+            self.assertEqual("seeded", result.action)
+
+
+class ArtifactPathTests(unittest.TestCase):
+    """Sanity-check :func:`artifact_jar_path`."""
+
+    def test_path_layout_matches_maven_convention(self):
+        path = preflight.artifact_jar_path(
+            Path("/tmp/m2"), "org.almostrealism", "ar-foo", "0.74")
+        self.assertEqual(
+            Path("/tmp/m2/org/almostrealism/ar-foo/0.74/ar-foo-0.74.jar"),
+            path,
+        )
+
+    def test_path_layout_handles_multi_segment_group(self):
+        path = preflight.artifact_jar_path(
+            Path("/tmp/m2"), "com.example.sub", "thing", "1.0")
+        self.assertEqual(
+            Path("/tmp/m2/com/example/sub/thing/1.0/thing-1.0.jar"),
+            path,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/mcp/test-runner/test_preflight_integration.py
+++ b/tools/mcp/test-runner/test_preflight_integration.py
@@ -1,0 +1,332 @@
+"""Integration tests for ar-test-runner preflight wiring.
+
+These tests verify that ``TestRunner.start_run`` correctly invokes the
+preflight seeding step before launching Maven, and that a preflight
+failure short-circuits the run cleanly:
+
+* When all upstream artifacts are already in ``~/.m2``, the preflight
+  is a no-op and the test launches normally.
+* When the seeding subprocess returns success, the test launches and
+  the preflight banner is recorded in ``output.txt``.
+* When the seeding subprocess fails, the run is marked ``failed``
+  immediately, no Maven test process is spawned, and the preflight
+  banner explains why.
+
+Maven is never actually invoked: ``server.subprocess.Popen`` is
+stubbed in each test to capture invocations and ``preflight._default_runner``
+is replaced with an in-process callable.
+
+Run from the repo root::
+
+    python3 -m unittest tools/mcp/test-runner/test_preflight_integration.py -v
+"""
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+_HERE = Path(__file__).resolve().parent
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
+
+_COMMON_DIR = _HERE.parent / "common"
+if str(_COMMON_DIR) not in sys.path:
+    sys.path.insert(0, str(_COMMON_DIR))
+
+import preflight  # noqa: E402
+import server  # noqa: E402
+
+
+def _write_root_pom(project_root: Path, version: str = "0.74") -> None:
+    (project_root / "pom.xml").write_text(
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<project xmlns="http://maven.apache.org/POM/4.0.0">\n'
+        '    <modelVersion>4.0.0</modelVersion>\n'
+        '    <groupId>org.almostrealism</groupId>\n'
+        '    <artifactId>common</artifactId>\n'
+        f'    <version>{version}</version>\n'
+        '    <packaging>pom</packaging>\n'
+        '</project>\n'
+    )
+
+
+def _write_module_pom(project_root: Path, module: str, ar_deps: list) -> None:
+    dep_blocks = []
+    for artifact_id, version in ar_deps:
+        dep_blocks.append(
+            "        <dependency>\n"
+            "            <groupId>org.almostrealism</groupId>\n"
+            f"            <artifactId>{artifact_id}</artifactId>\n"
+            f"            <version>{version}</version>\n"
+            "        </dependency>"
+        )
+    module_dir = project_root / module
+    module_dir.mkdir(parents=True, exist_ok=True)
+    deps_xml = "\n".join(dep_blocks) if dep_blocks else ""
+    (module_dir / "pom.xml").write_text(
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<project xmlns="http://maven.apache.org/POM/4.0.0">\n'
+        '    <parent>\n'
+        '        <groupId>org.almostrealism</groupId>\n'
+        '        <artifactId>common</artifactId>\n'
+        '        <version>0.74</version>\n'
+        '    </parent>\n'
+        '    <modelVersion>4.0.0</modelVersion>\n'
+        f'    <artifactId>ar-{module.replace("/", "-")}</artifactId>\n'
+        '    <dependencies>\n'
+        f'{deps_xml}\n'
+        '    </dependencies>\n'
+        '</project>\n'
+    )
+
+
+def _install_jar(repository: Path, artifact_id: str, version: str) -> None:
+    base = repository / "org" / "almostrealism" / artifact_id / version
+    base.mkdir(parents=True, exist_ok=True)
+    (base / f"{artifact_id}-{version}.jar").write_bytes(b"")
+
+
+class _FakePopen:
+    """Minimal stand-in for ``subprocess.Popen`` used in tests.
+
+    Records every invocation in :data:`launched` so assertions can
+    confirm what ``server.start_run`` tried to spawn without actually
+    launching Maven.
+    """
+
+    launched: list = []
+
+    def __init__(self, cmd, *args, **kwargs):
+        type(self).launched.append((list(cmd), kwargs))
+        self.pid = 99999
+
+    # Methods invoked by the watcher thread:
+    def poll(self):
+        return 0
+
+    def wait(self):
+        return 0
+
+    @classmethod
+    def reset(cls):
+        cls.launched = []
+
+
+class StartRunPreflightIntegrationTests(unittest.TestCase):
+    """``TestRunner.start_run`` calls preflight before the test launch."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self._tmp_path = Path(self._tmp.name)
+        self._project_root = self._tmp_path / "project"
+        self._project_root.mkdir()
+        self._runs_dir = self._tmp_path / "runs"
+        self._runs_dir.mkdir()
+        self._m2 = self._tmp_path / "m2"
+        self._m2.mkdir()
+        _write_root_pom(self._project_root)
+        _write_module_pom(self._project_root, "engine/utils", [
+            ("ar-space", "0.74"),
+        ])
+
+        self._patches = [
+            patch.object(server, "PROJECT_ROOT", self._project_root),
+            patch.object(server, "RUNS_DIR", self._runs_dir),
+            patch.object(server, "subprocess",
+                         _StubSubprocess(_FakePopen)),
+            patch.object(preflight, "DEFAULT_M2_REPOSITORY", self._m2),
+            patch.object(server.threading, "Timer", _NoOpTimer),
+            patch.object(server.threading, "Thread", _NoOpThread),
+            patch.object(server.TestRunner, "_spawn_watcher_subprocess",
+                         lambda *_args, **_kwargs: None),
+        ]
+        for p in self._patches:
+            p.start()
+        _FakePopen.reset()
+        self._runner = server.TestRunner()
+
+    def tearDown(self):
+        for p in self._patches:
+            p.stop()
+        self._tmp.cleanup()
+
+    def _read_output(self, run_id: str) -> str:
+        return (self._runs_dir / run_id / "output.txt").read_text()
+
+    def _read_metadata(self, run_id: str) -> dict:
+        with open(self._runs_dir / run_id / "metadata.json") as f:
+            return json.load(f)
+
+    def test_skipped_preflight_when_artifacts_installed(self):
+        """All AR jars present in m2: preflight is a no-op, test launches."""
+        _install_jar(self._m2, "ar-space", "0.74")
+
+        with patch.object(preflight, "_default_runner",
+                          side_effect=AssertionError(
+                              "preflight runner must not run when artifacts present")):
+            run_id, _ = self._runner.start_run(
+                server.RunConfig(module="engine/utils"))
+
+        output = self._read_output(run_id)
+        self.assertIn("PREFLIGHT: skipped", output)
+        # The test process was launched (single-invocation path).
+        self.assertEqual(1, len(_FakePopen.launched))
+        cmd, _ = _FakePopen.launched[0]
+        self.assertIn("mvn", cmd)
+        self.assertIn("test", cmd)
+        meta = self._read_metadata(run_id)
+        self.assertEqual("running", meta["status"])
+
+    def test_seed_runs_when_artifact_missing_then_test_launches(self):
+        """At least one AR jar missing: preflight runs, then test launches."""
+        seed_calls = []
+
+        def fake_runner(cmd, cwd, writer):
+            seed_calls.append((list(cmd), Path(cwd)))
+            if writer is not None:
+                writer("[fake mvn] BUILD SUCCESS\n")
+            # Simulate a successful install by creating the jar so a
+            # subsequent missing-check would pass.
+            _install_jar(self._m2, "ar-space", "0.74")
+            return 0
+
+        with patch.object(preflight, "_default_runner", fake_runner):
+            run_id, _ = self._runner.start_run(
+                server.RunConfig(module="engine/utils"))
+
+        # Preflight ran exactly once with the expected command.
+        self.assertEqual(1, len(seed_calls),
+                         f"expected exactly one preflight install, got {seed_calls}")
+        seed_cmd, seed_cwd = seed_calls[0]
+        self.assertEqual(
+            ["mvn", "-pl", "engine/utils", "-am", "install",
+             "-DskipTests", "-B"],
+            seed_cmd,
+        )
+        self.assertEqual(self._project_root.resolve(), seed_cwd.resolve())
+
+        # Preflight banner and seed output are in output.txt; test launched.
+        output = self._read_output(run_id)
+        self.assertIn("PREFLIGHT: seeding 1 upstream artifact(s)", output)
+        self.assertIn("PREFLIGHT: seeded 1 artifact(s)", output)
+        self.assertIn("[fake mvn] BUILD SUCCESS", output)
+        self.assertEqual(1, len(_FakePopen.launched))
+        meta = self._read_metadata(run_id)
+        self.assertEqual("running", meta["status"])
+
+    def test_seed_failure_short_circuits_test_launch(self):
+        """Failed preflight: run is marked failed, no test process spawned."""
+        seed_calls = []
+
+        def fake_runner(cmd, cwd, writer):
+            seed_calls.append((list(cmd), Path(cwd)))
+            if writer is not None:
+                writer("[fake mvn] BUILD FAILURE: cannot resolve dependency\n")
+            return 1
+
+        with patch.object(preflight, "_default_runner", fake_runner):
+            run_id, _ = self._runner.start_run(
+                server.RunConfig(module="engine/utils"))
+
+        # The seed was attempted.
+        self.assertEqual(1, len(seed_calls))
+        # No Maven test process was launched.
+        self.assertEqual(0, len(_FakePopen.launched),
+                         "test must not launch when preflight fails")
+
+        meta = self._read_metadata(run_id)
+        self.assertEqual("failed", meta["status"])
+        self.assertEqual(1, meta["exit_code"])
+
+        output = self._read_output(run_id)
+        self.assertIn("PREFLIGHT: FAILED", output)
+        self.assertIn("[fake mvn] BUILD FAILURE", output)
+
+    def test_repetitions_path_also_runs_preflight_once(self):
+        """Multi-invocation runs preflight before scheduling the loop."""
+        seed_calls = []
+
+        def fake_runner(cmd, cwd, writer):
+            seed_calls.append(list(cmd))
+            _install_jar(self._m2, "ar-space", "0.74")
+            return 0
+
+        with patch.object(preflight, "_default_runner", fake_runner):
+            run_id, _ = self._runner.start_run(
+                server.RunConfig(module="engine/utils", repetitions=5))
+
+        # Preflight runs exactly once (not once per repetition).
+        self.assertEqual(1, len(seed_calls))
+        # The repetitions watcher thread was scheduled but, because Thread is
+        # stubbed, no Maven invocations actually ran. The output file holds
+        # the preflight banner.
+        meta = self._read_metadata(run_id)
+        self.assertEqual("running", meta["status"])
+        self.assertEqual(5, meta["repetitions"])
+
+    def test_module_without_ar_deps_skips_preflight(self):
+        """Module with no org.almostrealism deps: preflight is skipped."""
+        _write_module_pom(self._project_root, "leaf", [])
+
+        with patch.object(preflight, "_default_runner",
+                          side_effect=AssertionError(
+                              "preflight runner must not run for a leaf module")):
+            run_id, _ = self._runner.start_run(
+                server.RunConfig(module="leaf"))
+
+        output = self._read_output(run_id)
+        self.assertIn("PREFLIGHT: skipped", output)
+        self.assertEqual(1, len(_FakePopen.launched))
+
+
+class _NoOpTimer:
+    """Stand-in for ``threading.Timer`` that records but does not run callbacks."""
+
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+    def start(self):
+        pass
+
+    def cancel(self):
+        pass
+
+
+class _NoOpThread:
+    """Stand-in for ``threading.Thread`` that does not start a real thread."""
+
+    def __init__(self, *args, **kwargs):
+        self.target = kwargs.get("target") or (args[0] if args else None)
+        self.args = kwargs.get("args", ())
+
+    def start(self):
+        pass
+
+
+class _StubSubprocess:
+    """Drop-in replacement for the ``subprocess`` module attribute on server.
+
+    Routes ``Popen`` to ``_FakePopen`` while preserving any other names the
+    code under test may touch.
+    """
+
+    def __init__(self, popen_cls):
+        self.Popen = popen_cls
+        # Real subprocess module attributes preserved for any helper that
+        # still references them.
+        import subprocess as _real_subprocess
+        self.PIPE = _real_subprocess.PIPE
+        self.STDOUT = _real_subprocess.STDOUT
+        self.DEVNULL = _real_subprocess.DEVNULL
+        self.TimeoutExpired = _real_subprocess.TimeoutExpired
+        self.SubprocessError = _real_subprocess.SubprocessError
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Primary fix (the must-have): make ar-test-runner self-sufficient on the first call in a fresh worktree, so agents stop bouncing through the fail-mvn-then-install-then-retry cycle that pushes them to bash mvn and triggers the cascade documented in the
feature/prompt-efficiency-nudges retrospective on job 5acb6cd5.

What the test runner does now
-----------------------------

A new tools/mcp/test-runner/preflight.py performs a lazy seed before every test invocation:

  1. Parse the target module's pom.xml for direct <dependency> entries with <groupId>org.almostrealism</groupId>.
  2. Look for each artifact's .jar in ~/.m2/repository/.
  3. If every direct dep is already present, skip (a few ms of inspection -- idempotent for the second-and-onwards call).
  4. Otherwise, run mvn -pl <module> -am install -DskipTests -B from the project root. -am builds the full upstream chain so subsequent invocations skip the seed.

The seed is wired into TestRunner.start_run in server.py. Both the single-invocation and the multi-invocation paths run it once, before launching any test process. The seed's stdout/stderr is appended to the run's output.txt between two clearly-labelled PREFLIGHT: banners so an agent inspecting get_run_output sees exactly what happened.

When the seed itself fails (e.g. the upstream module fails to compile), the run is marked failed immediately and no Maven test process is spawned -- the agent gets a fast, accurate failure instead of a redundant dependency-resolution error from `mvn test`.

Secondary fix (smallest change the evidence supports) -----------------------------------------------------

The retro also showed that even after the seed gap is closed, an opencode-driven agent who falls back to bash for any other reason gets no steering toward ar-build-validator -- the existing Claude hook mvn-artifact-staleness.py has no opencode counterpart, and the existing block-mvn-test-direct hook deliberately does not match mvn install / mvn compile.

This commit adds:

  - .claude/hooks/lib/mvn_build_check.py: shared core that detects artifact-producing mvn goals (install, compile, package, deploy, ...) in a bash command. Renders a short steer message pointing at the ar-build-validator MCP tool for "is the build clean?" checks. The note is explicitly informational ("does not block the command") so legitimate uses like dependency seeding, packaging for downstream consumers, or CI setup are not discouraged -- they just see a small note in the bash output suggesting the structured tool.

  - .opencode/plugins/warn-mvn-build.ts: opencode adapter that invokes the shared core via subprocess and appends the steer to the bash tool's output on .after. Never throws. Uses the same callID cache pattern as block-mvn-test-direct.ts.

  - Registered the new plugin in .opencode/opencode.json.

The Claude staleness hook (.claude/hooks/mvn-artifact-staleness.py) is unchanged -- it already produces a richer per-module staleness table via additionalContext, which is the right shape for Claude's hook-context channel. The new opencode plugin is the equivalent for the output-mutation channel and adds the steer toward ar-build-validator that neither hook surfaced before.

Why this approach
-----------------

Research confirmed:

  - GitRepositorySetup.prepare() and EnvironmentManagedJob.prepareEnvironment() handle clone/branch/venv but do nothing Maven-related, so a fresh worktree never has the ar-*.jar files installed.
  - ar-build-validator already runs `mvn install -DskipTests` for its BUILD_REQUIRED_CHECKS so it does not have the same gap as the test runner.
  - block-mvn-test-direct (both .sh and .ts) only matches mvn test/integration-test/-Dtest=. It honors -DskipTests so the new preflight's own subprocess invocation does not collide with the block rule.

Tool-side preflight (rather than worktree setup) was chosen because it (a) only runs when the agent actually uses the test runner, (b) only seeds the specific module's deps, (c) short-circuits when already seeded, and (d) does not add wall time to jobs that never touch the test runner.

Tests
-----

All tests are in NEW files; no base-branch test files were modified.

  - tools/mcp/test-runner/test_preflight.py (21 tests): pom parsing, version inheritance, missing-artifact detection, seed command shape, runner short-circuit semantics, output-writer failure isolation.

  - tools/mcp/test-runner/test_preflight_integration.py (5 tests): TestRunner.start_run wiring -- skipped path does not spawn the seed subprocess, seed-needed path runs the subprocess and then launches the test, seed failure short-circuits the test launch, multi-invocation path runs preflight exactly once.

  - .claude/hooks/lib/test_mvn_build_check.py (25 tests): goal detection across install / compile / package / clean / -version, chained-command attribution, -DskipTests case (still warns, informational only), CLI argv mode.

  - .opencode/plugins/__tests__/warn-mvn-build.smoke.cjs and .test.ts: smoke + functional plugin tests confirming warn-only behavior, no false-positives on mvn test, cache hit/miss paths, and that the plugin never throws.

All 46 test-runner Python tests pass (20 existing + 26 new), all 109 hook lib Python tests pass (84 existing + 25 new), all 5 opencode smoke tests and all 5 opencode TS plugin tests pass.

Note on the primary job's own run
---------------------------------

This job's own primary phase ran in a fresh worktree, but the local ~/.m2 was already populated (likely by a host-side build), so the preflight gap did not actually fire during the session. The fix is still wired correctly -- the preflight code path is exercised by the unit tests with a sandboxed empty Maven repository, and a real fresh-worktree call will go through the same code path on the next agent session that lands on a host without the cache.

Pre-existing CI note
--------------------

ar-build-validator's checkstyle check fails on master and on this branch because of a stray line in
flowtree/runtime/src/test/java/io/flowtree/jobs/InstructionPromptBuilderTest.java:461 (introduced by master commit c1e155d1e, not by this branch). RULE 1 write-lock prevents agents from modifying base-branch test files, so that fix is out of scope here. Validation of this branch's changes was performed via the new Python tests directly and via the code_policy / duplicate_code / test_timeouts checks, which all passed.