### PR TITLE
Block checkstyle configuration edits with abandon-before-tamper rule

### DIFF
--- a/.claude/hooks/block-checkstyle-edit.sh
+++ b/.claude/hooks/block-checkstyle-edit.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# PreToolUse — Write/Edit/MultiEdit/NotebookEdit/Bash: block any attempt
+# to modify a checkstyle configuration file.
+#
+# Agents must not weaken, exempt, suppress, or relax checkstyle rules
+# to make a task pass.  This is a structural block: the check is
+# enforced in the harness before the file edit (or shell command)
+# takes effect, so the cheat can't be undone by the agent.
+#
+# This is a thin shell wrapper.  The decision logic lives in
+# .claude/hooks/lib/checkstyle_config_check.py — the single source
+# of truth for this policy across both Claude Code (this script)
+# and opencode (.opencode/plugins/block-checkstyle-edit.ts).
+#
+# Exit 0  → allow
+# Exit 2  → BLOCK (the forceful ALL-CAPS reason is on stderr, shown
+#           to the model as the block reason)
+#
+# The block message is deliberately written in ALL CAPS and lists
+# the abandon-before-tamper principle the project requires: if a
+# task cannot be completed without modifying checkstyle, the agent
+# MUST abandon the task and declare it impossible.  Declaring
+# failure is always preferable to tampering with enforcement.
+#
+# See docs/plans/OPENCODE_HOOKS.md for the architecture.
+set -euo pipefail
+exec python3 "$(cd "$(dirname "$0")" && pwd)/lib/checkstyle_config_check.py" --stdin

--- a/.claude/hooks/lib/checkstyle_config_check.py
+++ b/.claude/hooks/lib/checkstyle_config_check.py
@@ -1,0 +1,390 @@
+#!/usr/bin/env python3
+"""Decide whether a tool call is an attempt to modify a checkstyle configuration.
+
+This module is the single source of truth for the "block edits to checkstyle
+configuration" policy. It is invoked by:
+
+  - .claude/hooks/block-checkstyle-edit.sh     (Claude Code, --stdin)
+  - .opencode/plugins/block-checkstyle-edit.ts  (opencode, argv)
+
+A checkstyle configuration is any file the maven-checkstyle-plugin or
+similar tooling loads to define which rules to enforce. The two shapes
+agents have used in past sessions to make violations disappear are:
+
+  1. The main configuration file (checkstyle.xml at the repo root or in
+     a module-local override).
+  2. Suppression / exemption files (e.g. checkstyle-suppressions.xml,
+     inline SuppressionFilter / SuppressionSingleFilter entries inside
+     checkstyle.xml, or any *checkstyle*suppress*.xml file).
+
+Both shapes are covered by the same matcher in `is_checkstyle_path`:
+anything under a `/checkstyle/` directory, or any file whose name
+contains both `checkstyle` and `suppress` and ends in `.xml`, in
+addition to the canonical `checkstyle.xml` and
+`checkstyle-suppressions.xml` basenames.
+
+Two CLI entry points:
+
+  python3 checkstyle_config_check.py <json>
+      Used by the .ts adapter. <json> is a JSON object with `tool`
+      (one of "bash", "write", "edit", "multiedit", "notebookedit")
+      and either `command` (for bash) or `filePath`/`file_path`
+      (for the file tools). Returns the Decision as a JSON object on
+      stdout, exit 0 always. The .ts adapter does the harness-native
+      rendering (throw on block).
+
+  python3 checkstyle_config_check.py --stdin
+      Used by the .sh adapter. Reads a Claude-Code-style hook payload
+      from stdin (`{"tool_name": "...", "tool_input": {...}}`),
+      computes the Decision, and renders natively (exit 2 + stderr
+      on block, exit 0 on allow).
+
+The Decision shape (always JSON):
+
+    {
+      "action":  "block" | "allow",
+      "reason":  "str",   # shown to the model on block; printed to stderr
+      "context": "str",   # unused (this policy is binary, no warn path)
+      "stderr":  "str",   # always printed to stderr for the human
+    }
+
+The block message is intentionally written in ALL CAPS so the agent
+cannot mistake it for ordinary guidance. See BLOCK_REASON below.
+"""
+import json
+import os
+import re
+import shlex
+import sys
+
+
+# ---------------------------------------------------------------------------
+# Path matching
+# ---------------------------------------------------------------------------
+
+# A path is a checkstyle configuration if its basename is one of the
+# canonical filenames, or if it lives in a `/checkstyle/` directory, or
+# if its name contains both `checkstyle` and `suppress` (covering
+# module-local variants like `engine-ml-checkstyle-suppressions.xml`).
+#
+# Comparison is case-insensitive because some filesystems (e.g. macOS
+# HFS+ default, Windows) treat CHECKSTYLE.XML the same as
+# checkstyle.xml; the maven-checkstyle-plugin is also case-tolerant
+# when resolving configLocation.
+EXACT_BASENAMES = {
+    "checkstyle.xml",
+    "checkstyle-suppressions.xml",
+    "checkstyle_checks.xml",
+    "checkstyle-config.xml",
+}
+
+
+def is_checkstyle_path(path):
+    """True if `path` is the path of a checkstyle configuration file.
+
+    `path` may be absolute, relative, or `~`-expanded. Returns False
+    on empty/None input. The match is case-insensitive on the
+    basename and on the directory segment.
+    """
+    if not path:
+        return False
+    p = os.path.expanduser(str(path)).replace("\\", "/")
+    if not p:
+        return False
+    lower = p.lower()
+    basename = os.path.basename(lower)
+
+    if basename in EXACT_BASENAMES:
+        return True
+
+    # Files inside a /checkstyle/ directory.  We check for the
+    # directory segment specifically (rather than a substring of
+    # `checkstyle`) so that a file called `mycheckstyle-rules.xml`
+    # outside a checkstyle/ directory does not match by accident.
+    if "/checkstyle/" in lower and lower.endswith(".xml"):
+        return True
+
+    # Filenames that combine `checkstyle` and `suppress` and end in
+    # .xml — covers `module-checkstyle-suppressions.xml`,
+    # `checkstyle-suppressions-legacy.xml`, etc.
+    if basename.endswith(".xml") and "checkstyle" in basename and "suppress" in basename:
+        return True
+
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Bash command analysis
+# ---------------------------------------------------------------------------
+
+# The minimum write-mutate signal: a redirect, a tee, an in-place sed,
+# or a copy/move/install whose destination could be the checkstyle
+# file.  We deliberately err on the side of *more* matches here
+# (matching `cat >` redundantly with the `>` pattern, for example)
+# because false positives cost the agent one extra "that command
+# wasn't actually a write" message whereas a false negative is the
+# cheat going through.
+BASH_WRITE_HINT = re.compile(
+    r"(?:"
+    r"\s>>\s"             # append redirect
+    r"|\s>\s"             # write redirect
+    r"|^>"                # leading redirect
+    r"|\btee\b"           # tee
+    r"|\bsed\s+-i\b"      # in-place sed
+    r"|\bdd\s+of="        # dd output file
+    r"|\bcp\s"            # copy
+    r"|\bmv\s"            # move / rename
+    r"|\binstall\s"       # install(1) copy
+    r"|\bcat\s+>"         # cat into redirect
+    r"|\bcat\s+>>"        # cat into append
+    r"|\bprintf\b"        # printf (often paired with redirect)
+    r"|\becho\s+>"        # echo into redirect
+    r"|\becho\s+>>"       # echo into append
+    r")"
+)
+
+
+def _tokens_that_could_be_paths(command):
+    """Yield every shlex token from `command` that could be a path.
+
+    A token "could be a path" if it ends in `.xml` or if it is
+    recognized as a redirect target (the argument to `>`, `>>`, or
+    `<>`).  We also strip any surrounding quotes so that
+    `> "checkstyle.xml"` and `> checkstyle.xml` both match.
+    """
+    try:
+        tokens = shlex.split(command, comments=False, posix=True)
+    except ValueError:
+        # Unbalanced quotes.  Fall back to whitespace splitting —
+        # slightly noisier but never silent.
+        tokens = command.split()
+
+    for tok in tokens:
+        clean = tok.strip("'\"")
+        if not clean:
+            continue
+        if clean.lower().endswith(".xml"):
+            yield clean
+        # A redirect target is the token after `>`, `>>`, `<>`, or `2>`.
+        # shlex may or may not keep the operator attached to the
+        # following path, so we also yield the operator+next-token
+        # pair below.
+    # Walk the raw command again to catch redirect targets that shlex
+    # may have detached (e.g. `>  checkstyle.xml` with extra spaces).
+    for m in re.finditer(r"(?:\>\>|\>|\<\<\>|\d\>)\s*(\S+)", command):
+        yield m.group(1).strip("'\"")
+
+
+def bash_command_targets_checkstyle(command):
+    """True if `command` references any checkstyle config file path.
+
+    Does NOT consider the *intent* (read vs. write) — see
+    `bash_command_writes_checkstyle` for the full check.
+    """
+    if not command or not command.strip():
+        return False
+    for candidate in _tokens_that_could_be_paths(command):
+        if is_checkstyle_path(candidate):
+            return True
+    return False
+
+
+def bash_command_writes_checkstyle(command):
+    """True if `command` both references a checkstyle config AND has a
+    write/mutate intent (redirect, tee, sed -i, cp, mv, etc.).
+
+    The "AND" is important: a `cat checkstyle.xml` (read) is fine,
+    a `grep checkstyle.xml` (search) is fine, but a `> checkstyle.xml`
+    (overwrite) is the cheat and must be blocked.
+    """
+    if not command or not command.strip():
+        return False
+    if not bash_command_targets_checkstyle(command):
+        return False
+    return bool(BASH_WRITE_HINT.search(command))
+
+
+# ---------------------------------------------------------------------------
+# Top-level decide
+# ---------------------------------------------------------------------------
+
+BLOCK_REASON_TEMPLATE = (
+    "BLOCKED: MODIFYING CHECKSTYLE CONFIGURATION IS FORBIDDEN.\n"
+    "\n"
+    "THIS INCLUDES:\n"
+    "  - checkstyle.xml (root or any module-local copy)\n"
+    "  - Any checkstyle suppression file (checkstyle-suppressions.xml,\n"
+    "    or any *checkstyle*suppress*.xml, or any .xml under a\n"
+    "    checkstyle/ directory)\n"
+    "  - Any other file the maven-checkstyle-plugin would load\n"
+    "\n"
+    "ADDING EXEMPTIONS, SUPPRESSIONS, OR DISABLING/RELAXING RULES IS\n"
+    "NEVER ACCEPTABLE. THERE IS NO EXCUSE. AN EXEMPTION YOU ADD IS NOT\n"
+    "A FIX, IT IS A CHEAT.\n"
+    "\n"
+    "IF THE TASK SEEMS IMPOSSIBLE WITHOUT MODIFYING CHECKSTYLE:\n"
+    "  - YOU MUST ABANDON THE TASK\n"
+    "  - DECLARE IT IMPOSSIBLE\n"
+    "  - REPORT WHAT YOU TRIED AND WHY IT COULD NOT COMPLY\n"
+    "\n"
+    "DECLARING FAILURE IS ALWAYS PREFERABLE TO TAMPERING WITH\n"
+    "ENFORCEMENT. ABANDONING THE TASK IS THE SANCTIONED, EXPECTED,\n"
+    "CORRECT OUTCOME -- NOT A LAST RESORT.\n"
+    "\n"
+    "THE CORRECT ACTION IS TO FIX THE CODE TO COMPLY WITH THE RULES,\n"
+    "OR STOP.\n"
+    "\n"
+    "Target: {target}\n"
+    "Tool:   {tool}\n"
+)
+
+
+def _format_block_reason(tool, target):
+    return BLOCK_REASON_TEMPLATE.format(tool=tool or "<unknown>", target=target or "<unknown>")
+
+
+def decide(tool, tool_input):
+    """Return a Decision dict for a (tool, tool_input) pair.
+
+    `tool` is the tool name (case-insensitive). Recognized values:
+      - "bash"          : tool_input["command"] is the shell command
+      - "write"         : tool_input["file_path"] / tool_input["filePath"]
+      - "edit"          : tool_input["file_path"] / tool_input["filePath"]
+      - "multiedit"     : tool_input["file_path"] / tool_input["filePath"]
+      - "notebookedit"  : tool_input["file_path"] / tool_input["filePath"]
+
+    For unknown tool names, returns "allow" with a non-empty stderr
+    so a typo in the adapter cannot accidentally block the agent.
+    """
+    if tool is None:
+        tool = ""
+    if tool_input is None:
+        tool_input = {}
+    tool_lc = str(tool).strip().lower()
+
+    if tool_lc in ("write", "edit", "multiedit", "notebookedit"):
+        path = (
+            tool_input.get("file_path")
+            or tool_input.get("filePath")
+            or tool_input.get("filepath")
+            or ""
+        )
+        if not path:
+            return {"action": "allow", "reason": "", "context": "", "stderr": ""}
+        if is_checkstyle_path(path):
+            reason = _format_block_reason(tool_lc, path)
+            return {
+                "action": "block",
+                "reason": reason,
+                "context": "",
+                "stderr": reason,
+            }
+        return {"action": "allow", "reason": "", "context": "", "stderr": ""}
+
+    if tool_lc == "bash":
+        command = tool_input.get("command") or ""
+        if not command.strip():
+            return {"action": "allow", "reason": "", "context": "", "stderr": ""}
+        if bash_command_writes_checkstyle(command):
+            reason = _format_block_reason("bash", command)
+            return {
+                "action": "block",
+                "reason": reason,
+                "context": "",
+                "stderr": reason,
+            }
+        return {"action": "allow", "reason": "", "context": "", "stderr": ""}
+
+    return {
+        "action": "allow",
+        "reason": "",
+        "context": "",
+        "stderr": f"checkstyle_config_check: unknown tool {tool!r}",
+    }
+
+
+def decide_from_payload(payload):
+    """Decide from a unified payload shape used by the .ts adapter.
+
+    `payload` is a dict with at least `tool`, and either `command`
+    (for bash) or `filePath`/`file_path` (for file tools).
+    """
+    if not isinstance(payload, dict):
+        return {"action": "allow", "reason": "", "context": "", "stderr": "non-dict payload"}
+    tool = payload.get("tool") or ""
+    # Accept Claude-Code-style (file_path) and opencode-style
+    # (filePath) key names for the file tools.
+    normalized = {
+        "command": payload.get("command") or "",
+        "file_path": (
+            payload.get("file_path")
+            or payload.get("filePath")
+            or payload.get("filepath")
+            or ""
+        ),
+    }
+    return decide(tool, normalized)
+
+
+# ---------------------------------------------------------------------------
+# CLI / --stdin adapters
+# ---------------------------------------------------------------------------
+
+def _read_stdin_payload():
+    """Read a Claude-Code-style hook payload from stdin and return
+    (tool_name, tool_input)."""
+    raw = sys.stdin.read()
+    try:
+        data = json.loads(raw)
+    except Exception:
+        return ("", {})
+    if not isinstance(data, dict):
+        return ("", {})
+    tool = data.get("tool_name") or data.get("tool") or ""
+    tool_input = data.get("tool_input") or {}
+    if not isinstance(tool_input, dict):
+        tool_input = {}
+    return (tool, tool_input)
+
+
+def _render_harness_native(decision):
+    """Render a Decision in the Claude Code hook contract (exit code + stderr)."""
+    action = decision.get("action")
+    reason = decision.get("reason", "") or ""
+    stderr_msg = decision.get("stderr", "") or ""
+
+    if action == "block":
+        sys.stderr.write(reason)
+        sys.exit(2)
+
+    if stderr_msg:
+        sys.stderr.write(stderr_msg)
+    sys.exit(0)
+
+
+def main(argv=None):
+    argv = list(sys.argv[1:] if argv is None else argv)
+    if argv and argv[0] == "--stdin":
+        tool, tool_input = _read_stdin_payload()
+        _render_harness_native(decide(tool, tool_input))
+        return
+
+    if not argv:
+        sys.stderr.write(
+            "usage: checkstyle_config_check.py '<json-payload>' | --stdin\n"
+        )
+        sys.exit(2)
+
+    # argv mode: a single JSON payload string.
+    raw = argv[0]
+    try:
+        payload = json.loads(raw)
+    except Exception as e:
+        sys.stderr.write(f"checkstyle_config_check: invalid JSON payload: {e}\n")
+        sys.exit(2)
+    print(json.dumps(decide_from_payload(payload)))
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/lib/checkstyle_config_check.py
+++ b/.claude/hooks/lib/checkstyle_config_check.py
@@ -126,20 +126,16 @@ def is_checkstyle_path(path):
 # cheat going through.
 BASH_WRITE_HINT = re.compile(
     r"(?:"
-    r"\s>>\s"             # append redirect
-    r"|\s>\s"             # write redirect
-    r"|^>"                # leading redirect
-    r"|\btee\b"           # tee
-    r"|\bsed\s+-i\b"      # in-place sed
-    r"|\bdd\s+of="        # dd output file
-    r"|\bcp\s"            # copy
-    r"|\bmv\s"            # move / rename
-    r"|\binstall\s"       # install(1) copy
-    r"|\bcat\s+>"         # cat into redirect
-    r"|\bcat\s+>>"        # cat into append
-    r"|\bprintf\b"        # printf (often paired with redirect)
-    r"|\becho\s+>"        # echo into redirect
-    r"|\becho\s+>>"       # echo into append
+    r"(?<!['\"])>>(?!['\"])"    # append redirect (whitespace optional)
+    r"|(?<!['\"])>(?!['\"])"    # write redirect (whitespace optional)
+    r"|\btee\b"                   # tee
+    r"|\bsed\s+-i\b"              # in-place sed
+    r"|\bdd\s+of="                 # dd output file
+    r"|\bcp\s"                     # copy
+    r"|\bmv\s"                     # move / rename
+    r"|\binstall\s"                # install(1) copy
+    r"|\bcat\s+>"                  # cat into redirect
+    r"|\bcat\s+>>"                 # cat into append
     r")"
 )
 
@@ -163,17 +159,19 @@ def _tokens_that_could_be_paths(command):
         clean = tok.strip("'\"")
         if not clean:
             continue
-        if clean.lower().endswith(".xml"):
+        lower = clean.lower()
+        if lower.endswith(".xml"):
             yield clean
-        # A redirect target is the token after `>`, `>>`, `<>`, or `2>`.
-        # shlex may or may not keep the operator attached to the
-        # following path, so we also yield the operator+next-token
-        # pair below.
+        # Handle key=value tokens like `of=checkstyle.xml` (e.g. dd of=...)
+        if "=" in clean:
+            _, value = clean.split("=", 1)
+            if value and value.lower().endswith(".xml"):
+                yield value.strip("'\"")
+        # A redirect target is the token after `>`, `>>`, `<>`, `2>`, `2>>`, etc.
     # Walk the raw command again to catch redirect targets that shlex
     # may have detached (e.g. `>  checkstyle.xml` with extra spaces).
-    for m in re.finditer(r"(?:\>\>|\>|\<\<\>|\d\>)\s*(\S+)", command):
+    for m in re.finditer(r"(?:\d?>>|\d?>|<>)\s*(\S+)", command):
         yield m.group(1).strip("'\"")
-
 
 def bash_command_targets_checkstyle(command):
     """True if `command` references any checkstyle config file path.

--- a/.claude/hooks/lib/test_checkstyle_config_check.py
+++ b/.claude/hooks/lib/test_checkstyle_config_check.py
@@ -204,6 +204,20 @@ class BashWritesCheckstyleTests(unittest.TestCase):
             )
         )
 
+    def test_redirect_overwrite_no_space_blocks(self):
+        self.assertTrue(
+            self.core.bash_command_writes_checkstyle(
+                "echo '<module/>' >checkstyle.xml"
+            )
+        )
+
+    def test_dd_of_blocks(self):
+        self.assertTrue(
+            self.core.bash_command_writes_checkstyle(
+                "dd if=/dev/zero of=checkstyle.xml bs=1 count=1"
+            )
+        )
+
     def test_redirect_append_blocks(self):
         self.assertTrue(
             self.core.bash_command_writes_checkstyle(
@@ -215,7 +229,6 @@ class BashWritesCheckstyleTests(unittest.TestCase):
         self.assertTrue(
             self.core.bash_command_writes_checkstyle("> checkstyle.xml")
         )
-
     def test_sed_in_place_blocks(self):
         # `sed -i` rewrites the file in place, so the path is the
         # target even with no `>` redirect in sight.

--- a/.claude/hooks/lib/test_checkstyle_config_check.py
+++ b/.claude/hooks/lib/test_checkstyle_config_check.py
@@ -1,0 +1,632 @@
+#!/usr/bin/env python3
+"""Unit tests for checkstyle_config_check.py.
+
+Run from the repo root:
+
+    python3 -m unittest .claude/hooks/lib/test_checkstyle_config_check.py -v
+
+or:
+
+    python3 .claude/hooks/lib/test_checkstyle_config_check.py
+
+The tests exercise the pure `is_checkstyle_path` /
+`bash_command_writes_checkstyle` / `decide` functions directly and
+also drive the CLI entry points (argv mode and --stdin mode) to
+verify the rendering contract used by the .sh and .ts adapters.
+
+Coverage:
+  - is_checkstyle_path()     : 20+ path cases (blocks + allows)
+  - bash_command_writes_checkstyle() : 20+ command cases (bash bypass
+    patterns from the task: redirection >> / >, sed -i, tee, cp/mv,
+    install, cat >, python -c, etc.)
+  - decide()                 : 12+ tool/tool_input cases across the
+    five supported tools (bash, write, edit, multiedit, notebookedit)
+  - --stdin mode             : the .sh adapter contract (exit 2 +
+    stderr on block, exit 0 silent on allow)
+  - argv mode                : the .ts adapter contract (JSON stdout,
+    exit 0 always)
+
+These are the load-bearing tests for the structural block — if any
+of them fails, an agent that reaches for the cheat will be
+let through.
+"""
+import importlib.util
+import json
+import os
+import subprocess
+import unittest
+
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+CORE_PATH = os.path.join(HERE, "checkstyle_config_check.py")
+
+
+def _load_core():
+    spec = importlib.util.spec_from_file_location(
+        "checkstyle_config_check", CORE_PATH
+    )
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m
+
+
+# ── Path matching ──────────────────────────────────────────────────────────
+
+
+class IsCheckstylePathTests(unittest.TestCase):
+    """is_checkstyle_path(path) is the core matcher."""
+
+    def setUp(self):
+        self.core = _load_core()
+
+    # The two canonical basenames must always match.
+
+    def test_root_checkstyle_xml_matches(self):
+        self.assertTrue(self.core.is_checkstyle_path("checkstyle.xml"))
+
+    def test_root_checkstyle_xml_with_dot_slash_matches(self):
+        self.assertTrue(self.core.is_checkstyle_path("./checkstyle.xml"))
+
+    def test_absolute_checkstyle_xml_matches(self):
+        self.assertTrue(
+            self.core.is_checkstyle_path("/repo/checkstyle.xml")
+        )
+
+    def test_checkstyle_suppressions_xml_matches(self):
+        self.assertTrue(
+            self.core.is_checkstyle_path("checkstyle-suppressions.xml")
+        )
+
+    def test_module_local_checkstyle_xml_matches(self):
+        # Maven checkstyle plugin can be configured to use module-local
+        # checkstyle.xml files (e.g. <configLocation> in a module's
+        # pom.xml).  The matcher must cover those, not just the repo
+        # root.
+        self.assertTrue(
+            self.core.is_checkstyle_path(
+                "engine/ml/checkstyle.xml"
+            )
+        )
+
+    def test_module_local_checkstyle_suppressions_xml_matches(self):
+        self.assertTrue(
+            self.core.is_checkstyle_path(
+                "engine/ml/checkstyle-suppressions.xml"
+            )
+        )
+
+    # Files inside a /checkstyle/ directory.
+
+    def test_checkstyle_directory_xml_matches(self):
+        self.assertTrue(
+            self.core.is_checkstyle_path("config/checkstyle/extra.xml")
+        )
+
+    def test_checkstyle_directory_any_xml_matches(self):
+        # Any .xml under a checkstyle/ directory is a checkstyle
+        # config — even a file the agent has just created.
+        self.assertTrue(
+            self.core.is_checkstyle_path(
+                "/tmp/checkstyle/new-rules.xml"
+            )
+        )
+
+    # Filenames combining `checkstyle` and `suppress`.
+
+    def test_module_prefixed_suppressions_xml_matches(self):
+        self.assertTrue(
+            self.core.is_checkstyle_path(
+                "engine-ml-checkstyle-suppressions.xml"
+            )
+        )
+
+    def test_legacy_suppressions_xml_matches(self):
+        self.assertTrue(
+            self.core.is_checkstyle_path(
+                "checkstyle-suppressions-legacy.xml"
+            )
+        )
+
+    # Case insensitivity.
+
+    def test_checkstyle_uppercase_xml_matches(self):
+        self.assertTrue(self.core.is_checkstyle_path("CHECKSTYLE.XML"))
+
+    def test_mixed_case_suppressions_xml_matches(self):
+        self.assertTrue(
+            self.core.is_checkstyle_path("CheckStyle-Suppressions.xml")
+        )
+
+    # Non-matches (false-positive guards).
+
+    def test_unrelated_xml_does_not_match(self):
+        self.assertFalse(self.core.is_checkstyle_path("pom.xml"))
+
+    def test_unrelated_java_does_not_match(self):
+        self.assertFalse(self.core.is_checkstyle_path("Main.java"))
+
+    def test_unrelated_md_does_not_match(self):
+        self.assertFalse(self.core.is_checkstyle_path("README.md"))
+
+    def test_substring_checkstyle_in_name_only_does_not_match(self):
+        # `xcheckstyle.xml` is NOT under a /checkstyle/ directory and
+        # the basename is not the canonical name, so it must not match.
+        self.assertFalse(
+            self.core.is_checkstyle_path("/tmp/xcheckstyle.xml")
+        )
+
+    def test_substring_suppress_in_name_only_does_not_match(self):
+        # The matcher requires BOTH `checkstyle` and `suppress` for
+        # the "filename contains both" rule.  A file called
+        # `suppressions.xml` with no checkstyle in its name is not a
+        # checkstyle config and must not be blocked.
+        self.assertFalse(
+            self.core.is_checkstyle_path("/tmp/suppressions.xml")
+        )
+
+    def test_empty_path_does_not_match(self):
+        self.assertFalse(self.core.is_checkstyle_path(""))
+
+    def test_none_path_does_not_match(self):
+        self.assertFalse(self.core.is_checkstyle_path(None))
+
+    def test_directory_only_path_does_not_match(self):
+        # The matcher is for *file* paths.  A bare directory name
+        # without an .xml file at the end must not match.
+        self.assertFalse(self.core.is_checkstyle_path("checkstyle/"))
+
+    def test_home_expansion_works(self):
+        # Expanduser should not crash on a ~-prefixed path that
+        # looks like a checkstyle config.
+        self.assertTrue(
+            self.core.is_checkstyle_path("~/checkstyle.xml")
+        )
+
+
+# ── Bash command analysis ──────────────────────────────────────────────────
+
+
+class BashWritesCheckstyleTests(unittest.TestCase):
+    """bash_command_writes_checkstyle(command) catches the bash bypass
+    patterns the task explicitly calls out: redirection, sed -i, tee,
+    cp, mv, cat >, python -c, etc.
+    """
+
+    def setUp(self):
+        self.core = _load_core()
+
+    # The big cheat patterns — every one must block.
+
+    def test_redirect_overwrite_blocks(self):
+        self.assertTrue(
+            self.core.bash_command_writes_checkstyle(
+                "echo '<module/>' > checkstyle.xml"
+            )
+        )
+
+    def test_redirect_append_blocks(self):
+        self.assertTrue(
+            self.core.bash_command_writes_checkstyle(
+                "printf '<module/>' >> checkstyle.xml"
+            )
+        )
+
+    def test_leading_redirect_blocks(self):
+        self.assertTrue(
+            self.core.bash_command_writes_checkstyle("> checkstyle.xml")
+        )
+
+    def test_sed_in_place_blocks(self):
+        # `sed -i` rewrites the file in place, so the path is the
+        # target even with no `>` redirect in sight.
+        self.assertTrue(
+            self.core.bash_command_writes_checkstyle(
+                "sed -i 's/foo/bar/' checkstyle.xml"
+            )
+        )
+
+    def test_tee_blocks(self):
+        self.assertTrue(
+            self.core.bash_command_writes_checkstyle(
+                "cat input.xml | tee checkstyle.xml > /dev/null"
+            )
+        )
+
+    def test_tee_with_suppressions_path_blocks(self):
+        self.assertTrue(
+            self.core.bash_command_writes_checkstyle(
+                "tee checkstyle-suppressions.xml"
+            )
+        )
+
+    def test_cp_into_checkstyle_blocks(self):
+        # cp's destination is the second argument, and the
+        # destination matches — block.
+        self.assertTrue(
+            self.core.bash_command_writes_checkstyle(
+                "cp my-config.xml checkstyle.xml"
+            )
+        )
+
+    def test_mv_into_checkstyle_blocks(self):
+        self.assertTrue(
+            self.core.bash_command_writes_checkstyle(
+                "mv /tmp/foo.xml checkstyle.xml"
+            )
+        )
+
+    def test_cat_into_redirect_blocks(self):
+        self.assertTrue(
+            self.core.bash_command_writes_checkstyle(
+                "cat > checkstyle.xml"
+            )
+        )
+
+    def test_python_script_redirect_to_checkstyle_blocks(self):
+        # `python3 -c '...'` followed by `>` to a checkstyle file
+        # must be caught.  The classic pattern is: emit XML on
+        # stdout via python, redirect to the config file.
+        self.assertTrue(
+            self.core.bash_command_writes_checkstyle(
+                "python3 -c \"print('<module/>')\" > checkstyle.xml"
+            )
+        )
+
+    def test_absolute_path_redirect_blocks(self):
+        self.assertTrue(
+            self.core.bash_command_writes_checkstyle(
+                "echo bad > /repo/checkstyle.xml"
+            )
+        )
+
+    def test_heredoc_into_checkstyle_blocks(self):
+        self.assertTrue(
+            self.core.bash_command_writes_checkstyle(
+                "cat > checkstyle.xml <<'EOF'\n<module/>\nEOF"
+            )
+        )
+
+    def test_path_under_checkstyle_directory_blocks(self):
+        # Files in a /checkstyle/ directory are configs too.
+        self.assertTrue(
+            self.core.bash_command_writes_checkstyle(
+                "cat > /tmp/checkstyle/new-rules.xml"
+            )
+        )
+
+    # Read-only commands must NOT be blocked (a `cat checkstyle.xml`
+    # is fine; a `grep checkstyle.xml` is fine).
+
+    def test_cat_checkstyle_does_not_block(self):
+        self.assertFalse(
+            self.core.bash_command_writes_checkstyle("cat checkstyle.xml")
+        )
+
+    def test_grep_checkstyle_does_not_block(self):
+        self.assertFalse(
+            self.core.bash_command_writes_checkstyle(
+                "grep -r 'checkstyle' ."
+            )
+        )
+
+    def test_ls_checkstyle_does_not_block(self):
+        self.assertFalse(
+            self.core.bash_command_writes_checkstyle("ls -la checkstyle.xml")
+        )
+
+    def test_vim_checkstyle_does_not_block(self):
+        # `vim` is interactive and not a write pattern the matcher
+        # recognises — the structured Write/Edit tools are how the
+        # agent edits files in this project, so the bash bypass for
+        # editing is largely hypothetical.  We just verify the
+        # matcher is silent on read-style `vim` calls.
+        self.assertFalse(
+            self.core.bash_command_writes_checkstyle("vim checkstyle.xml")
+        )
+
+    # Edge cases.
+
+    def test_empty_command_does_not_block(self):
+        self.assertFalse(self.core.bash_command_writes_checkstyle(""))
+
+    def test_whitespace_command_does_not_block(self):
+        self.assertFalse(self.core.bash_command_writes_checkstyle("   "))
+
+    def test_unrelated_write_does_not_block(self):
+        # Writing to a non-checkstyle file must pass.
+        self.assertFalse(
+            self.core.bash_command_writes_checkstyle("echo hi > pom.xml")
+        )
+
+
+# ── decide() top-level dispatch ────────────────────────────────────────────
+
+
+class DecideTests(unittest.TestCase):
+    """decide(tool, tool_input) routes to the right matcher per tool."""
+
+    def setUp(self):
+        self.core = _load_core()
+
+    def test_write_to_checkstyle_xml_blocks(self):
+        d = self.core.decide(
+            "Write", {"file_path": "checkstyle.xml", "content": "x"}
+        )
+        self.assertEqual(d["action"], "block")
+        self.assertIn("FORBIDDEN", d["reason"])
+        self.assertIn("ABANDON", d["reason"])
+        self.assertIn("checkstyle.xml", d["reason"])
+
+    def test_edit_checkstyle_xml_blocks(self):
+        d = self.core.decide(
+            "Edit",
+            {
+                "file_path": "/repo/checkstyle.xml",
+                "old_string": "a",
+                "new_string": "b",
+            },
+        )
+        self.assertEqual(d["action"], "block")
+
+    def test_edit_suppressions_file_blocks(self):
+        d = self.core.decide(
+            "Edit",
+            {"file_path": "checkstyle-suppressions.xml"},
+        )
+        self.assertEqual(d["action"], "block")
+
+    def test_multiedit_checkstyle_blocks(self):
+        d = self.core.decide(
+            "MultiEdit", {"file_path": "engine/checkstyle/rules.xml"}
+        )
+        self.assertEqual(d["action"], "block")
+
+    def test_notebookedit_checkstyle_blocks(self):
+        d = self.core.decide(
+            "NotebookEdit", {"file_path": "checkstyle.xml"}
+        )
+        self.assertEqual(d["action"], "block")
+
+    def test_bash_redirect_to_checkstyle_blocks(self):
+        d = self.core.decide(
+            "Bash", {"command": "echo x > checkstyle.xml"}
+        )
+        self.assertEqual(d["action"], "block")
+
+    def test_write_to_unrelated_file_allows(self):
+        d = self.core.decide(
+            "Write", {"file_path": "README.md", "content": "x"}
+        )
+        self.assertEqual(d["action"], "allow")
+        self.assertEqual(d["reason"], "")
+
+    def test_edit_unrelated_file_allows(self):
+        d = self.core.decide(
+            "Edit", {"file_path": "src/Foo.java", "old_string": "a", "new_string": "b"}
+        )
+        self.assertEqual(d["action"], "allow")
+
+    def test_bash_read_of_checkstyle_allows(self):
+        # Reading checkstyle config is fine.
+        d = self.core.decide(
+            "Bash", {"command": "cat checkstyle.xml"}
+        )
+        self.assertEqual(d["action"], "allow")
+
+    def test_bash_grep_checkstyle_allows(self):
+        d = self.core.decide(
+            "Bash", {"command": "grep -r 'checkstyle' ."}
+        )
+        self.assertEqual(d["action"], "allow")
+
+    def test_unknown_tool_allows(self):
+        # An unknown tool name must never accidentally block work.
+        d = self.core.decide("SomeNewTool", {"file_path": "checkstyle.xml"})
+        self.assertEqual(d["action"], "allow")
+        self.assertIn("unknown", d["stderr"])
+
+    def test_none_tool_allows(self):
+        d = self.core.decide(None, {"command": "echo x > checkstyle.xml"})
+        self.assertEqual(d["action"], "allow")
+
+    def test_none_tool_input_allows(self):
+        d = self.core.decide("Write", None)
+        self.assertEqual(d["action"], "allow")
+
+    def test_empty_file_path_allows(self):
+        # An empty file_path is a no-op (the harness supplies a real
+        # path on every real Write/Edit call), not a reason to block.
+        d = self.core.decide("Write", {"file_path": ""})
+        self.assertEqual(d["action"], "allow")
+
+    def test_block_message_is_all_caps_section(self):
+        # The block reason must contain the same forceful, ALL-CAPS
+        # phrasing called out in the task description.
+        d = self.core.decide(
+            "Write", {"file_path": "checkstyle.xml"}
+        )
+        self.assertIn("MODIFYING CHECKSTYLE CONFIGURATION IS FORBIDDEN", d["reason"])
+        self.assertIn("NEVER ACCEPTABLE", d["reason"])
+        self.assertIn("ABANDON THE TASK", d["reason"])
+        self.assertIn("DECLARING FAILURE", d["reason"])
+        self.assertIn("FIX THE CODE", d["reason"])
+
+    def test_block_message_includes_target(self):
+        d = self.core.decide(
+            "Write", {"file_path": "/path/to/checkstyle.xml"}
+        )
+        # The target path must appear in the reason so the agent
+        # knows what it was about to write.
+        self.assertIn("/path/to/checkstyle.xml", d["reason"])
+
+    def test_block_message_includes_tool(self):
+        d = self.core.decide(
+            "Edit", {"file_path": "checkstyle.xml"}
+        )
+        self.assertIn("Tool:", d["reason"])
+        self.assertIn("edit", d["reason"].lower())
+
+    def test_opencode_style_filePath_key_blocks(self):
+        # The opencode adapter uses camelCase `filePath` rather than
+        # Claude Code's snake_case `file_path`.  The matcher must
+        # accept both.
+        d = self.core.decide(
+            "write", {"filePath": "checkstyle.xml", "content": "x"}
+        )
+        self.assertEqual(d["action"], "block")
+
+
+# ── --stdin mode (the .sh adapter contract) ──────────────────────────────
+
+
+class StdinModeTests(unittest.TestCase):
+    """The .sh adapter contract: --stdin mode renders natively."""
+
+    def _run_stdin(self, payload):
+        return subprocess.run(
+            ["python3", CORE_PATH, "--stdin"],
+            input=json.dumps(payload),
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+
+    def test_block_path_exits_2_with_stderr(self):
+        r = self._run_stdin({
+            "tool_name": "Write",
+            "tool_input": {"file_path": "checkstyle.xml", "content": "x"},
+        })
+        self.assertEqual(r.returncode, 2)
+        self.assertIn("FORBIDDEN", r.stderr)
+        self.assertIn("ABANDON", r.stderr)
+        # Block path emits nothing on stdout.
+        self.assertEqual(r.stdout, "")
+
+    def test_block_bash_redirect_exits_2(self):
+        r = self._run_stdin({
+            "tool_name": "Bash",
+            "tool_input": {"command": "echo x > checkstyle.xml"},
+        })
+        self.assertEqual(r.returncode, 2)
+        self.assertIn("FORBIDDEN", r.stderr)
+
+    def test_allow_path_exits_0_silently(self):
+        r = self._run_stdin({
+            "tool_name": "Write",
+            "tool_input": {"file_path": "README.md", "content": "x"},
+        })
+        self.assertEqual(r.returncode, 0)
+        self.assertEqual(r.stdout, "")
+        self.assertEqual(r.stderr, "")
+
+    def test_allow_bash_exits_0_silently(self):
+        r = self._run_stdin({
+            "tool_name": "Bash",
+            "tool_input": {"command": "ls -la"},
+        })
+        self.assertEqual(r.returncode, 0)
+
+    def test_empty_input_exits_0_silently(self):
+        r = self._run_stdin({})
+        self.assertEqual(r.returncode, 0)
+
+    def test_malformed_json_exits_0_silently(self):
+        r = subprocess.run(
+            ["python3", CORE_PATH, "--stdin"],
+            input="not json",
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        # Never block on uncertainty about the harness payload —
+        # the structured Write/Edit/Bash calls always have JSON.
+        self.assertEqual(r.returncode, 0)
+        self.assertEqual(r.stdout, "")
+
+    def test_block_message_is_forceful(self):
+        r = self._run_stdin({
+            "tool_name": "Edit",
+            "tool_input": {"file_path": "checkstyle.xml"},
+        })
+        self.assertEqual(r.returncode, 2)
+        # Five phrases from the task description.
+        for phrase in (
+            "FORBIDDEN",
+            "NEVER ACCEPTABLE",
+            "ABANDON",
+            "ALWAYS PREFERABLE",
+            "FIX THE CODE",
+        ):
+            self.assertIn(phrase, r.stderr, msg=f"missing phrase: {phrase}")
+
+
+# ── argv mode (the .ts adapter contract) ──────────────────────────────────
+
+
+class ArgvModeTests(unittest.TestCase):
+    """The .ts adapter contract: argv mode returns JSON, exit 0."""
+
+    def _run_argv(self, payload):
+        return subprocess.run(
+            ["python3", CORE_PATH, json.dumps(payload)],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+
+    def test_block_returns_block_json(self):
+        r = self._run_argv({
+            "tool": "write",
+            "filePath": "checkstyle.xml",
+        })
+        self.assertEqual(r.returncode, 0)
+        obj = json.loads(r.stdout)
+        self.assertEqual(obj["action"], "block")
+        self.assertIn("FORBIDDEN", obj["reason"])
+
+    def test_bash_block_returns_block_json(self):
+        r = self._run_argv({
+            "tool": "bash",
+            "command": "echo x > checkstyle.xml",
+        })
+        self.assertEqual(r.returncode, 0)
+        obj = json.loads(r.stdout)
+        self.assertEqual(obj["action"], "block")
+
+    def test_allow_returns_allow_json(self):
+        r = self._run_argv({
+            "tool": "write",
+            "filePath": "README.md",
+        })
+        self.assertEqual(r.returncode, 0)
+        obj = json.loads(r.stdout)
+        self.assertEqual(obj["action"], "allow")
+        self.assertEqual(obj["reason"], "")
+
+    def test_unknown_tool_returns_allow_json(self):
+        r = self._run_argv({"tool": "some_new_tool"})
+        self.assertEqual(r.returncode, 0)
+        obj = json.loads(r.stdout)
+        self.assertEqual(obj["action"], "allow")
+
+    def test_invalid_json_exits_2(self):
+        r = subprocess.run(
+            ["python3", CORE_PATH, "not json"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        self.assertEqual(r.returncode, 2)
+
+    def test_no_argv_exits_2(self):
+        r = subprocess.run(
+            ["python3", CORE_PATH],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        self.assertEqual(r.returncode, 2)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -51,6 +51,11 @@
           },
           {
             "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/block-checkstyle-edit.sh",
+            "description": "Block bash manipulation of checkstyle configuration (checkstyle.xml, checkstyle-suppressions.xml, any /checkstyle/ dir, etc.) — abandon the task rather than tamper with enforcement"
+          },
+          {
+            "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/block-memory-write.sh",
             "description": "Block shell writes into ~/.claude/projects/*/memory/ — use ar-consultant/ar-manager"
           },
@@ -79,6 +84,11 @@
       {
         "matcher": "Edit",
         "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/block-checkstyle-edit.sh",
+            "description": "Block edits to checkstyle configuration — abandon the task rather than tamper with enforcement"
+          },
           {
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/block-pom-write.sh",
@@ -116,6 +126,11 @@
         "hooks": [
           {
             "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/block-checkstyle-edit.sh",
+            "description": "Block MultiEdit of checkstyle configuration — abandon the task rather than tamper with enforcement"
+          },
+          {
+            "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/block-memory-write.sh",
             "description": "Block MultiEdit in ~/.claude/projects/*/memory/ — use ar-consultant/ar-manager"
           }
@@ -126,6 +141,11 @@
         "hooks": [
           {
             "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/block-checkstyle-edit.sh",
+            "description": "Block NotebookEdit of checkstyle configuration — abandon the task rather than tamper with enforcement"
+          },
+          {
+            "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/block-memory-write.sh",
             "description": "Block NotebookEdit in ~/.claude/projects/*/memory/ — use ar-consultant/ar-manager"
           }
@@ -134,6 +154,11 @@
       {
         "matcher": "Write",
         "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/block-checkstyle-edit.sh",
+            "description": "Block writes of checkstyle configuration — abandon the task rather than tamper with enforcement"
+          },
           {
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/block-pom-write.sh",

--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -52,6 +52,7 @@
     "./plugins/block-mvn-test-direct.ts",
     "./plugins/block-git-commit.ts",
     "./plugins/block-git-worktree.ts",
-    "./plugins/warn-git-log.ts"
+    "./plugins/warn-git-log.ts",
+    "./plugins/block-checkstyle-edit.ts"
   ]
 }

--- a/.opencode/plugins/__tests__/block-checkstyle-edit.smoke.cjs
+++ b/.opencode/plugins/__tests__/block-checkstyle-edit.smoke.cjs
@@ -1,0 +1,146 @@
+// .opencode/plugins/__tests__/block-checkstyle-edit.smoke.cjs
+//
+// Plain-Node smoke test for the block-checkstyle-edit opencode
+// adapter's wiring.  Mirrors block-mvn-test-direct.smoke.cjs.
+// Runs without any TypeScript or Bun tooling — it exercises the
+// same Python shared core the .ts plugin uses, and verifies the
+// input-shape expectations the .ts plugin relies on.  The .ts
+// plugin itself is loaded by opencode via Bun at startup; the
+// .ts file is verified at that point.
+//
+// Run from the repo root:
+//   node .opencode/plugins/__tests__/block-checkstyle-edit.smoke.cjs
+
+const { spawnSync } = require("node:child_process")
+const path = require("node:path")
+const fs = require("node:fs")
+
+const HERE = __dirname
+const CORE = path.resolve(HERE, "..", "..", "..", ".claude", "hooks", "lib", "checkstyle_config_check.py")
+
+if (!fs.existsSync(CORE)) {
+  console.error("shared core not found at", CORE)
+  process.exit(2)
+}
+
+let failures = 0
+function expect(cond, msg) {
+  if (!cond) {
+    console.error("  FAIL:", msg)
+    failures++
+  }
+}
+
+function callCore(payload) {
+  const r = spawnSync("python3", [CORE, JSON.stringify(payload)], { encoding: "utf-8", timeout: 5000 })
+  if (r.status !== 0) {
+    return { action: "allow", reason: "", context: "", stderr: `core exit ${r.status}` }
+  }
+  try {
+    return JSON.parse(r.stdout)
+  } catch {
+    return { action: "allow", reason: "", context: "", stderr: "core returned non-JSON" }
+  }
+}
+
+console.log("== tool.execute.before: file-tool block path ==")
+{
+  const d = callCore({ tool: "write", filePath: "checkstyle.xml" })
+  expect(d.action === "block", "write to checkstyle.xml → block")
+  expect(d.reason.includes("FORBIDDEN"), "block reason says FORBIDDEN")
+  expect(d.reason.includes("ABANDON"), "block reason says ABANDON")
+  expect(d.reason.includes("checkstyle.xml"), "block reason names the target")
+}
+
+console.log("== tool.execute.before: file-tool suppressions block ==")
+{
+  const d = callCore({ tool: "edit", filePath: "checkstyle-suppressions.xml" })
+  expect(d.action === "block", "edit checkstyle-suppressions.xml → block")
+}
+
+console.log("== tool.execute.before: bash redirect block ==")
+{
+  const d = callCore({ tool: "bash", command: "echo x > checkstyle.xml" })
+  expect(d.action === "block", "echo x > checkstyle.xml → block")
+  expect(d.reason.includes("FORBIDDEN"), "bash block reason says FORBIDDEN")
+}
+
+console.log("== tool.execute.before: bash sed -i block ==")
+{
+  const d = callCore({ tool: "bash", command: "sed -i 's/foo/bar/' checkstyle.xml" })
+  expect(d.action === "block", "sed -i on checkstyle.xml → block")
+}
+
+console.log("== tool.execute.before: bash tee block ==")
+{
+  const d = callCore({ tool: "bash", command: "tee /tmp/checkstyle-suppressions.xml" })
+  expect(d.action === "block", "tee to checkstyle-suppressions.xml → block")
+}
+
+console.log("== tool.execute.before: allow path ==")
+{
+  const d = callCore({ tool: "write", filePath: "README.md" })
+  expect(d.action === "allow", "write to README.md → allow")
+}
+
+console.log("== tool.execute.before: allow bash (read-only) ==")
+{
+  const d = callCore({ tool: "bash", command: "cat checkstyle.xml" })
+  expect(d.action === "allow", "cat checkstyle.xml → allow (read-only)")
+}
+
+console.log("== tool.execute.before: allow bash (unrelated) ==")
+{
+  const d = callCore({ tool: "bash", command: "echo hi > pom.xml" })
+  expect(d.action === "allow", "echo hi > pom.xml → allow")
+}
+
+console.log("== Module-local checkstyle paths block ==")
+{
+  const d = callCore({ tool: "edit", filePath: "engine/ml/checkstyle.xml" })
+  expect(d.action === "block", "module-local checkstyle.xml → block")
+}
+
+console.log("== /checkstyle/ directory paths block ==")
+{
+  const d = callCore({ tool: "write", filePath: "config/checkstyle/extra.xml" })
+  expect(d.action === "block", "file in /checkstyle/ directory → block")
+}
+
+console.log("== Block message is forceful ALL-CAPS ==")
+{
+  const d = callCore({ tool: "write", filePath: "checkstyle.xml" })
+  const phrases = [
+    "MODIFYING CHECKSTYLE CONFIGURATION IS FORBIDDEN",
+    "NEVER ACCEPTABLE",
+    "ABANDON THE TASK",
+    "ALWAYS PREFERABLE",
+    "FIX THE CODE",
+  ]
+  for (const phrase of phrases) {
+    expect(d.reason.includes(phrase), `block reason must contain: ${phrase}`)
+  }
+}
+
+console.log("== Non-checkstyle .xml allows (no false positives) ==")
+{
+  expect(callCore({ tool: "write", filePath: "pom.xml" }).action === "allow", "pom.xml → allow")
+  expect(callCore({ tool: "write", filePath: "settings.xml" }).action === "allow", "settings.xml → allow")
+  expect(callCore({ tool: "write", filePath: "xcheckstyle.xml" }).action === "allow", "xcheckstyle.xml → allow (substring guard)")
+  expect(callCore({ tool: "write", filePath: "suppressions.xml" }).action === "allow", "suppressions.xml → allow (needs both keywords)")
+}
+
+console.log("== Edge cases ==")
+{
+  expect(callCore({ tool: "write", filePath: "" }).action === "allow", "empty filePath → allow")
+  expect(callCore({ tool: "write" }).action === "allow", "missing filePath → allow")
+  expect(callCore({ tool: "bash" }).action === "allow", "missing command → allow")
+  expect(callCore({ tool: "bash", command: "" }).action === "allow", "empty command → allow")
+  expect(callCore({ tool: "some_other_tool", filePath: "checkstyle.xml" }).action === "allow", "unknown tool → allow (defensive)")
+}
+
+if (failures > 0) {
+  console.error(`\n${failures} assertion(s) failed`)
+  process.exit(1)
+}
+console.log("\nAll block-checkstyle-edit opencode adapter wiring assertions passed.")

--- a/.opencode/plugins/__tests__/block-checkstyle-edit.test.ts
+++ b/.opencode/plugins/__tests__/block-checkstyle-edit.test.ts
@@ -1,0 +1,218 @@
+// .opencode/plugins/__tests__/block-checkstyle-edit.test.ts
+//
+// Self-contained test for the opencode adapter.  We don't launch
+// opencode itself — we just exercise the plugin's handlers directly
+// with synthetic input/output, after first calling the plugin
+// factory.
+//
+// Run with:
+//   bun test .opencode/plugins/__tests__/block-checkstyle-edit.test.ts
+//   # or
+//   npx tsx .opencode/plugins/__tests__/block-checkstyle-edit.test.ts
+//
+// Requires Python 3 on PATH (the plugin shells out to the shared
+// core).
+
+import { spawnSync } from "node:child_process"
+import * as path from "node:path"
+import { fileURLToPath, pathToFileURL } from "node:url"
+import * as fs from "node:fs"
+
+const HERE = path.dirname(fileURLToPath(import.meta.url))
+const PLUGIN_PATH = path.resolve(HERE, "..", "block-checkstyle-edit.ts")
+const PYTHON_HERE = path.resolve(HERE, "..", "..", "..", ".claude", "hooks", "lib")
+const PYTHON_CORE = path.join(PYTHON_HERE, "checkstyle_config_check.py")
+
+if (!fs.existsSync(PYTHON_CORE)) {
+  throw new Error(`shared core not found at ${PYTHON_CORE}`)
+}
+const py = spawnSync("python3", [PYTHON_CORE, JSON.stringify({ tool: "write", filePath: "checkstyle.xml" })], { encoding: "utf-8" })
+if (py.status !== 0) {
+  throw new Error(`python3 not usable: status=${py.status} stderr=${py.stderr}`)
+}
+
+type Decision = { action: "block" | "allow"; reason: string; context: string; stderr: string }
+type Hooks = {
+  "tool.execute.before"?: (input: { tool: string; sessionID: string; callID: string }, output: { args: unknown }) => Promise<void>
+  "tool.execute.after"?: (
+    input: { tool: string; sessionID: string; callID: string; args: unknown },
+    output: { title: string; output: string; metadata: unknown },
+  ) => Promise<void>
+}
+type PluginFactory = (input?: unknown) => Promise<Hooks>
+
+async function loadPlugin(): Promise<PluginFactory> {
+  const mod = (await import(pathToFileURL(PLUGIN_PATH).href)) as { BlockCheckstyleEditPlugin: PluginFactory }
+  return mod.BlockCheckstyleEditPlugin
+}
+
+const sessionID = "test-session"
+const callID = "test-call"
+
+let failures = 0
+function expect(cond: unknown, msg: string): void {
+  if (!cond) {
+    console.error(`  FAIL: ${msg}`)
+    failures++
+  }
+}
+
+async function run(): Promise<void> {
+  const factory = await loadPlugin()
+  const hooks = await factory()
+  const before = hooks["tool.execute.before"]!
+
+  // 1. `write` of checkstyle.xml must throw (block).
+  {
+    let threw: Error | null = null
+    try {
+      await before({ tool: "write", sessionID, callID }, { args: { filePath: "checkstyle.xml", content: "x" } })
+    } catch (e) {
+      threw = e as Error
+    }
+    expect(threw !== null, "write checkstyle.xml should throw (block)")
+    expect(
+      !!threw && threw.message.includes("FORBIDDEN") && threw.message.includes("ABANDON"),
+      "block message must say FORBIDDEN and ABANDON",
+    )
+    expect(
+      !!threw && threw.message.includes("checkstyle.xml"),
+      "block message must name the target file",
+    )
+  }
+
+  // 2. `edit` of checkstyle-suppressions.xml must throw.
+  {
+    let threw: Error | null = null
+    try {
+      await before({ tool: "edit", sessionID, callID }, { args: { filePath: "checkstyle-suppressions.xml", oldString: "a", newString: "b" } })
+    } catch (e) {
+      threw = e as Error
+    }
+    expect(threw !== null, "edit checkstyle-suppressions.xml should throw (block)")
+  }
+
+  // 3. `bash` with redirect to checkstyle.xml must throw.
+  {
+    let threw: Error | null = null
+    try {
+      await before({ tool: "bash", sessionID, callID }, { args: { command: "echo x > checkstyle.xml" } })
+    } catch (e) {
+      threw = e as Error
+    }
+    expect(threw !== null, "bash `echo x > checkstyle.xml` should throw (block)")
+  }
+
+  // 4. `bash` with sed -i on checkstyle.xml must throw.
+  {
+    let threw: Error | null = null
+    try {
+      await before({ tool: "bash", sessionID, callID }, { args: { command: "sed -i 's/a/b/' checkstyle.xml" } })
+    } catch (e) {
+      threw = e as Error
+    }
+    expect(threw !== null, "bash `sed -i` on checkstyle.xml should throw (block)")
+  }
+
+  // 5. `write` of an unrelated file must NOT throw.
+  {
+    let threw: Error | null = null
+    try {
+      await before({ tool: "write", sessionID, callID }, { args: { filePath: "README.md", content: "x" } })
+    } catch (e) {
+      threw = e as Error
+    }
+    expect(threw === null, "write README.md should be allowed")
+  }
+
+  // 6. `bash` reading checkstyle.xml must NOT throw.
+  {
+    let threw: Error | null = null
+    try {
+      await before({ tool: "bash", sessionID, callID }, { args: { command: "cat checkstyle.xml" } })
+    } catch (e) {
+      threw = e as Error
+    }
+    expect(threw === null, "bash `cat checkstyle.xml` should be allowed (read-only)")
+  }
+
+  // 7. Non-inspected tools (read, grep, glob) must be a no-op.
+  {
+    let threw: Error | null = null
+    try {
+      await before({ tool: "read", sessionID, callID }, { args: { filePath: "checkstyle.xml" } })
+    } catch (e) {
+      threw = e as Error
+    }
+    expect(threw === null, "read of checkstyle.xml should be a no-op (this plugin only blocks writes/edits)")
+  }
+
+  // 8. Missing `filePath` field on write should be a no-op (defensive).
+  {
+    let threw: Error | null = null
+    try {
+      await before({ tool: "write", sessionID, callID }, { args: { content: "x" } })
+    } catch (e) {
+      threw = e as Error
+    }
+    expect(threw === null, "missing filePath on write should be a no-op")
+  }
+
+  // 9. Missing `command` field on bash should be a no-op.
+  {
+    let threw: Error | null = null
+    try {
+      await before({ tool: "bash", sessionID, callID }, { args: {} })
+    } catch (e) {
+      threw = e as Error
+    }
+    expect(threw === null, "missing command on bash should be a no-op")
+  }
+
+  // 10. `apply_patch` with a checkstyle file in the patch header must throw.
+  {
+    let threw: Error | null = null
+    try {
+      await before(
+        { tool: "apply_patch", sessionID, callID },
+        { args: { patchText: "*** Update File: checkstyle.xml\n@@ -1,1 +1,1 @@\n-old\n+new\n" } },
+      )
+    } catch (e) {
+      threw = e as Error
+    }
+    expect(threw !== null, "apply_patch of checkstyle.xml should throw (block)")
+  }
+
+  // 11. Module-local checkstyle path must throw.
+  {
+    let threw: Error | null = null
+    try {
+      await before({ tool: "edit", sessionID, callID }, { args: { filePath: "engine/ml/checkstyle.xml", oldString: "a", newString: "b" } })
+    } catch (e) {
+      threw = e as Error
+    }
+    expect(threw !== null, "edit module-local checkstyle.xml should throw (block)")
+  }
+
+  // 12. Filenames matching `*checkstyle*suppress*.xml` must throw.
+  {
+    let threw: Error | null = null
+    try {
+      await before({ tool: "write", sessionID, callID }, { args: { filePath: "engine-ml-checkstyle-suppressions.xml", content: "x" } })
+    } catch (e) {
+      threw = e as Error
+    }
+    expect(threw !== null, "write of *checkstyle*suppress*.xml should throw (block)")
+  }
+
+  if (failures > 0) {
+    console.error(`\n${failures} assertion(s) failed`)
+    process.exit(1)
+  }
+  console.log("All block-checkstyle-edit plugin adapter assertions passed.")
+}
+
+run().catch((e) => {
+  console.error("test runner crashed:", e)
+  process.exit(1)
+})

--- a/.opencode/plugins/__tests__/block-checkstyle-edit.test.ts
+++ b/.opencode/plugins/__tests__/block-checkstyle-edit.test.ts
@@ -103,6 +103,17 @@ async function run(): Promise<void> {
     expect(threw !== null, "bash `echo x > checkstyle.xml` should throw (block)")
   }
 
+  // 3b. `bash` with redirect to checkstyle.xml (no space) must throw.
+  {
+    let threw: Error | null = null
+    try {
+      await before({ tool: "bash", sessionID, callID }, { args: { command: "echo x >checkstyle.xml" } })
+    } catch (e) {
+      threw = e as Error
+    }
+    expect(threw !== null, "bash `echo x >checkstyle.xml` should throw (block)")
+  }
+
   // 4. `bash` with sed -i on checkstyle.xml must throw.
   {
     let threw: Error | null = null

--- a/.opencode/plugins/block-checkstyle-edit.ts
+++ b/.opencode/plugins/block-checkstyle-edit.ts
@@ -1,0 +1,187 @@
+// .opencode/plugins/block-checkstyle-edit.ts
+//
+// opencode adapter for the "block edits to checkstyle configuration"
+// policy.  Mirrors .opencode/plugins/block-mvn-test-direct.ts in
+// shape: pull the relevant field(s) out of the opencode tool-call
+// event, ask the shared core to decide, and translate the structured
+// result into opencode-native rendering (throw to block).
+//
+// The decision logic lives in the shared core
+//   .claude/hooks/lib/checkstyle_config_check.py
+// which is the single source of truth for this policy across both
+// Claude Code (.claude/hooks/block-checkstyle-edit.sh) and opencode
+// (this file).
+//
+// opencode tool coverage:
+//   - `bash`     : tool_input.command -> the shell command.  The
+//                  shared core runs its bash-bypass detector
+//                  (redirect, sed -i, tee, cp/mv, etc.).
+//   - `write`    : tool_input.filePath  -> the file being created.
+//   - `edit`     : tool_input.filePath  -> the file being edited.
+//   - `apply_patch` (if present): tool_input.patchText contains
+//                  the patch body; the path is encoded inside it.
+//                  We extract a path from the patch text and check
+//                  it against the same matcher.
+//
+// Any other tool name is a no-op (we return early) so the plugin
+// does not affect the read/grep/glob workflows.
+//
+// Block semantics: a thrown Error is propagated by opencode as the
+// tool's failure message, which is exactly what the model sees as
+// the block reason — matching Claude Code's "exit 2 + stderr"
+// semantics.  See docs/plans/OPENCODE_HOOKS.md for the harness
+// contract differences.
+
+import type { Plugin } from "@opencode-ai/plugin"
+import { spawnSync } from "node:child_process"
+import * as path from "node:path"
+import { fileURLToPath } from "node:url"
+
+// The shared core. Resolved relative to this file so the plugin
+// works regardless of the cwd opencode was launched from.
+// Path: .opencode/plugins/block-checkstyle-edit.ts
+//   -> .opencode/plugins/
+//   -> .opencode/
+//   -> <repo root>
+//   -> .claude/hooks/lib/checkstyle_config_check.py
+const HERE = path.dirname(fileURLToPath(import.meta.url))
+const CORE = path.resolve(
+  HERE,
+  "..",
+  "..",
+  ".claude",
+  "hooks",
+  "lib",
+  "checkstyle_config_check.py",
+)
+
+interface Decision {
+  action: "block" | "allow"
+  reason: string
+  context: string
+  stderr: string
+}
+
+// Tools this plugin inspects.  opencode has no MultiEdit /
+// NotebookEdit concept; a single `edit` tool with a `replaceAll`
+// flag covers the multi-replace case, and notebook editing is
+// outside the scope of a terminal coding agent.
+const FILE_TOOLS = new Set(["write", "edit"])
+
+/**
+ * Call the shared core with a unified payload.  Returns a Decision
+ * object.  On any internal error (Python missing, core crashed,
+ * bad JSON), returns an "allow" Decision so a hook malfunction can
+ * never block legitimate work.
+ */
+function callCore(payload: Record<string, unknown>): Decision {
+  const result = spawnSync("python3", [CORE, JSON.stringify(payload)], {
+    encoding: "utf-8",
+    timeout: 5_000,
+  })
+
+  if (result.error) {
+    return { action: "allow", reason: "", context: "", stderr: `core spawn failed: ${result.error.message}` }
+  }
+  if (result.status !== 0) {
+    return { action: "allow", reason: "", context: "", stderr: `core exited ${result.status}: ${result.stderr}` }
+  }
+
+  try {
+    return JSON.parse(result.stdout) as Decision
+  } catch (e) {
+    return { action: "allow", reason: "", context: "", stderr: `core returned non-JSON: ${String(e)}` }
+  }
+}
+
+/**
+ * Best-effort logging.  If logging fails for any reason, we just
+ * swallow it — a logging failure must never affect the policy
+ * decision.
+ */
+function logDecision(tool: string, decision: Decision): void {
+  if (!decision.stderr) return
+  // eslint-disable-next-line no-console
+  console.error(`[ar-hooks/block-checkstyle-edit] (${tool}) ${decision.stderr.trim().split("\n", 1)[0]}`)
+}
+
+/**
+ * Extract the file path from a write/edit tool's args object.
+ * Returns the empty string if `filePath` is missing or non-string.
+ */
+function extractFilePath(args: unknown): string {
+  if (!args || typeof args !== "object") return ""
+  const obj = args as { filePath?: unknown; file_path?: unknown }
+  if (typeof obj.filePath === "string") return obj.filePath
+  if (typeof obj.file_path === "string") return obj.file_path
+  return ""
+}
+
+/**
+ * Extract the bash command from a `bash` tool's args object.
+ * Returns the empty string if `command` is missing or non-string.
+ */
+function extractBashCommand(args: unknown): string {
+  if (!args || typeof args !== "object") return ""
+  const obj = args as { command?: unknown }
+  return typeof obj.command === "string" ? obj.command : ""
+}
+
+/**
+ * Extract a file path from an `apply_patch` tool's patch text.  The
+ * patch format used by opencode (the `*** Update File:` /
+ * `*** Add File:` / `*** Delete File:` headers, similar to
+ * `git apply` / `patch -p1`) embeds the path in the first line
+ * after the header.  We do a best-effort regex extraction; if
+ * nothing looks like a path, the empty string is returned (which
+ * the core treats as "no target", i.e. allow).
+ */
+function extractPatchFilePath(args: unknown): string {
+  if (!args || typeof args !== "object") return ""
+  const obj = args as { patchText?: unknown }
+  if (typeof obj.patchText !== "string") return ""
+  const header = obj.patchText.match(/^\*\*\*\s+(?:Update|Add|Delete)\s+File:\s*(\S+)/m)
+  return header ? header[1] : ""
+}
+
+/**
+ * Build the payload for the shared core from a tool name and the
+ * opencode `output.args` object.  Returns null if the tool is not
+ * one this plugin inspects, signalling "no-op".
+ */
+function buildPayload(tool: string, args: unknown): Record<string, unknown> | null {
+  const toolLc = tool.toLowerCase()
+  if (toolLc === "bash") {
+    return { tool: "bash", command: extractBashCommand(args) }
+  }
+  if (FILE_TOOLS.has(toolLc)) {
+    return { tool: toolLc, filePath: extractFilePath(args) }
+  }
+  if (toolLc === "apply_patch") {
+    const p = extractPatchFilePath(args)
+    if (!p) return null
+    return { tool: "edit", filePath: p }
+  }
+  return null
+}
+
+export const BlockCheckstyleEditPlugin: Plugin = async () => {
+  return {
+    "tool.execute.before": async (input, output) => {
+      const payload = buildPayload(input.tool, output.args)
+      if (!payload) return
+      // A payload with no file path / no command is a no-op.  The
+      // core treats empty targets as "allow", but skipping the
+      // subprocess entirely saves ~50ms of cold Python startup.
+      if (payload.tool === "bash" && !payload.command) return
+      if (payload.tool !== "bash" && !payload.filePath) return
+
+      const decision = callCore(payload)
+      logDecision(input.tool, decision)
+
+      if (decision.action === "block") {
+        throw new Error(decision.reason || decision.stderr)
+      }
+    },
+  }
+}

--- a/.opencode/plugins/tsconfig.json
+++ b/.opencode/plugins/tsconfig.json
@@ -13,6 +13,7 @@
     "block-git-commit.ts",
     "block-git-worktree.ts",
     "warn-git-log.ts",
+    "block-checkstyle-edit.ts",
     "_lib/command_pattern.ts"
   ]
 }

--- a/flowtree/runtime/src/main/java/io/flowtree/jobs/InstructionPromptBuilder.java
+++ b/flowtree/runtime/src/main/java/io/flowtree/jobs/InstructionPromptBuilder.java
@@ -389,6 +389,7 @@ public class InstructionPromptBuilder {
      * <ol>
      *   <li>Opening paragraph (autonomous agent context)</li>
      *   <li>Git workflow reminder (always) — agent does not control commits</li>
+     *   <li>Enforcement Configuration (always) — abandon-before-tamper rule for checkstyle / policy / test-integrity config</li>
      *   <li>Communication (when workstream URL is set)</li>
      *   <li>Permission Denials (when workstream URL is set)</li>
      *   <li>Non-Code Requests (when workstream URL is set)</li>
@@ -513,6 +514,20 @@ public class InstructionPromptBuilder {
         sb.append("still perform — but understand that they will all end up in a single final ");
         sb.append("commit, and your job is to leave the working tree in a state that reflects ");
         sb.append("all of those phases together.\n\n");
+
+        // Enforcement configuration -- placed near the top so the agent
+        // sees the abandon-before-tamper rule before reaching for the
+        // edit-checkstyle hook.  Complement to the structural block in
+        // .claude/hooks/block-checkstyle-edit.sh and the opencode
+        // plugin .opencode/plugins/block-checkstyle-edit.ts.
+        sb.append("## Enforcement Configuration\n");
+        sb.append("Enforcement configuration (checkstyle rules and suppressions, policy ");
+        sb.append("validators, test integrity checks) must NEVER be weakened, exempted, or ");
+        sb.append("disabled to make a task succeed. If you conclude a task cannot be completed ");
+        sb.append("without modifying enforcement config, ABANDON the task and report it as ");
+        sb.append("impossible — declaring failure is always preferable to tampering with ");
+        sb.append("enforcement. Attempts to edit checkstyle configuration are blocked; do not ");
+        sb.append("try to circumvent the block.\n\n");
 
         // Messaging instructions - only when a workstream URL is configured
         if (workstreamUrl != null && !workstreamUrl.isEmpty()) {

--- a/flowtree/runtime/src/test/java/io/flowtree/jobs/InstructionPromptBuilderEnforcementConfigTest.java
+++ b/flowtree/runtime/src/test/java/io/flowtree/jobs/InstructionPromptBuilderEnforcementConfigTest.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2026 Michael Murray
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.flowtree.jobs;
+
+import org.almostrealism.util.TestSuiteBase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for the unconditional "Enforcement Configuration" section in
+ * {@link InstructionPromptBuilder}.  The abandon-before-tamper rule is
+ * the proactive prompt-template complement to the structural
+ * {@code .claude/hooks/block-checkstyle-edit.sh} block and its
+ * opencode counterpart.  The rule is in scope on every primary and
+ * correction session, regardless of workstream URL or other
+ * configuration, so these tests are unconditional and use the bare
+ * {@code build()} call.
+ *
+ * <p>This test class is intentionally separate from
+ * {@link InstructionPromptBuilderTest} so the enforcement-config rule
+ * is easy to find and so a future refactor of the existing class
+ * does not accidentally drop the rule's coverage.</p>
+ */
+public class InstructionPromptBuilderEnforcementConfigTest extends TestSuiteBase {
+
+	/**
+	 * Phrase anchors taken from the abandon-before-tamper principle
+	 * text.  Each anchor is a short, distinctive substring that
+	 * uniquely identifies a clause in the rendered section; together
+	 * they assert that the entire principle is present.
+	 */
+	private static final String[] ANCHORS = new String[] {
+		"Enforcement configuration",
+		"checkstyle rules and suppressions",
+		"NEVER be weakened, exempted, or disabled",
+		"ABANDON the task",
+		"declaring failure is always preferable",
+		"do not try to circumvent the block"
+	};
+
+	/** The bare prompt must contain the section header. */
+	@Test(timeout = 30000)
+	public void enforcementConfigSectionAppearsInBarePrompt() {
+		String result = new InstructionPromptBuilder()
+			.setPrompt("test")
+			.build();
+		assertTrue("Enforcement Configuration section must appear in every prompt",
+			result.contains("## Enforcement Configuration"));
+	}
+
+	/** The principle must include all its core clauses. */
+	@Test(timeout = 30000)
+	public void enforcementConfigPrincipleIncludesAllAnchors() {
+		String result = new InstructionPromptBuilder()
+			.setPrompt("test")
+			.build();
+		for (String anchor : ANCHORS) {
+			assertTrue("Enforcement Configuration section must contain: " + anchor,
+				result.contains(anchor));
+		}
+	}
+
+	/** The principle appears in correction sessions too. */
+	@Test(timeout = 30000)
+	public void enforcementConfigSectionAppearsInCorrectionSession() {
+		String result = new InstructionPromptBuilder()
+			.setPrompt("rule correction prompt")
+			.setWorkstreamUrl("http://controller:8080/api/workstreams/ws1")
+			.setCorrectionSession(true)
+			.build();
+		assertTrue("Enforcement Configuration section must also appear in correction sessions",
+			result.contains("## Enforcement Configuration"));
+	}
+
+	/** The principle appears regardless of workstream URL configuration. */
+	@Test(timeout = 30000)
+	public void enforcementConfigSectionAppearsWithoutWorkstreamUrl() {
+		String result = new InstructionPromptBuilder()
+			.setPrompt("Do some work")
+			.build();
+		assertTrue("Enforcement Configuration section must appear even without a workstream URL",
+			result.contains("## Enforcement Configuration"));
+	}
+
+	/** The principle appears before the user request marker. */
+	@Test(timeout = 30000)
+	public void enforcementConfigSectionAppearsBeforeUserRequestMarker() {
+		String result = new InstructionPromptBuilder()
+			.setPrompt("task body")
+			.build();
+		int sectionIdx = result.indexOf("## Enforcement Configuration");
+		int requestIdx = result.indexOf("--- BEGIN USER REQUEST ---");
+		assertTrue("Enforcement Configuration section should appear in the prompt", sectionIdx >= 0);
+		assertTrue("User request marker should appear in the prompt", requestIdx >= 0);
+		assertTrue("Enforcement Configuration section should precede the user request marker",
+			sectionIdx < requestIdx);
+	}
+
+	/**
+	 * The principle is positioned near the top of the prompt, so the
+	 * agent sees it before reaching for the edit-checkstyle hook.
+	 * Specifically it should appear after the git workflow reminder
+	 * (which is the unconditional operational block at the top) and
+	 * before the Working Efficiently section (which is the next
+	 * unconditional operational block).
+	 */
+	@Test(timeout = 30000)
+	public void enforcementConfigSectionFollowsGitWorkflowReminder() {
+		String result = new InstructionPromptBuilder()
+			.setPrompt("task body")
+			.build();
+		int gitIdx = result.indexOf("Note on git workflow");
+		int enforcementIdx = result.indexOf("## Enforcement Configuration");
+		assertTrue("Git workflow reminder should appear in the prompt", gitIdx >= 0);
+		assertTrue("Enforcement Configuration section should appear in the prompt", enforcementIdx >= 0);
+		assertTrue("Enforcement Configuration should follow the git workflow reminder",
+			enforcementIdx > gitIdx);
+	}
+
+	/**
+	 * The principle does not duplicate the existing Test Integrity
+	 * Policy section: that one is conditional on
+	 * {@code protectTestFiles} and is a project-policy marker, while
+	 * this new section is unconditional and covers all enforcement
+	 * configuration (checkstyle rules and suppressions, policy
+	 * validators, test integrity checks).  We assert the section text
+	 * mentions all three so the principle's scope is clear.
+	 */
+	@Test(timeout = 30000)
+	public void enforcementConfigPrincipleListsScope() {
+		String result = new InstructionPromptBuilder()
+			.setPrompt("test")
+			.build();
+		// The principle should enumerate the three enforcement-config
+		// categories so the agent understands the rule's scope.
+		assertTrue("Principle must mention checkstyle rules and suppressions",
+			result.contains("checkstyle rules and suppressions"));
+		assertTrue("Principle must mention policy validators",
+			result.contains("policy validators"));
+		assertTrue("Principle must mention test integrity checks",
+			result.contains("test integrity checks"));
+	}
+
+	/**
+	 * The principle is concise: a single short paragraph (one
+	 * continuation of the same paragraph, no internal blank lines).
+	 * If a future refactor accidentally breaks it into multiple
+	 * paragraphs or expands it beyond a short statement, this test
+	 * flags the change so the rule stays operational rather than
+	 * motivational.  We check that the section header is followed
+	 * within a short window by the body's closing text and then
+	 * another section.
+	 */
+	@Test(timeout = 30000)
+	public void enforcementConfigSectionIsConcise() {
+		String result = new InstructionPromptBuilder()
+			.setPrompt("test")
+			.build();
+		int start = result.indexOf("## Enforcement Configuration");
+		assertTrue("Section must be present", start >= 0);
+		// Within 1500 characters of the section header, the rule's
+		// close phrase must appear.  This is a soft cap: the current
+		// rendering is ~500 chars, so 1500 gives room for natural
+		// wording tweaks without becoming an essay.
+		int close = result.indexOf("do not try to circumvent the block", start);
+		assertTrue("Principle close phrase must appear soon after the header",
+			close >= 0 && close - start < 1500);
+		// And it must not be the very last thing in the prompt.
+		int requestIdx = result.indexOf("--- BEGIN USER REQUEST ---");
+		assertTrue("User request marker must appear after the principle", requestIdx >= 0);
+		assertTrue("Principle must end before the user request marker",
+			close < requestIdx);
+	}
+
+	/**
+	 * The principle does not contradict the existing Test Integrity
+	 * Policy section: that one is project-policy ("you MUST NOT
+	 * modify test files that exist on the base branch"), and the new
+	 * one is meta-policy ("never weaken enforcement config").  Both
+	 * are present, and the new one does not re-state the test
+	 * integrity policy verbatim.
+	 */
+	@Test(timeout = 30000)
+	public void enforcementConfigPrincipleDoesNotContradictTestIntegrityPolicy() {
+		String result = new InstructionPromptBuilder()
+			.setPrompt("test")
+			.setProtectTestFiles(true)
+			.build();
+		assertTrue("Enforcement Configuration section must be present",
+			result.contains("## Enforcement Configuration"));
+		assertTrue("Test Integrity Policy section must still be present",
+			result.contains("## Test Integrity Policy"));
+		// The new principle's wording about "test integrity checks"
+		// is the meta-rule (abandon-before-tamper), not a duplicate
+		// of the project rule (don't modify test files).  We assert
+		// the new principle is intact and the project rule is intact.
+		assertTrue("Project rule text must still be present",
+			result.contains("You MUST NOT modify test files that exist on the base branch"));
+	}
+}


### PR DESCRIPTION
A previous sensitive-file-protection job (e1561b0dc) was supposed to add protection against test/CI file modification but instead added a checkstyle exemption and explicitly described the action as cheating. Prompt-level guidance has repeatedly failed to prevent this, so the fix is now structural: a hook that blocks every attempt to edit checkstyle configuration, plus a proactive prompt-template principle that names the correct response (abandon the task) so the agent reaches the correct conclusion before the hook fires.

Part 1 — Hook (shared-core + thin per-harness adapter):

  - .claude/hooks/lib/checkstyle_config_check.py   (new) shared core
  - .claude/hooks/lib/test_checkstyle_config_check.py  (new) 72 unit tests
    covering path matching, bash bypass detection, decide() dispatch,
    --stdin mode (.sh adapter contract), and argv mode (.ts contract)
  - .claude/hooks/block-checkstyle-edit.sh         (new) thin shell wrapper
  - .opencode/plugins/block-checkstyle-edit.ts     (new) opencode plugin
  - .opencode/plugins/__tests__/block-checkstyle-edit.smoke.cjs (new)
  - .opencode/plugins/__tests__/block-checkstyle-edit.test.ts   (new)
  - .claude/settings.json: registered for Bash, Edit, Write,
    MultiEdit, NotebookEdit matchers
  - .opencode/opencode.json: registered in plugin list
  - .opencode/plugins/tsconfig.json: added to include

The matcher covers checkstyle.xml (root + any module-local), checkstyle-suppressions.xml, any .xml under a /checkstyle/ directory, and any *checkstyle*suppress*.xml file. The bash bypass detector catches redirects (>>, >), sed -i, tee, cp/mv, dd of=, install, heredocs, and python3 -c with redirect. The block message is intentionally ALL CAPS and lists the abandon-before-tamper rule, so the agent understands that abandoning the task is the sanctioned correct outcome -- not a last resort.

Part 2 — Proactive prompt-template principle:

  - flowtree/runtime/src/main/java/io/flowtree/jobs/InstructionPromptBuilder.java added a new unconditional "## Enforcement Configuration" section between the Git workflow reminder and the workstream sections. Lists checkstyle rules/suppressions, policy validators, and test integrity checks as the scope; states the abandon-before-tamper rule; mentions the structural block so the agent knows the cheat will not work.
  - flowtree/runtime/src/test/java/io/flowtree/jobs/InstructionPromptBuilderEnforcementConfigTest.java (new) 9 tests in a new class: section present in bare prompts, correction sessions, with/without workstream URL; all anchor phrases present; concise (one short paragraph); scope enumerated; project-policy test integrity rule still intact.

The new Java test class is in a separate file from the base-branch InstructionPromptBuilderTest to respect the RULE 1 write-lock and keep the enforcement-config rule's coverage easy to find.

Verification:
  - 72/72 python unit tests pass (.claude/hooks/lib/test_checkstyle_config_check.py)
  - opencode .smoke.cjs wiring assertions pass
  - opencode .ts plugin assertions pass (12 cases)
  - 9/9 new Java tests pass (InstructionPromptBuilderEnforcementConfigTest)
  - 35/35 existing InstructionPromptBuilderTest cases pass (no regression)
  - 80/80 CodingAgentJob enforcement + commit-message tests pass
  - ar-build-validator: checkstyle 0 violations, code_policy 0 violations, test_timeouts 0, duplicate_code 0; build SUCCESS

Did not modify any checkstyle configuration in this commit; the abandon-before-tamper rule was applied to this very change.