### PR TITLE
Gate phase-entry Slack messages to PRIMARY phase only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ claude-output/**
 **/pattern-factory.json
 **/pattern-factory-new.json
 **/scene-settings.json
+retrospective-results.json
 commit.txt
 workstreams.yaml
 flowtree-controller.log

--- a/flowtree/agents/src/main/java/io/flowtree/jobs/HarnessStatusReporter.java
+++ b/flowtree/agents/src/main/java/io/flowtree/jobs/HarnessStatusReporter.java
@@ -110,11 +110,20 @@ public final class HarnessStatusReporter {
      * Publishes a phase-entry message naming the phase and the runner/model/
      * provider/effort that will execute it.
      *
+     * <p>To keep channel traffic focused on lifecycle outcomes, entry
+     * announcements are emitted only for the {@link Phase#PRIMARY PRIMARY}
+     * phase. Every other phase still publishes a phase-exit message via
+     * {@link #phaseExit(Phase, AgentRunResult)} when it finishes, so the
+     * operator still sees when each phase ends and on which runner/model.</p>
+     *
      * @param phase  the lifecycle phase being dispatched
      * @param runner the runner name that will run it
      * @param config the effective phase configuration (model/provider/effort)
      */
     public void phaseEntry(Phase phase, String runner, PhaseConfig config) {
+        if (phase != Phase.PRIMARY) {
+            return;
+        }
         post(formatPhaseEntry(phase, runner, config));
     }
 

--- a/flowtree/agents/src/main/java/io/flowtree/jobs/HarnessStatusReporter.java
+++ b/flowtree/agents/src/main/java/io/flowtree/jobs/HarnessStatusReporter.java
@@ -114,7 +114,7 @@ public final class HarnessStatusReporter {
      * announcements are emitted only for the {@link Phase#PRIMARY PRIMARY}
      * phase. Every other phase still publishes a phase-exit message via
      * {@link #phaseExit(Phase, AgentRunResult)} when it finishes, so the
-     * operator still sees when each phase ends and on which runner/model.</p>
+     * operator still sees when each phase ends.</p>
      *
      * @param phase  the lifecycle phase being dispatched
      * @param runner the runner name that will run it

--- a/flowtree/agents/src/test/java/io/flowtree/jobs/HarnessStatusReporterPhaseEntrySuppressionTest.java
+++ b/flowtree/agents/src/test/java/io/flowtree/jobs/HarnessStatusReporterPhaseEntrySuppressionTest.java
@@ -46,8 +46,8 @@ import static org.junit.Assert.assertTrue;
  * </ul>
  *
  * <p>This test class is branch-introduced (no equivalent exists on the base
- * branch) so that the new verbosity policy has explicit coverage without
- * modifying the base-branch test file that originally asserted the more
+ * branch) so that the new verbosity policy has explicit coverage alongside
+ * updates to the existing reporter tests that previously asserted the more
  * verbose behavior.</p>
  */
 public class HarnessStatusReporterPhaseEntrySuppressionTest extends TestSuiteBase {
@@ -173,10 +173,21 @@ public class HarnessStatusReporterPhaseEntrySuppressionTest extends TestSuiteBas
                 posts.isEmpty());
     }
 
-    // TODO(review): Phase.MAVEN_DEPENDENCY_PROTECTION and Phase.PUSH_CONFLICT_RESOLUTION are listed
-    // in this class's javadoc as having suppressed entry messages but lack dedicated test methods.
-    // Add mavenDependencyProtectionPhaseEntryIsSuppressed and pushConflictResolutionPhaseEntryIsSuppressed
-    // following the same pattern as the other per-phase suppression tests above.
+    /** Entering MAVEN_DEPENDENCY_PROTECTION and PUSH_CONFLICT_RESOLUTION is silent — no entry message is posted. */
+    @Test(timeout = 30000)
+    public void remainingNonPrimaryPhaseEntriesAreSuppressed() {
+        Phase[] phases = {
+                Phase.MAVEN_DEPENDENCY_PROTECTION,
+                Phase.PUSH_CONFLICT_RESOLUTION
+        };
+        for (Phase phase : phases) {
+            List<Posted> posts = new ArrayList<>();
+            reporter(posts).phaseEntry(phase, "claude",
+                    new PhaseConfig("claude", "opus", "high", "anthropic"));
+            assertTrue("entering " + phase + " must NOT post an entry message",
+                    posts.isEmpty());
+        }
+    }
 
     /** Completion messages are still emitted for every non-PRIMARY phase. */
     @Test(timeout = 30000)

--- a/flowtree/agents/src/test/java/io/flowtree/jobs/HarnessStatusReporterPhaseEntrySuppressionTest.java
+++ b/flowtree/agents/src/test/java/io/flowtree/jobs/HarnessStatusReporterPhaseEntrySuppressionTest.java
@@ -1,0 +1,283 @@
+/*
+ * Copyright 2026 Michael Murray
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.flowtree.jobs;
+
+import io.flowtree.jobs.agent.AgentRunResult;
+import io.flowtree.jobs.agent.Phase;
+import io.flowtree.jobs.agent.PhaseConfig;
+import org.almostrealism.util.TestSuiteBase;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Verifies the phase-message verbosity policy:
+ *
+ * <ul>
+ *   <li>Entering the {@link Phase#PRIMARY PRIMARY} phase posts a single
+ *       entry message naming the runner, model, and provider.</li>
+ *   <li>Entering any non-PRIMARY phase (review, deduplication, organizational
+ *       placement, maven-dependency-protection, post-completion, commit-message,
+ *       git-tampering-restart, push-conflict-resolution, retrospective) is a
+ *       silent no-op — no entry message is published.</li>
+ *   <li>{@link HarnessStatusReporter#phaseExit(Phase, AgentRunResult)} still
+ *       publishes its completion message for every phase.</li>
+ *   <li>The preserved message types (inactivity suspension, unusual
+ *       termination) are unaffected by the entry-message gate.</li>
+ * </ul>
+ *
+ * <p>This test class is branch-introduced (no equivalent exists on the base
+ * branch) so that the new verbosity policy has explicit coverage without
+ * modifying the base-branch test file that originally asserted the more
+ * verbose behavior.</p>
+ */
+public class HarnessStatusReporterPhaseEntrySuppressionTest extends TestSuiteBase {
+
+    /** A captured post: the JSON body handed to the poster sink. */
+    private static final class Posted {
+        /** The JSON body of the post. */
+        private final String body;
+
+        /**
+         * Creates a Posted with the given body.
+         */
+        private Posted(String body) {
+            this.body = body;
+        }
+    }
+
+    /** Builds a reporter whose posts accumulate into {@code sink}. */
+    private static HarnessStatusReporter reporter(List<Posted> sink) {
+        return new HarnessStatusReporter("http://controller/api/workstreams/ws-1",
+                (url, body) -> sink.add(new Posted(body)));
+    }
+
+    /** Builds a successful session result with the given duration and cost. */
+    private static AgentRunResult successResult(long durationMs, double costUsd) {
+        return new AgentRunResult(0, false, "", "sess", durationMs, 0,
+                3, costUsd, "success", false, Collections.emptyList(),
+                Collections.emptyMap());
+    }
+
+    /** Entering PRIMARY posts a single entry message with the standard gear prefix. */
+    @Test(timeout = 30000)
+    public void primaryPhaseEntryPostsEntryMessage() {
+        List<Posted> posts = new ArrayList<>();
+        reporter(posts).phaseEntry(Phase.PRIMARY, "claude",
+                new PhaseConfig("claude", "opus", "high", "anthropic"));
+
+        assertEquals("entering PRIMARY must post exactly one message",
+                1, posts.size());
+        String body = posts.get(0).body;
+        assertTrue("PRIMARY entry must lead with the gear system prefix",
+                body.contains(HarnessStatusReporter.SYSTEM_PREFIX));
+        assertTrue("PRIMARY entry must carry the phase-entry emoji",
+                body.contains(HarnessStatusReporter.PHASE_ENTRY_EMOJI));
+        assertTrue("PRIMARY entry must name the phase", body.contains("PRIMARY"));
+        assertTrue("PRIMARY entry must name the runner", body.contains("claude"));
+    }
+
+    /** Entering REVIEW is silent — no entry message is posted. */
+    @Test(timeout = 30000)
+    public void reviewPhaseEntryIsSuppressed() {
+        List<Posted> posts = new ArrayList<>();
+        reporter(posts).phaseEntry(Phase.REVIEW, "opencode",
+                new PhaseConfig("opencode", "sonnet", "medium", "anthropic"));
+
+        assertTrue("entering REVIEW must NOT post an entry message (got "
+                + posts.size() + ")", posts.isEmpty());
+    }
+
+    /** Entering DEDUPLICATION is silent — no entry message is posted. */
+    @Test(timeout = 30000)
+    public void deduplicationPhaseEntryIsSuppressed() {
+        List<Posted> posts = new ArrayList<>();
+        reporter(posts).phaseEntry(Phase.DEDUPLICATION, "claude",
+                new PhaseConfig("claude", "opus", "high", "anthropic"));
+
+        assertTrue("entering DEDUPLICATION must NOT post an entry message",
+                posts.isEmpty());
+    }
+
+    /** Entering COMMIT_MESSAGE is silent — no entry message is posted. */
+    @Test(timeout = 30000)
+    public void commitMessagePhaseEntryIsSuppressed() {
+        List<Posted> posts = new ArrayList<>();
+        reporter(posts).phaseEntry(Phase.COMMIT_MESSAGE, "claude",
+                new PhaseConfig("claude", "opus", "high", "anthropic"));
+
+        assertTrue("entering COMMIT_MESSAGE must NOT post an entry message",
+                posts.isEmpty());
+    }
+
+    /** Entering ORGANIZATIONAL_PLACEMENT is silent — no entry message is posted. */
+    @Test(timeout = 30000)
+    public void organizationalPlacementPhaseEntryIsSuppressed() {
+        List<Posted> posts = new ArrayList<>();
+        reporter(posts).phaseEntry(Phase.ORGANIZATIONAL_PLACEMENT, "claude",
+                new PhaseConfig("claude", "opus", "high", "anthropic"));
+
+        assertTrue("entering ORGANIZATIONAL_PLACEMENT must NOT post an entry message",
+                posts.isEmpty());
+    }
+
+    /** Entering POST_COMPLETION is silent — no entry message is posted. */
+    @Test(timeout = 30000)
+    public void postCompletionPhaseEntryIsSuppressed() {
+        List<Posted> posts = new ArrayList<>();
+        reporter(posts).phaseEntry(Phase.POST_COMPLETION, "claude",
+                new PhaseConfig("claude", "opus", "high", "anthropic"));
+
+        assertTrue("entering POST_COMPLETION must NOT post an entry message",
+                posts.isEmpty());
+    }
+
+    /** Entering RETROSPECTIVE is silent — no entry message is posted. */
+    @Test(timeout = 30000)
+    public void retrospectivePhaseEntryIsSuppressed() {
+        List<Posted> posts = new ArrayList<>();
+        reporter(posts).phaseEntry(Phase.RETROSPECTIVE, "claude",
+                new PhaseConfig("claude", "opus", "high", "anthropic"));
+
+        assertTrue("entering RETROSPECTIVE must NOT post an entry message",
+                posts.isEmpty());
+    }
+
+    /** Entering GIT_TAMPERING_RESTART is silent — no entry message is posted. */
+    @Test(timeout = 30000)
+    public void gitTamperingRestartPhaseEntryIsSuppressed() {
+        List<Posted> posts = new ArrayList<>();
+        reporter(posts).phaseEntry(Phase.GIT_TAMPERING_RESTART, "claude",
+                new PhaseConfig("claude", "opus", "high", "anthropic"));
+
+        assertTrue("entering GIT_TAMPERING_RESTART must NOT post an entry message",
+                posts.isEmpty());
+    }
+
+    // TODO(review): Phase.MAVEN_DEPENDENCY_PROTECTION and Phase.PUSH_CONFLICT_RESOLUTION are listed
+    // in this class's javadoc as having suppressed entry messages but lack dedicated test methods.
+    // Add mavenDependencyProtectionPhaseEntryIsSuppressed and pushConflictResolutionPhaseEntryIsSuppressed
+    // following the same pattern as the other per-phase suppression tests above.
+
+    /** Completion messages are still emitted for every non-PRIMARY phase. */
+    @Test(timeout = 30000)
+    public void completionMessagesStillEmittedForEveryPhase() {
+        List<Posted> posts = new ArrayList<>();
+        HarnessStatusReporter r = reporter(posts);
+
+        r.phaseExit(Phase.PRIMARY, successResult(125000, 0.42));
+        r.phaseExit(Phase.REVIEW, successResult(60000, 0.10));
+        r.phaseExit(Phase.DEDUPLICATION, successResult(30000, 0.05));
+        r.phaseExit(Phase.COMMIT_MESSAGE, successResult(20000, 0.02));
+        r.phaseExit(Phase.ORGANIZATIONAL_PLACEMENT, successResult(15000, 0.01));
+        r.phaseExit(Phase.POST_COMPLETION, successResult(10000, 0.01));
+        r.phaseExit(Phase.RETROSPECTIVE, successResult(8000, 0.01));
+
+        assertEquals("every phase must still produce a completion message",
+                7, posts.size());
+        for (Posted post : posts) {
+            assertTrue("completion message must carry the phase-exit emoji",
+                    post.body.contains(HarnessStatusReporter.PHASE_EXIT_EMOJI));
+            assertTrue("completion message must contain 'complete'",
+                    post.body.contains("complete"));
+        }
+    }
+
+    /** A full PR-like pipeline posts only one entry message (the PRIMARY one) and a series of completion messages. */
+    @Test(timeout = 30000)
+    public void fullPipelineProducesOneEntryAndCompletionMessagesOnly() {
+        List<Posted> posts = new ArrayList<>();
+        HarnessStatusReporter r = reporter(posts);
+
+        Phase[] pipeline = {
+                Phase.PRIMARY, Phase.REVIEW, Phase.DEDUPLICATION,
+                Phase.COMMIT_MESSAGE, Phase.POST_COMPLETION
+        };
+        PhaseConfig config = new PhaseConfig("claude", "opus", "high", "anthropic");
+        for (Phase phase : pipeline) {
+            r.phaseEntry(phase, "claude", config);
+            r.phaseExit(phase, successResult(10000, 0.01));
+        }
+
+        assertEquals("a 5-phase pipeline must produce 1 entry (PRIMARY) + 5 completions = 6 messages",
+                pipeline.length + 1, posts.size());
+        int entryCount = (int) posts.stream()
+                .filter(p -> p.body.contains(HarnessStatusReporter.PHASE_ENTRY_EMOJI))
+                .count();
+        int exitCount = (int) posts.stream()
+                .filter(p -> p.body.contains(HarnessStatusReporter.PHASE_EXIT_EMOJI))
+                .count();
+        assertEquals("only one entry message (for PRIMARY) must be posted",
+                1, entryCount);
+        assertEquals("one completion message per phase must be posted",
+                pipeline.length, exitCount);
+        assertTrue("the single entry message must be the PRIMARY one",
+                posts.get(0).body.contains("Entering PRIMARY")
+                        || posts.get(0).body.contains("PRIMARY"));
+    }
+
+    /** Inactivity suspension messages are unaffected by the entry-message gate. */
+    @Test(timeout = 30000)
+    public void inactivityMessagesUnaffectedByEntryGate() {
+        List<Posted> posts = new ArrayList<>();
+        HarnessStatusReporter r = reporter(posts);
+
+        r.inactivitySuspended("opencode", 0, 3);
+        r.inactivitySuspended("opencode", 3, 3);
+
+        assertEquals("inactivity messages must still be emitted", 2, posts.size());
+        assertTrue("first inactivity must announce relaunch",
+                posts.get(0).body.contains("relaunching"));
+        assertTrue("final inactivity must announce abandonment",
+                posts.get(1).body.contains("abandoning"));
+        for (Posted post : posts) {
+            assertTrue("inactivity message must carry the pause emoji",
+                    post.body.contains(HarnessStatusReporter.INACTIVITY_EMOJI));
+        }
+    }
+
+    /** Unusual-termination messages are unaffected by the entry-message gate. */
+    @Test(timeout = 30000)
+    public void unusualMessagesUnaffectedByEntryGate() {
+        List<Posted> posts = new ArrayList<>();
+        HarnessStatusReporter r = reporter(posts);
+
+        r.unusual("Git tampering detected — restarting session");
+        r.unusual("Post-completion command timed out — abandoning");
+
+        assertEquals("unusual messages must still be emitted", 2, posts.size());
+        for (Posted post : posts) {
+            assertTrue("unusual message must carry the warning emoji",
+                    post.body.contains(HarnessStatusReporter.UNUSUAL_EMOJI));
+        }
+    }
+
+    /** Entry suppression is silent: the suppression does not produce any partial JSON or empty post. */
+    @Test(timeout = 30000)
+    public void suppressedEntryProducesNoPartialOutput() {
+        List<Posted> posts = new ArrayList<>();
+        reporter(posts).phaseEntry(Phase.REVIEW, "claude",
+                new PhaseConfig("claude", "opus", "high", "anthropic"));
+
+        assertTrue("suppressed entry must produce zero posts", posts.isEmpty());
+    }
+}

--- a/flowtree/agents/src/test/java/io/flowtree/jobs/HarnessStatusReporterTest.java
+++ b/flowtree/agents/src/test/java/io/flowtree/jobs/HarnessStatusReporterTest.java
@@ -74,7 +74,7 @@ public class HarnessStatusReporterTest extends TestSuiteBase {
     @Test(timeout = 30000)
     public void phaseEntryMessageCarriesDistinctivePrefix() {
         List<Posted> posts = new ArrayList<>();
-        reporter(posts).phaseEntry(Phase.REVIEW, "claude",
+        reporter(posts).phaseEntry(Phase.PRIMARY, "claude",
                 new PhaseConfig("claude", "opus", "high", "anthropic"));
 
         assertEquals(1, posts.size());
@@ -83,7 +83,7 @@ public class HarnessStatusReporterTest extends TestSuiteBase {
                 post.body.contains(HarnessStatusReporter.SYSTEM_PREFIX));
         assertTrue("phase-entry message must carry the phase-entry emoji",
                 post.body.contains(HarnessStatusReporter.PHASE_ENTRY_EMOJI));
-        assertTrue("phase-entry names the phase", post.body.contains("REVIEW"));
+        assertTrue("phase-entry names the phase", post.body.contains("PRIMARY"));
         assertTrue("phase-entry names the runner and model",
                 post.body.contains("claude") && post.body.contains("opus"));
         assertTrue("phase-entry names the provider", post.body.contains("anthropic"));

--- a/retrospective-results.json
+++ b/retrospective-results.json
@@ -1,1 +1,1 @@
-{"transcriptFound": true, "findingsCount": 4}
+{"transcriptFound": true, "findingsCount": 6}

--- a/retrospective-results.json
+++ b/retrospective-results.json
@@ -1,1 +1,0 @@
-{"transcriptFound": true, "findingsCount": 6}


### PR DESCRIPTION
The harness currently posts a phase-entry ("Entering X") and a phase-exit ("X complete") message for every phase. For multi-phase pipelines this produces redundant back-to-back end-then-start pairs (e.g. "DEDUPLICATION complete" immediately followed by "Entering COMMIT-MESSAGE").

Suppress the phase-entry announcement for every phase except PRIMARY. PRIMARY's entry message remains as the job's opening signal. Phase-exit ("X complete") messages are still emitted for every phase, and the preserved message types (inactivity suspension, unusual termination) are unaffected.

Implementation: a one-line early-return in HarnessStatusReporter.phaseEntry for non-PRIMARY phases. The formatting helpers (formatPhaseEntry, formatPhaseExit, formatInactivity) are unchanged so callers and tests that exercise formatting continue to work as before.

Tests:
- Updated base-branch test phaseEntryMessageCarriesDistinctivePrefix to use Phase.PRIMARY (this tripps the agent-commit test write-lock, RULE 1; operator can land via manual CI skip per the task spec).
- New branch-introduced test class HarnessStatusReporterPhaseEntrySuppressionTest asserts the new behavior: PRIMARY entry posts, every other non-PRIMARY phase entry is silent, completion messages still emit for all phases, and the preserved message types (inactivity, unusual) are unaffected.