### PR TITLE
Shared schema contract feasibility study

### DIFF
--- a/docs/plans/SHARED_SCHEMA_CONTRACT.md
+++ b/docs/plans/SHARED_SCHEMA_CONTRACT.md
@@ -1,0 +1,326 @@
+# Shared Schema Contract — Go/No-Go Feasibility Study
+
+**Status:** NO-GO — See verdict at the end.
+
+**Branch:** `feature/shared-schema-contract`  
+**Date:** 2026-06-14
+
+---
+
+## 1. The Problem Under Study
+
+The FlowTree controller API and the ar-manager MCP server
+(`tools/mcp/manager/server.py`) maintain **two hand-written copies of the
+same parameter schema**:
+
+- The controller validates config fields in Java.
+- The MCP tools separately re-declare those fields as Python parameters with
+  natural-language docstrings.
+
+They drift. At least five "controller field added, MCP parameter forgotten"
+gaps are documented: `phase_configs`, `workspace_update_config` (workspace
+endpoint), `retrospective_enabled`, `completion_listeners`, `dispatch_capable`.
+
+**The idea under study:** have both the API and the MCP tool surface derive
+from one shared OpenAPI-style specification, so divergence is structurally
+impossible.
+
+**Acceptance criterion:** adding or changing a config field must require
+editing exactly **one artifact**, after which BOTH the controller validation
+AND the MCP tool parameter (including its natural-language description) update
+automatically, with **no separate human step**.
+
+---
+
+## 2. The Two-Copy Map (what exists today)
+
+### 2.1 Copy 1 — Java controller (authoritative)
+
+The controller is a NanoHTTPD Java HTTP server. Config fields are read and
+applied in two handler classes:
+
+**`WorkstreamRegistrationHandler.handleUpdate()`**
+(`flowtree/runtime/src/main/java/io/flowtree/api/WorkstreamRegistrationHandler.java`):
+```java
+String defaultBranch = JsonFieldExtractor.extractString(body, "defaultBranch");
+String baseBranch    = JsonFieldExtractor.extractString(body, "baseBranch");
+String repoUrl       = JsonFieldExtractor.extractString(body, "repoUrl");
+String planningDocument = JsonFieldExtractor.extractString(body, "planningDocument");
+String channelName   = JsonFieldExtractor.extractString(body, "channelName");
+Map<String, String> requiredLabels   = JsonFieldExtractor.extractStringObject(body, "requiredLabels");
+List<String> dependentRepos          = JsonFieldExtractor.extractStringArray(body, "dependentRepos");
+List<String> completionListeners     = extractCompletionListeners(body);
+// plus phaseConfigs / defaultPhaseConfig via PhaseConfigResolver
+```
+
+**`WorkspaceConfigHandler.handle()`**
+(`flowtree/runtime/src/main/java/io/flowtree/api/WorkspaceConfigHandler.java`):
+```java
+String name           = JsonFieldExtractor.extractString(body, "name");
+String defaultChannel = JsonFieldExtractor.extractString(body, "defaultChannel");
+String newId          = JsonFieldExtractor.extractString(body, "newId");
+boolean slackTeamIdPresent = body.contains("\"slackTeamId\"");
+// plus phaseConfigs / defaultPhaseConfig via PhaseConfigResolver
+```
+
+There is **no schema file** for either endpoint. The field list is implicit in
+the `JsonFieldExtractor` call sequence. Adding a new field means writing a new
+`extractString()` call.
+
+### 2.2 Copy 2 — Python MCP server (the second copy)
+
+`tools/mcp/manager/server.py` (6,510 lines) declares matching tools using
+`from mcp.server.fastmcp import FastMCP` and `@mcp.tool()` decorators:
+
+```python
+@mcp.tool()
+def workstream_update_config(
+    workstream_id: str,
+    default_branch: str = "",
+    base_branch: str = "",
+    repo_url: str = "",
+    planning_document: str = "",
+    channel_name: str = "",
+    required_labels: str = "",
+    dependent_repos: str = "",
+    completion_listeners: str = "",
+    default_phase_config: str = "",
+    phase_configs: str = "",
+    ...
+) -> dict:
+    """Update configuration for an existing workstream.
+    ...300+ words of context-specific docstring...
+    """
+```
+
+Each parameter has a multi-sentence docstring explaining its semantics to MCP
+clients. The function body converts snake_case Python params to camelCase JSON
+and POSTs to the controller. A new field requires: (a) a new parameter in the
+Python signature, (b) a docstring update, and (c) a payload-forward line in
+the body.
+
+### 2.3 The existing backstop
+
+`McpToolWorkstreamConfigSurfaceTest.java`
+(`flowtree/runtime/src/test/java/io/flowtree/jobs/`) is a static text-parsing
+test that reads `server.py` and asserts that every entry in a curated set
+(`REQUIRED_ON_BOTH_REGISTER_AND_UPDATE`) appears in the Python function
+signature. It fails CI when a controller field is added without the Python
+parameter. It does **not** verify docstring content.
+
+---
+
+## 3. FastMCP OpenAPI Integration — Concrete Finding
+
+### 3.1 Which FastMCP is this?
+
+The codebase uses:
+```python
+from mcp.server.fastmcp import FastMCP   # mcp >= 1.0.0
+mcp = FastMCP("ar-manager")
+```
+
+This is the **Anthropic MCP SDK**'s built-in FastMCP class, from the `mcp`
+package (`requirements.txt`: `mcp>=1.0.0`).
+
+The `from_openapi()` class method and its `OpenAPIProvider` — the features
+needed to source an MCP server from an OpenAPI spec — belong to the
+**standalone `fastmcp` library** (by Jerrod Tanner / jlowin). That is a
+**different package** not present in this codebase. The two libraries share a
+name but have separate PyPI entries, separate APIs, and are not
+interchangeable.
+
+Concretely:
+- `mcp.server.fastmcp.FastMCP` — has `@mcp.tool()` decorator only; no
+  `from_openapi()`.
+- `fastmcp 2.x` (standalone) — has `FastMCP.from_openapi()`; but is not
+  installed here and switching would require rewriting the entire server.
+
+### 3.2 Does the controller serve OpenAPI docs?
+
+No. The controller is a NanoHTTPD HTTP server with hand-rolled JSON
+request/response handling. It exposes no `/openapi.json`, no Swagger endpoint,
+and no machine-readable schema. There is no framework (Spring, JAX-RS, Quarkus,
+etc.) generating OpenAPI from the Java handler code.
+
+### 3.3 What would "sourcing from OpenAPI" require?
+
+To use `FastMCP.from_openapi()` (if we switched libraries), the MCP server
+would need to fetch a live OpenAPI document from the controller at startup.
+This requires:
+
+1. **Switching from `mcp.server.fastmcp` to the standalone `fastmcp 2.x`** —
+   a full rewrite of the 6,510-line `server.py`.
+2. **The controller serving an OpenAPI document** — which requires adding an
+   OpenAPI generation mechanism to the Java NanoHTTPD server (either annotating
+   the handler methods for a reflection-based generator, or hand-authoring a
+   YAML/JSON spec file).
+3. **The descriptions problem** (see §4) — still unsolved even if steps 1 and
+   2 were done.
+
+Even completing steps 1 and 2 does not satisfy the acceptance criterion,
+because the Java controller's field validation still comes from
+`JsonFieldExtractor.extractString()` calls, not from the spec. The spec and
+the Java handler remain two independent artifacts.
+
+---
+
+## 4. The Descriptions Problem
+
+The MCP docstrings for `workstream_update_config` are not simple field names.
+They are context-specific, multi-sentence explanations written for AI clients:
+
+```
+default_phase_config: New workstream-level default configuration as a
+    JSON object with optional ``runner`` / ``model`` / ``effort`` /
+    ``provider`` keys. Pass ``'{}'`` to clear the stored default
+    (all phases will then fall through to the workspace or controller
+    default). Empty string leaves it unchanged. Use ``agent_options``
+    to discover available runner names. Example::
+
+        '{"runner": "opencode", "model": "qwen3-coder:exacto",
+          "effort": "medium", "provider": "openrouter"}'
+```
+
+An OpenAPI `description` field could technically hold this text. But there is
+no mechanism for auto-generating these descriptions from Java code. They would
+have to be authored in the spec file by a human. This means:
+
+- **The spec file becomes the new second copy** — a human edits it whenever a
+  field is added, exactly as they today edit the Python signature.
+- **Or** the descriptions live only in the Python tool function, which means
+  the Python file and the spec are two copies.
+
+Neither path satisfies the acceptance criterion.
+
+---
+
+## 5. Legitimate Surface Differences
+
+The API surface and MCP surface **legitimately differ** in several ways. A
+shared-spec approach must handle these without reintroducing the manual
+bookkeeping it replaces:
+
+| Controller-side field | MCP exposure | Reason for difference |
+|---|---|---|
+| `slackTeamId` (workspace) | Exposed as `slack_team_id` (with sentinel for absent vs. empty) | Complex absence-vs-empty semantics require MCP-layer logic |
+| `channelId` (workstream) | Not exposed on update | Setting channelId on update is unsafe; the MCP tool omits it |
+| `archived` | Not in update payload | Archival has its own endpoint with safety checks |
+| Legacy `model`/`effort`/`runners` | Exposed as rejected parameters with a 400 error | Backwards-compat error messaging for old clients |
+| `retrospective_enabled` | MCP param only (on submit, not update) | Submit-time parameter, not a persisted config field |
+| `workspace_id` | Register-only, not update | Controller update handler does not accept it |
+
+For a shared spec to "express these cleanly without a curation layer," it would
+need an `x-mcp-exclude` or similar extension on each internal-only field. But
+that extension is itself a **per-field annotation that must be maintained in the
+spec** every time a new field is added — exactly the kind of recurring manual
+step the acceptance criterion rules out as insufficient.
+
+---
+
+## 6. The Killer Finding: Two-Copy Problem Relocates, Not Disappears
+
+For the acceptance criterion to be met, BOTH of the following must be true when
+a new field is added:
+
+1. The **controller validates** the new field.
+2. The **MCP tool exposes** the new field with a meaningful description.
+
+Under any shared-spec approach studied here:
+
+- **Controller side:** Still validated by `JsonFieldExtractor.extractString()`
+  in `WorkstreamRegistrationHandler.handleUpdate()`. The spec does not drive
+  controller behavior. Editing the spec has zero effect on the controller.
+  **The spec and the Java handler are the new two copies.**
+
+- **MCP side:** Even with `fastmcp 2.x` + `from_openapi()`, the generated MCP
+  tool would have parameters derived from the spec's schema, not from the
+  (absent) descriptions. A human must still author the description text
+  somewhere — either in the spec (making the spec a maintained artifact) or in
+  a separate overlay (a third artifact).
+
+The approach trades one drift point for two, not one.
+
+---
+
+## 7. Honest Comparison Against the Divergence Test
+
+The question asks whether a shared-spec approach is better than "just keep the
+divergence test." Let us compare honestly:
+
+| Property | Shared OpenAPI spec | `McpToolWorkstreamConfigSurfaceTest` |
+|---|---|---|
+| Catches missing MCP param at CI | Yes (if spec is kept current) | Yes (already does this today) |
+| Human edit required for new field | Yes — edit spec + Java handler + MCP docstring | Yes — edit Java handler + Python param + docstring |
+| Edit count per new field | 3 artifacts | 3 artifacts (same) |
+| Catches missing docstring content | No — spec descriptions would be stubs | No — test only checks param names |
+| Implementation complexity | Very high (library swap, controller redesign) | Already shipped, costs nothing |
+| Risk | High — full MCP server rewrite | None — test already exists |
+| Constraint on surface differences | Forces one-for-one mapping or per-field curation | Allows arbitrary divergence via `REQUIRED_ON_REGISTER_ONLY` set |
+
+The divergence test **already provides the same CI-level catch** as a shared
+spec, with zero implementation cost and zero rigidity on legitimate surface
+differences.
+
+---
+
+## 8. Verdict: NO-GO
+
+**The shared-spec approach does not satisfy the acceptance criterion.**
+
+Specifically:
+
+1. **The controller does not derive from any spec.** Its field validation is
+   `JsonFieldExtractor.extractString()` calls in Java. Making it derive from a
+   spec would require redesigning the controller's request handling. Even then,
+   the spec would be a second artifact alongside the Java code.
+
+2. **FastMCP `from_openapi()` is not available** in the MCP library used by
+   this codebase (`mcp.server.fastmcp`). Using it requires a library swap and a
+   full rewrite of the 6,510-line `server.py`.
+
+3. **Descriptions cannot be auto-generated.** The MCP docstrings contain
+   context-specific, multi-sentence AI-targeted guidance that has no source in
+   the Java code. A spec's `description` fields would require human authoring —
+   making the spec a maintained artifact identical in burden to the Python
+   function docstrings.
+
+4. **Legitimate surface differences require per-field curation.** An
+   "exclude from MCP" marker on internal-only fields is itself a recurring
+   manual edit — exactly the kind of human step the acceptance criterion
+   prohibits.
+
+5. **The two-copy problem relocates, not disappears.** In the realistic
+   implementation, the spec + the Java handler are the new two copies. The edit
+   count per new field does not decrease; the implementation cost is very high.
+
+**What blocks it, exactly stated:** There is no mechanism by which editing one
+artifact causes the Java controller to validate a new field AND the MCP tool to
+expose it with a useful description. Any approach that achieves both requires at
+minimum two separate edits: one to the Java handler and one to the descriptions.
+That is the definition of a two-copy system.
+
+---
+
+## 9. What to Do Instead
+
+The existing `McpToolWorkstreamConfigSurfaceTest` already provides CI-enforced
+detection of parameter divergence. It should be **extended, not replaced**:
+
+1. **Expand the `REQUIRED_ON_BOTH_REGISTER_AND_UPDATE` set** as each new field
+   is added. This is the authoritative list of "what must be exposed via MCP."
+   Making this set the canonical record is lighter than a full OpenAPI spec and
+   more honest about what the test actually checks.
+
+2. **Add a docstring completeness check** if desired — a test that asserts each
+   required parameter has a non-empty docstring in the Python tool (catching
+   the case where a param is added with an empty description).
+
+3. **Document the "add a field" workflow** in `CLAUDE.md` or a developer guide:
+   - Add the `extractString()` call in the Java handler.
+   - Add the parameter to the Python tool signature with a docstring.
+   - Add the parameter name to `REQUIRED_ON_BOTH_REGISTER_AND_UPDATE`.
+   - CI fails if step 3 is forgotten.
+
+This three-step workflow is the honest answer to what the problem requires. The
+shared-spec approach does not reduce the step count.

--- a/flowtree/runtime/src/main/java/io/flowtree/api/FlowTreeApiEndpoint.java
+++ b/flowtree/runtime/src/main/java/io/flowtree/api/FlowTreeApiEndpoint.java
@@ -59,6 +59,8 @@ import io.flowtree.slack.SlackNotifier;
 import io.flowtree.slack.NotifierRegistry;
 import io.flowtree.workstream.WorkstreamConfig;
 import io.flowtree.submission.PhaseConfigResolver;
+import io.flowtree.workstream.WorkspaceEntry;
+import io.flowtree.workstream.WorkspaceSecretEntry;
 
 /**
  * HTTP API endpoint for FlowTree orchestration.
@@ -128,7 +130,7 @@ public class FlowTreeApiEndpoint extends NanoHTTPD implements ConsoleFeatures {
     private Map<String, String> orgToWorkspaceId = new HashMap<>();
 
     /** Resolves a Slack workspace ID to its entry for the workspace runner layer. */
-    private Function<String, WorkstreamConfig.WorkspaceEntry> workspaceLookup = id -> null;
+    private Function<String, WorkspaceEntry> workspaceLookup = id -> null;
     /** Tracks which jobs should have a PR auto-created on success. */
     private final Map<String, AutoPrContext> autoCreatePrJobs = new HashMap<>();
 
@@ -274,7 +276,7 @@ public class FlowTreeApiEndpoint extends NanoHTTPD implements ConsoleFeatures {
     }
 
     /** Sets the workspace lookup feeding the workspace layer of {@link SubmissionConfigResolver}; {@code null} disables it. */
-    public void setWorkspaceLookup(Function<String, WorkstreamConfig.WorkspaceEntry> lookup) {
+    public void setWorkspaceLookup(Function<String, WorkspaceEntry> lookup) {
         this.workspaceLookup = lookup != null ? lookup : id -> null;
     }
 
@@ -285,9 +287,9 @@ public class FlowTreeApiEndpoint extends NanoHTTPD implements ConsoleFeatures {
      * the workspace for a listener workstream and propagate any
      * workspace-level routing defaults.
      */
-    public WorkstreamConfig.WorkspaceEntry workspaceLookupOrNull(String workspaceId) {
+    public WorkspaceEntry workspaceLookupOrNull(String workspaceId) {
         if (workspaceId == null || workspaceId.isEmpty()) return null;
-        WorkstreamConfig.WorkspaceEntry entry = workspaceLookup.apply(workspaceId);
+        WorkspaceEntry entry = workspaceLookup.apply(workspaceId);
         return entry;
     }
 
@@ -364,7 +366,7 @@ public class FlowTreeApiEndpoint extends NanoHTTPD implements ConsoleFeatures {
      * @param cache workspace-ID → (secret-name → entry) map
      */
     public void setSecretsCache(
-            Map<String, Map<String, WorkstreamConfig.WorkspaceSecretEntry>> cache) {
+            Map<String, Map<String, WorkspaceSecretEntry>> cache) {
         secretsHandler.setSecretsCache(cache);
     }
 
@@ -849,7 +851,7 @@ public class FlowTreeApiEndpoint extends NanoHTTPD implements ConsoleFeatures {
         // resolver. Same code path the Slack listener uses, so workspace-level
         // settings are honoured uniformly regardless of submission entrypoint.
         String wsId = workstream.getWorkspaceId();
-        WorkstreamConfig.WorkspaceEntry wsEntry = (wsId != null && !wsId.isEmpty()) ? workspaceLookup.apply(wsId) : null;
+        WorkspaceEntry wsEntry = (wsId != null && !wsId.isEmpty()) ? workspaceLookup.apply(wsId) : null;
         if (wsId != null && !wsId.isEmpty() && wsEntry == null) log("submitWorkspaceMissing workspaceId=" + wsId);
         PhaseConfigBundle requestBundle = PhaseConfigResolver.bundleFromRequest(body);
         SubmissionConfigResolver configResolver = SubmissionConfigResolver.resolve(

--- a/flowtree/runtime/src/main/java/io/flowtree/api/SecretsRequestHandler.java
+++ b/flowtree/runtime/src/main/java/io/flowtree/api/SecretsRequestHandler.java
@@ -47,6 +47,7 @@ import io.flowtree.slack.SlackNotifier;
 import io.flowtree.slack.NotifierRegistry;
 import io.flowtree.workstream.WorkstreamConfig;
 import io.flowtree.github.GitHubProxyHandler;
+import io.flowtree.workstream.WorkspaceSecretEntry;
 
 /**
  * Handles all {@code /api/secrets} and {@code /api/secrets/{name}} requests
@@ -77,7 +78,7 @@ public class SecretsRequestHandler implements ConsoleFeatures {
     private String sharedSecret;
 
     /** In-memory secrets index, keyed by workspace ID then secret name. */
-    private Map<String, Map<String, WorkstreamConfig.WorkspaceSecretEntry>> secretsCache =
+    private Map<String, Map<String, WorkspaceSecretEntry>> secretsCache =
             new HashMap<>();
 
     /**
@@ -109,7 +110,7 @@ public class SecretsRequestHandler implements ConsoleFeatures {
      * @param cache workspace-ID → (secret-name → entry) map
      */
     public void setSecretsCache(
-            Map<String, Map<String, WorkstreamConfig.WorkspaceSecretEntry>> cache) {
+            Map<String, Map<String, WorkspaceSecretEntry>> cache) {
         this.secretsCache = cache != null ? cache : new HashMap<>();
     }
 
@@ -154,10 +155,10 @@ public class SecretsRequestHandler implements ConsoleFeatures {
                 || secretName == null || secretName.isEmpty()) {
             return null;
         }
-        Map<String, WorkstreamConfig.WorkspaceSecretEntry> wsSecrets =
+        Map<String, WorkspaceSecretEntry> wsSecrets =
                 secretsCache.get(workspaceId);
         if (wsSecrets == null) return null;
-        WorkstreamConfig.WorkspaceSecretEntry entry = wsSecrets.get(secretName);
+        WorkspaceSecretEntry entry = wsSecrets.get(secretName);
         if (entry == null) return null;
         Map<String, String> payload;
         try {
@@ -402,7 +403,7 @@ public class SecretsRequestHandler implements ConsoleFeatures {
      * @return JSON response with {@code {"names":[...]}}
      */
     private Response handleListSecretNames(String workspaceId) {
-        Map<String, WorkstreamConfig.WorkspaceSecretEntry> wsSecrets =
+        Map<String, WorkspaceSecretEntry> wsSecrets =
                 secretsCache.getOrDefault(workspaceId, new HashMap<>());
         StringBuilder json = new StringBuilder("{\"names\":[");
         boolean first = true;
@@ -426,7 +427,7 @@ public class SecretsRequestHandler implements ConsoleFeatures {
      */
     private Response handleRetrieveSecret(
             String secretName, String workspaceId, String workstreamId) {
-        Map<String, WorkstreamConfig.WorkspaceSecretEntry> wsSecrets =
+        Map<String, WorkspaceSecretEntry> wsSecrets =
                 secretsCache.get(workspaceId);
         if (wsSecrets == null || !wsSecrets.containsKey(secretName)) {
             log("event=secret_retrieve secret=" + secretName
@@ -438,7 +439,7 @@ public class SecretsRequestHandler implements ConsoleFeatures {
                             + JsonFieldExtractor.escapeJson(secretName) + "\"}");
         }
 
-        WorkstreamConfig.WorkspaceSecretEntry entry = wsSecrets.get(secretName);
+        WorkspaceSecretEntry entry = wsSecrets.get(secretName);
         Map<String, String> payload;
         try {
             payload = readSecretPayload(entry.getFile());
@@ -496,7 +497,7 @@ public class SecretsRequestHandler implements ConsoleFeatures {
             return error.respond("Invalid JSON payload: " + e.getMessage());
         }
 
-        Map<String, WorkstreamConfig.WorkspaceSecretEntry> wsSecrets =
+        Map<String, WorkspaceSecretEntry> wsSecrets =
                 secretsCache.get(workspaceId);
         if (wsSecrets == null || !wsSecrets.containsKey(secretName)) {
             return NanoHTTPD.newFixedLengthResponse(Response.Status.NOT_FOUND,
@@ -504,7 +505,7 @@ public class SecretsRequestHandler implements ConsoleFeatures {
                     "{\"ok\":false,\"error\":\"Secret not declared in config: "
                             + JsonFieldExtractor.escapeJson(secretName) + "\"}");
         }
-        WorkstreamConfig.WorkspaceSecretEntry entry = wsSecrets.get(secretName);
+        WorkspaceSecretEntry entry = wsSecrets.get(secretName);
         try {
             writeSecretPayload(entry.getFile(), payload);
         } catch (IOException e) {
@@ -526,7 +527,7 @@ public class SecretsRequestHandler implements ConsoleFeatures {
      * @return JSON response
      */
     private Response handleDeleteSecret(String secretName, String workspaceId) {
-        Map<String, WorkstreamConfig.WorkspaceSecretEntry> wsSecrets =
+        Map<String, WorkspaceSecretEntry> wsSecrets =
                 secretsCache.get(workspaceId);
         if (wsSecrets == null || !wsSecrets.containsKey(secretName)) {
             return NanoHTTPD.newFixedLengthResponse(Response.Status.NOT_FOUND,
@@ -534,7 +535,7 @@ public class SecretsRequestHandler implements ConsoleFeatures {
                     "{\"ok\":false,\"error\":\"Secret not found: "
                             + JsonFieldExtractor.escapeJson(secretName) + "\"}");
         }
-        WorkstreamConfig.WorkspaceSecretEntry entry = wsSecrets.get(secretName);
+        WorkspaceSecretEntry entry = wsSecrets.get(secretName);
         try {
             Files.deleteIfExists(Path.of(entry.getFile()));
         } catch (IOException e) {

--- a/flowtree/runtime/src/main/java/io/flowtree/api/WorkspaceConfigHandler.java
+++ b/flowtree/runtime/src/main/java/io/flowtree/api/WorkspaceConfigHandler.java
@@ -28,13 +28,14 @@ import java.util.function.Function;
 import io.flowtree.submission.PhaseConfigResolver;
 import io.flowtree.workstream.WorkstreamConfig;
 import io.flowtree.slack.SlackListener;
+import io.flowtree.workstream.WorkspaceEntry;
 
 /**
  * Handles the workspace config endpoint ({@code POST /api/workspaces/{id}/config})
  * for {@link FlowTreeApiEndpoint}.
  *
  * <p>The endpoint exposes a deliberately narrow set of {@link
- * WorkstreamConfig.WorkspaceEntry} fields:</p>
+ * WorkspaceEntry} fields:</p>
  * <ul>
  *   <li>{@code name} — human-readable label.</li>
  *   <li>{@code defaultChannel} — fallback Slack channel ID.</li>
@@ -64,7 +65,7 @@ import io.flowtree.slack.SlackListener;
 final class WorkspaceConfigHandler {
 
     /** Resolves a workspace ID to its config entry, or {@code null}. */
-    private final Function<String, WorkstreamConfig.WorkspaceEntry> workspaceLookup;
+    private final Function<String, WorkspaceEntry> workspaceLookup;
     /**
      * Renames a workspace: applies {@code (oldId, newId)} to the loaded
      * config. Returns {@code true} on success, {@code false} when the old ID
@@ -92,7 +93,7 @@ final class WorkspaceConfigHandler {
      * @param errorResponse   400-error response factory
      * @param log             log line consumer
      */
-    WorkspaceConfigHandler(Function<String, WorkstreamConfig.WorkspaceEntry> workspaceLookup,
+    WorkspaceConfigHandler(Function<String, WorkspaceEntry> workspaceLookup,
                            SlackListener listener,
                            Function<IHTTPSession, String> readBody,
                            Function<String, Response> errorResponse,
@@ -113,7 +114,7 @@ final class WorkspaceConfigHandler {
      * @param errorResponse   400-error response factory
      * @param log             log line consumer
      */
-    WorkspaceConfigHandler(Function<String, WorkstreamConfig.WorkspaceEntry> workspaceLookup,
+    WorkspaceConfigHandler(Function<String, WorkspaceEntry> workspaceLookup,
                            BiFunction<String, String, Boolean> renameWorkspace,
                            SlackListener listener,
                            Function<IHTTPSession, String> readBody,
@@ -169,7 +170,7 @@ final class WorkspaceConfigHandler {
         String legacyErr = PhaseConfigResolver.rejectLegacyRequestFields(body);
         if (legacyErr != null) return errorResponse.apply(legacyErr);
 
-        WorkstreamConfig.WorkspaceEntry entry = workspaceLookup.apply(workspaceId);
+        WorkspaceEntry entry = workspaceLookup.apply(workspaceId);
         if (entry == null) {
             String json = "{\"ok\":false,\"error\":\"Unknown workspace: "
                     + JsonFieldExtractor.escapeJson(workspaceId) + "\"}";

--- a/flowtree/runtime/src/main/java/io/flowtree/controller/FlowTreeController.java
+++ b/flowtree/runtime/src/main/java/io/flowtree/controller/FlowTreeController.java
@@ -25,7 +25,6 @@ import com.slack.api.methods.response.auth.AuthTestResponse;
 import com.slack.api.model.event.AppMentionEvent;
 import com.slack.api.model.event.MessageEvent;
 import io.flowtree.Server;
-import io.flowtree.jobs.GitOperations;
 import io.flowtree.jobs.McpToolDiscovery;
 import org.almostrealism.io.Console;
 import org.almostrealism.io.ConsoleFeatures;
@@ -56,6 +55,9 @@ import io.flowtree.workstream.WorkstreamConfig;
 import io.flowtree.slack.SlackListener;
 import io.flowtree.slack.SlackNotifier;
 import io.flowtree.slack.SlackTokens;
+import io.flowtree.workstream.WorkspaceEntry;
+import io.flowtree.workstream.WorkspaceSecretEntry;
+import io.flowtree.workstream.PushedToolEntry;
 
 /**
  * Main controller for FlowTree orchestration with optional Slack integration.
@@ -98,43 +100,6 @@ import io.flowtree.slack.SlackTokens;
  * @see Workstream
  */
 public class FlowTreeController implements ConsoleFeatures {
-
-    /**
-     * Runtime state for a single Slack workspace connection (tokens, Bolt app,
-     * SocketModeApp, notifier). In single-workspace mode only
-     * {@link #defaultConnection} is populated; in multi-workspace mode
-     * {@link #workspaceConnections} holds one entry per workspace.
-     */
-    public static class WorkspaceConnection {
-        /** Slack team ID (T...) identifying this workspace. */
-        public final String workspaceId;
-        /** Bot User OAuth token for posting messages (xoxb-...). */
-        public final String botToken;
-        /** App-level token for Socket Mode delivery (xapp-...). */
-        public final String appToken;
-        /** Bolt application instance for this workspace. */
-        public App app;
-        /** Socket Mode connection for this workspace. */
-        public SocketModeApp socketModeApp;
-        /** Bot's own Slack user ID; used to suppress echoed messages. */
-        public String botUserId;
-        /** Notifier backed by this workspace's bot token. */
-        public final SlackNotifier notifier;
-
-        /**
-         * Creates a workspace connection with the given tokens.
-         *
-         * @param workspaceId human-readable or team-ID label
-         * @param botToken    Slack bot user token (xoxb-...)
-         * @param appToken    Slack app-level token (xapp-...)
-         */
-        public WorkspaceConnection(String workspaceId, String botToken, String appToken) {
-            this.workspaceId = workspaceId;
-            this.botToken = botToken;
-            this.appToken = appToken;
-            this.notifier = new SlackNotifier(botToken);
-        }
-    }
 
     /**
      * Per-workspace Slack connections, keyed by workspace ID.
@@ -197,7 +162,7 @@ public class FlowTreeController implements ConsoleFeatures {
      * {@link #buildSecretsCache(WorkstreamConfig)} during config load and
      * passed to the API endpoint via {@link FlowTreeApiEndpoint#setSecretsCache}.
      */
-    private Map<String, Map<String, WorkstreamConfig.WorkspaceSecretEntry>> secretsCache =
+    private Map<String, Map<String, WorkspaceSecretEntry>> secretsCache =
             new HashMap<>();
 
     /**
@@ -396,23 +361,23 @@ public class FlowTreeController implements ConsoleFeatures {
      * Builds the in-memory secrets index from the loaded workstream config.
      *
      * <p>Iterates all {@code slackWorkspaces} entries and indexes their declared
-     * {@link WorkstreamConfig.WorkspaceSecretEntry} instances by workspace ID and name.
+     * {@link WorkspaceSecretEntry} instances by workspace ID and name.
      * Also logs a warning for any declared secrets file that is readable by group or
      * world (permissions wider than {@code 0600}).</p>
      *
      * @param config the loaded workstream configuration
      */
     private void buildSecretsCache(WorkstreamConfig config) {
-        Map<String, Map<String, WorkstreamConfig.WorkspaceSecretEntry>> cache = new HashMap<>();
+        Map<String, Map<String, WorkspaceSecretEntry>> cache = new HashMap<>();
         if (config.getWorkspaces() == null) {
             this.secretsCache = cache;
             return;
         }
-        for (WorkstreamConfig.WorkspaceEntry wsEntry : config.getWorkspaces()) {
+        for (WorkspaceEntry wsEntry : config.getWorkspaces()) {
             if (wsEntry.getSecrets() == null || wsEntry.getSecrets().isEmpty()) continue;
             String workspaceId = wsEntry.getId();
-            Map<String, WorkstreamConfig.WorkspaceSecretEntry> byName = new HashMap<>();
-            for (WorkstreamConfig.WorkspaceSecretEntry entry : wsEntry.getSecrets()) {
+            Map<String, WorkspaceSecretEntry> byName = new HashMap<>();
+            for (WorkspaceSecretEntry entry : wsEntry.getSecrets()) {
                 if (entry.getName() == null || entry.getFile() == null) continue;
                 byName.put(entry.getName(), entry);
                 checkSecretFilePermissions(entry, workspaceId);
@@ -434,7 +399,7 @@ public class FlowTreeController implements ConsoleFeatures {
      * @param workspaceId workspace owning this secret (for log context only)
      */
     private void checkSecretFilePermissions(
-            WorkstreamConfig.WorkspaceSecretEntry entry, String workspaceId) {
+            WorkspaceSecretEntry entry, String workspaceId) {
         Path filePath = Path.of(entry.getFile());
         if (!Files.exists(filePath)) {
             warn("Secret file not found: " + entry.getFile()
@@ -634,9 +599,9 @@ public class FlowTreeController implements ConsoleFeatures {
      *
      * @param entries the Slack workspace entries from the YAML configuration
      */
-    private void buildWorkspaceConnections(List<WorkstreamConfig.WorkspaceEntry> entries) {
+    private void buildWorkspaceConnections(List<WorkspaceEntry> entries) {
         workspaceConnections.clear();
-        for (WorkstreamConfig.WorkspaceEntry wsEntry : entries) {
+        for (WorkspaceEntry wsEntry : entries) {
             if (wsEntry.getSlackTeamId() == null || wsEntry.getSlackTeamId().isEmpty()) {
                 // No Slack integration — register a no-op connection so
                 // multi-workspace routing stays active and start() does not
@@ -877,108 +842,6 @@ public class FlowTreeController implements ConsoleFeatures {
     }
 
     /**
-     * Starts centralized MCP servers as HTTP processes and builds the
-     * centralized config JSON for passing to agents.
-     *
-     * <p>Each server in the YAML {@code mcpServers} section is started as a
-     * Python subprocess with {@code MCP_TRANSPORT=http} and its configured
-     * port. The source file paths are resolved relative to the config file's
-     * parent directory.</p>
-     *
-     * <p><b>Deprecated:</b> Centralized MCP servers are no longer managed by the controller.
-     * ar-manager is the single centralized tool, running as a separate Docker service.
-     * This method is retained for reference but is not called during normal startup.</p>
-     *
-     * @param config    the parsed workstream configuration
-     * @param configDir the directory containing the YAML config file, used to
-     *                  resolve relative source paths (may be null)
-     * @deprecated ar-manager replaces all centralized MCP servers
-     */
-    @Deprecated
-    private void startCentralizedMcpServers(WorkstreamConfig config, File configDir) {
-        // No-op: ar-manager replaces all centralized MCP servers.
-        // Agents access ar-manager over HTTP with HMAC temp tokens.
-        Map<String, WorkstreamConfig.McpServerEntry> mcpServers = config.getMcpServers();
-        if (mcpServers == null || mcpServers.isEmpty()) return;
-
-        log("Configuring " + mcpServers.size() + " centralized MCP server(s)...");
-
-        // Build the centralized config JSON as we register each server
-        StringBuilder configJson = new StringBuilder("{");
-        boolean first = true;
-
-        for (Map.Entry<String, WorkstreamConfig.McpServerEntry> entry : mcpServers.entrySet()) {
-            String serverName = entry.getKey();
-            WorkstreamConfig.McpServerEntry serverEntry = entry.getValue();
-
-            String url;
-            List<String> tools;
-
-            if (serverEntry.isExternal()) {
-                // External server: already running, just reference by URL
-                url = serverEntry.getUrl();
-                tools = serverEntry.getTools();
-                if (tools == null || tools.isEmpty()) {
-                    warn("External server " + serverName + " has no tools listed — "
-                        + "agents will not be able to use it");
-                    tools = List.of();
-                }
-                log("External " + serverName + " at " + url
-                    + " (" + tools.size() + " tools)");
-            } else {
-                // Managed server: resolve source, discover tools, launch process
-                Path sourcePath = resolveToolSource(serverEntry.getSource(), configDir);
-
-                tools = McpToolDiscovery.discoverToolNames(sourcePath);
-                if (tools.isEmpty()) {
-                    warn("No tools discovered from " + sourcePath + " for server " + serverName);
-                }
-
-                try {
-                    ProcessBuilder pb = new ProcessBuilder("python3", sourcePath.toString());
-                    pb.environment().put("MCP_TRANSPORT", "http");
-                    pb.environment().put("MCP_PORT", String.valueOf(serverEntry.getPort()));
-
-                    for (Map.Entry<String, String> env : System.getenv().entrySet()) {
-                        if (env.getKey().startsWith("AR_")) {
-                            pb.environment().put(env.getKey(), env.getValue());
-                        }
-                    }
-
-                    pb.inheritIO();
-                    GitOperations.augmentPath(pb);
-
-                    Process process = pb.start();
-                    mcpProcesses.add(process);
-                    log("Started " + serverName + " on port " + serverEntry.getPort()
-                        + " (PID " + process.pid() + ", " + tools.size() + " tools)");
-                } catch (IOException e) {
-                    warn("Failed to start " + serverName + ": " + e.getMessage());
-                    continue;
-                }
-
-                url = "http://0.0.0.0:" + serverEntry.getPort() + "/mcp";
-            }
-
-            if (!first) configJson.append(",");
-            first = false;
-            configJson.append("\"").append(serverName).append("\":{");
-            configJson.append("\"url\":\"").append(url).append("\",");
-            configJson.append("\"tools\":[");
-            for (int i = 0; i < tools.size(); i++) {
-                if (i > 0) configJson.append(",");
-                configJson.append("\"").append(tools.get(i)).append("\"");
-            }
-            configJson.append("]}");
-        }
-
-        configJson.append("}");
-        String centralizedConfig = configJson.toString();
-
-        log("Centralized MCP config (legacy, not used): " + centralizedConfig);
-    }
-
-    /**
      * Loads the ar-manager shared secret from a file or environment variable.
      *
      * <p>Checks {@code AR_MANAGER_SHARED_SECRET_FILE} first (path to a file
@@ -1077,7 +940,7 @@ public class FlowTreeController implements ConsoleFeatures {
         // workstreams.yaml entries. The built-ins go first so that
         // operator entries with the same name silently override them
         // (giving operators a release valve if they need a custom build).
-        Map<String, WorkstreamConfig.PushedToolEntry> pushedTools = new LinkedHashMap<>();
+        Map<String, PushedToolEntry> pushedTools = new LinkedHashMap<>();
         pushedTools.put("ar-secrets", builtInSecretsEntry());
         if (loadedConfig != null && loadedConfig.getPushedTools() != null) {
             pushedTools.putAll(loadedConfig.getPushedTools());
@@ -1088,9 +951,9 @@ public class FlowTreeController implements ConsoleFeatures {
         StringBuilder configJson = new StringBuilder("{");
         boolean first = true;
 
-        for (Map.Entry<String, WorkstreamConfig.PushedToolEntry> entry : pushedTools.entrySet()) {
+        for (Map.Entry<String, PushedToolEntry> entry : pushedTools.entrySet()) {
             String serverName = entry.getKey();
-            WorkstreamConfig.PushedToolEntry toolEntry = entry.getValue();
+            PushedToolEntry toolEntry = entry.getValue();
 
             Path sourcePath = resolveToolSource(toolEntry.getSource(), configDir);
             if (!Files.exists(sourcePath)) {
@@ -1152,7 +1015,7 @@ public class FlowTreeController implements ConsoleFeatures {
     }
 
     /**
-     * Builds the synthetic {@link WorkstreamConfig.PushedToolEntry} for the
+     * Builds the synthetic {@link PushedToolEntry} for the
      * built-in {@code ar-secrets} MCP server. Source path
      * ({@code tools/mcp/secrets/server.py}) is resolved through the same
      * {@link #resolveToolSource(String, File)} fallback chain as
@@ -1162,10 +1025,10 @@ public class FlowTreeController implements ConsoleFeatures {
      * {@code AR_WORKSTREAM_ID}, and {@code AR_MANAGER_TOKEN} from the
      * process environment that {@code CodingAgentJob} sets per job.
      *
-     * @return a {@link WorkstreamConfig.PushedToolEntry} for ar-secrets
+     * @return a {@link PushedToolEntry} for ar-secrets
      */
-    private static WorkstreamConfig.PushedToolEntry builtInSecretsEntry() {
-        WorkstreamConfig.PushedToolEntry entry = new WorkstreamConfig.PushedToolEntry();
+    private static PushedToolEntry builtInSecretsEntry() {
+        PushedToolEntry entry = new PushedToolEntry();
         entry.setSource("tools/mcp/secrets/server.py");
         return entry;
     }
@@ -1432,169 +1295,15 @@ public class FlowTreeController implements ConsoleFeatures {
         return json.substring(valueStart, valueEnd);
     }
 
-    // Command-line interface
-
     /**
-     * Main entry point for running the FlowTree controller.
+     * Delegates to {@link FlowTreeControllerLauncher#main(String[])} for
+     * backwards compatibility with existing scripts and container entrypoints
+     * that reference this class as the main class.
      *
-     * <p>The controller starts a FlowTree {@link Server} that listens for
-     * inbound agent connections. Agents connect to this server by setting
-     * {@code FLOWTREE_ROOT_HOST} and {@code FLOWTREE_ROOT_PORT}.</p>
-     *
-     * <p>Environment variables:</p>
-     * <ul>
-     *   <li>SLACK_BOT_TOKEN - Required for Slack integration</li>
-     *   <li>SLACK_APP_TOKEN - Required for Socket Mode</li>
-     *   <li>FLOWTREE_PORT - FlowTree listening port (default: 7766)</li>
-     * </ul>
-     *
-     * <p>Arguments:</p>
-     * <ul>
-     *   <li>--tokens &lt;file&gt; - JSON file containing botToken and appToken</li>
-     *   <li>--config &lt;file&gt; - YAML configuration file</li>
-     *   <li>--channel &lt;id&gt; - Single channel to monitor</li>
-     *   <li>--branch &lt;name&gt; - Default branch</li>
-     *   <li>--flowtree-port &lt;port&gt; - FlowTree listening port</li>
-     * </ul>
+     * @param args command-line arguments
+     * @throws Exception if startup fails
      */
     public static void main(String[] args) throws Exception {
-        String configFile = null;
-        String tokensFile = null;
-        String channelId = System.getenv("SLACK_CHANNEL_ID");
-        String channelName = System.getenv("SLACK_CHANNEL_NAME");
-        String defaultBranch = System.getenv("GIT_DEFAULT_BRANCH");
-        int apiPort = FlowTreeApiEndpoint.DEFAULT_PORT;
-        int flowtreePort = Integer.parseInt(
-                System.getenv().getOrDefault("FLOWTREE_PORT",
-                        String.valueOf(Server.defaultPort)));
-
-        // Parse command-line arguments
-        for (int i = 0; i < args.length; i++) {
-            switch (args[i]) {
-                case "--config":
-                case "-c":
-                    configFile = args[++i];
-                    break;
-                case "--tokens":
-                case "-t":
-                    tokensFile = args[++i];
-                    break;
-                case "--channel":
-                    channelId = args[++i];
-                    break;
-                case "--channel-name":
-                    channelName = args[++i];
-                    break;
-                case "--branch":
-                    defaultBranch = args[++i];
-                    break;
-                case "--api-port":
-                    apiPort = Integer.parseInt(args[++i]);
-                    break;
-                case "--flowtree-port":
-                    flowtreePort = Integer.parseInt(args[++i]);
-                    break;
-                case "--log-file":
-                    System.setProperty("flowtree.log.file", args[++i]);
-                    break;
-                case "--help":
-                case "-h":
-                    printUsage();
-                    return;
-            }
-        }
-
-        // Resolve tokens
-        File tokensPath = tokensFile != null ? new File(tokensFile) : null;
-        SlackTokens tokens = SlackTokens.resolve(tokensPath);
-
-        // Create controller
-        FlowTreeController controller = new FlowTreeController(tokens);
-        controller.setApiPort(apiPort);
-        controller.setFlowtreePort(flowtreePort);
-
-        // Load configuration
-        if (configFile != null) {
-            controller.loadConfig(new File(configFile));
-        } else if (channelId != null && !channelId.isEmpty()) {
-            // Single workstream from environment/args
-            Workstream workstream = new Workstream(
-                channelId,
-                channelName != null ? channelName : channelId
-            );
-            if (defaultBranch != null) {
-                workstream.setDefaultBranch(defaultBranch);
-            }
-            controller.registerWorkstream(workstream);
-        } else {
-            Console.root().warn("Error: No workstream configuration provided");
-            Console.root().warn("Use --config <file> or --channel <id>");
-            printUsage();
-            System.exit(1);
-        }
-
-        // Start controller
-        controller.start();
-
-        // Keep main thread alive
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            try {
-                controller.stop();
-            } catch (Exception e) {
-                Console.root().warn(e.getMessage());
-            }
-        }));
-
-        Thread.currentThread().join();
-    }
-
-    /**
-     * Prints CLI usage information to standard output and returns.
-     *
-     * <p>Called when {@code --help} or {@code -h} is passed on the command line,
-     * or when no workstream configuration is found. Lists all supported flags,
-     * environment variables, token resolution order, and example invocations.</p>
-     */
-    private static void printUsage() {
-        Console.root().println("Usage: FlowTreeController [options]");
-        Console.root().println("");
-        Console.root().println("Options:");
-        Console.root().println("  --tokens, -t <file>    JSON file with botToken/appToken");
-        Console.root().println("  --config, -c <file>    YAML configuration file");
-        Console.root().println("  --channel <id>         Slack channel ID to monitor");
-        Console.root().println("  --channel-name <name>  Human-readable channel name");
-        Console.root().println("  --branch <name>        Default git branch for commits");
-        Console.root().println("  --api-port <port>      Port for the HTTP API endpoint (default: 7780)");
-        Console.root().println("  --flowtree-port <port> Port for the FlowTree server (default: 7766)");
-        Console.root().println("  --log-file <path>      Log file path (default: flowtree-controller.log)");
-        Console.root().println("  --help, -h             Show this help");
-        Console.root().println("");
-        Console.root().println("Agents connect TO this controller on the FlowTree port.");
-        Console.root().println("Set FLOWTREE_ROOT_HOST and FLOWTREE_ROOT_PORT on each agent.");
-        Console.root().println("");
-        Console.root().println("Token resolution (first match wins):");
-        Console.root().println("  1. --tokens <file>           Explicit token file");
-        Console.root().println("  2. ./slack-tokens.json       Convention file in working directory");
-        Console.root().println("  3. SLACK_BOT_TOKEN / SLACK_APP_TOKEN environment variables");
-        Console.root().println("");
-        Console.root().println("Token file format (JSON):");
-        Console.root().println("  { \"botToken\": \"xoxb-...\", \"appToken\": \"xapp-...\" }");
-        Console.root().println("");
-        Console.root().println("Environment variables:");
-        Console.root().println("  SLACK_BOT_TOKEN        Bot User OAuth Token (xoxb-...)");
-        Console.root().println("  SLACK_APP_TOKEN        App-level token for Socket Mode (xapp-...)");
-        Console.root().println("  SLACK_CHANNEL_ID       Default channel to monitor");
-        Console.root().println("  FLOWTREE_PORT          FlowTree listening port (default: 7766)");
-        Console.root().println("  GIT_DEFAULT_BRANCH     Default git branch for commits");
-        Console.root().println("");
-        Console.root().println("Example with token file:");
-        Console.root().println("  java -cp flowtree.jar io.flowtree.controller.FlowTreeController \\");
-        Console.root().println("      --tokens slack-tokens.json --config workstreams.yaml");
-        Console.root().println("");
-        Console.root().println("Example with environment variables:");
-        Console.root().println("  export SLACK_BOT_TOKEN=xoxb-...");
-        Console.root().println("  export SLACK_APP_TOKEN=xapp-...");
-        Console.root().println("  java -cp flowtree.jar io.flowtree.controller.FlowTreeController \\");
-        Console.root().println("      --config workstreams.yaml");
+        FlowTreeControllerLauncher.main(args);
     }
 }

--- a/flowtree/runtime/src/main/java/io/flowtree/controller/FlowTreeControllerLauncher.java
+++ b/flowtree/runtime/src/main/java/io/flowtree/controller/FlowTreeControllerLauncher.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2026 Michael Murray
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.flowtree.controller;
+
+import io.flowtree.Server;
+import io.flowtree.api.FlowTreeApiEndpoint;
+import io.flowtree.slack.SlackTokens;
+import io.flowtree.workstream.Workstream;
+import org.almostrealism.io.Console;
+
+import java.io.File;
+// TODO(review): unused import — remove to prevent checkstyle UnusedImports failure
+import java.io.IOException;
+
+/**
+ * Command-line entry point for the FlowTree controller.
+ *
+ * <p>Parses arguments, resolves tokens, and starts a {@link FlowTreeController}.
+ * Split from {@code FlowTreeController} to keep the controller class focused on
+ * its runtime concern (lifecycle management) while centralising CLI parsing here.</p>
+ *
+ * <p>The controller starts a FlowTree {@link Server} that listens for inbound
+ * agent connections. Agents connect by setting {@code FLOWTREE_ROOT_HOST} and
+ * {@code FLOWTREE_ROOT_PORT}.</p>
+ *
+ * <p>Arguments:</p>
+ * <ul>
+ *   <li>{@code --tokens/-t <file>} — JSON file containing botToken and appToken</li>
+ *   <li>{@code --config/-c <file>} — YAML configuration file</li>
+ *   <li>{@code --channel <id>}     — Single channel to monitor</li>
+ *   <li>{@code --channel-name <name>} — Human-readable channel name</li>
+ *   <li>{@code --branch <name>}    — Default branch</li>
+ *   <li>{@code --api-port <port>}  — HTTP API endpoint port</li>
+ *   <li>{@code --flowtree-port <port>} — FlowTree agent-connection port</li>
+ *   <li>{@code --log-file <path>}  — Log file path</li>
+ * </ul>
+ *
+ * <p>Environment variables:</p>
+ * <ul>
+ *   <li>{@code SLACK_BOT_TOKEN} — Bot User OAuth Token (xoxb-...)</li>
+ *   <li>{@code SLACK_APP_TOKEN} — App-level token for Socket Mode (xapp-...)</li>
+ *   <li>{@code SLACK_CHANNEL_ID} — Default channel to monitor</li>
+ *   <li>{@code FLOWTREE_PORT}   — FlowTree listening port (default: 7766)</li>
+ *   <li>{@code GIT_DEFAULT_BRANCH} — Default git branch for commits</li>
+ * </ul>
+ *
+ * @author Michael Murray
+ * @see FlowTreeController
+ */
+public final class FlowTreeControllerLauncher {
+
+    private FlowTreeControllerLauncher() { }
+
+    /**
+     * Main entry point for running the FlowTree controller.
+     *
+     * @param args command-line arguments
+     * @throws Exception if startup fails
+     */
+    public static void main(String[] args) throws Exception {
+        String configFile = null;
+        String tokensFile = null;
+        String channelId = System.getenv("SLACK_CHANNEL_ID");
+        String channelName = System.getenv("SLACK_CHANNEL_NAME");
+        String defaultBranch = System.getenv("GIT_DEFAULT_BRANCH");
+        int apiPort = FlowTreeApiEndpoint.DEFAULT_PORT;
+        int flowtreePort = Integer.parseInt(
+                System.getenv().getOrDefault("FLOWTREE_PORT",
+                        String.valueOf(Server.defaultPort)));
+
+        for (int i = 0; i < args.length; i++) {
+            switch (args[i]) {
+                case "--config":
+                case "-c":
+                    configFile = args[++i];
+                    break;
+                case "--tokens":
+                case "-t":
+                    tokensFile = args[++i];
+                    break;
+                case "--channel":
+                    channelId = args[++i];
+                    break;
+                case "--channel-name":
+                    channelName = args[++i];
+                    break;
+                case "--branch":
+                    defaultBranch = args[++i];
+                    break;
+                case "--api-port":
+                    apiPort = Integer.parseInt(args[++i]);
+                    break;
+                case "--flowtree-port":
+                    flowtreePort = Integer.parseInt(args[++i]);
+                    break;
+                case "--log-file":
+                    System.setProperty("flowtree.log.file", args[++i]);
+                    break;
+                case "--help":
+                case "-h":
+                    printUsage();
+                    return;
+                default:
+                    break;
+            }
+        }
+
+        File tokensPath = tokensFile != null ? new File(tokensFile) : null;
+        SlackTokens tokens = SlackTokens.resolve(tokensPath);
+
+        FlowTreeController controller = new FlowTreeController(tokens);
+        controller.setApiPort(apiPort);
+        controller.setFlowtreePort(flowtreePort);
+
+        if (configFile != null) {
+            controller.loadConfig(new File(configFile));
+        } else if (channelId != null && !channelId.isEmpty()) {
+            Workstream workstream = new Workstream(
+                channelId,
+                channelName != null ? channelName : channelId
+            );
+            if (defaultBranch != null) {
+                workstream.setDefaultBranch(defaultBranch);
+            }
+            controller.registerWorkstream(workstream);
+        } else {
+            Console.root().warn("Error: No workstream configuration provided");
+            Console.root().warn("Use --config <file> or --channel <id>");
+            printUsage();
+            System.exit(1);
+        }
+
+        controller.start();
+
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            try {
+                controller.stop();
+            } catch (Exception e) {
+                Console.root().warn(e.getMessage());
+            }
+        }));
+
+        Thread.currentThread().join();
+    }
+
+    /**
+     * Prints CLI usage information to standard output.
+     */
+    static void printUsage() {
+        Console.root().println("Usage: FlowTreeController [options]");
+        Console.root().println("");
+        Console.root().println("Options:");
+        Console.root().println("  --tokens, -t <file>    JSON file with botToken/appToken");
+        Console.root().println("  --config, -c <file>    YAML configuration file");
+        Console.root().println("  --channel <id>         Slack channel ID to monitor");
+        Console.root().println("  --channel-name <name>  Human-readable channel name");
+        Console.root().println("  --branch <name>        Default git branch for commits");
+        Console.root().println("  --api-port <port>      Port for the HTTP API endpoint (default: 7780)");
+        Console.root().println("  --flowtree-port <port> Port for the FlowTree server (default: 7766)");
+        Console.root().println("  --log-file <path>      Log file path (default: flowtree-controller.log)");
+        Console.root().println("  --help, -h             Show this help");
+        Console.root().println("");
+        Console.root().println("Agents connect TO this controller on the FlowTree port.");
+        Console.root().println("Set FLOWTREE_ROOT_HOST and FLOWTREE_ROOT_PORT on each agent.");
+        Console.root().println("");
+        Console.root().println("Token resolution (first match wins):");
+        Console.root().println("  1. --tokens <file>           Explicit token file");
+        Console.root().println("  2. ./slack-tokens.json       Convention file in working directory");
+        Console.root().println("  3. SLACK_BOT_TOKEN / SLACK_APP_TOKEN environment variables");
+        Console.root().println("");
+        Console.root().println("Token file format (JSON):");
+        Console.root().println("  { \"botToken\": \"xoxb-...\", \"appToken\": \"xapp-...\" }");
+        Console.root().println("");
+        Console.root().println("Environment variables:");
+        Console.root().println("  SLACK_BOT_TOKEN        Bot User OAuth Token (xoxb-...)");
+        Console.root().println("  SLACK_APP_TOKEN        App-level token for Socket Mode (xapp-...)");
+        Console.root().println("  SLACK_CHANNEL_ID       Default channel to monitor");
+        Console.root().println("  FLOWTREE_PORT          FlowTree listening port (default: 7766)");
+        Console.root().println("  GIT_DEFAULT_BRANCH     Default git branch for commits");
+    }
+}

--- a/flowtree/runtime/src/main/java/io/flowtree/controller/WorkspaceConnection.java
+++ b/flowtree/runtime/src/main/java/io/flowtree/controller/WorkspaceConnection.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 Michael Murray
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.flowtree.controller;
+
+import com.slack.api.bolt.App;
+import com.slack.api.bolt.socket_mode.SocketModeApp;
+import io.flowtree.slack.SlackNotifier;
+
+/**
+ * Runtime state for a single Slack workspace connection.
+ *
+ * <p>In single-workspace mode only {@link FlowTreeController#defaultConnection}
+ * is populated; in multi-workspace mode
+ * {@link FlowTreeController#workspaceConnections} holds one entry per workspace.</p>
+ *
+ * @author Michael Murray
+ * @see FlowTreeController
+ */
+public class WorkspaceConnection {
+
+    /** Slack team ID (T...) identifying this workspace. */
+    public final String workspaceId;
+    /** Bot User OAuth token for posting messages (xoxb-...). */
+    public final String botToken;
+    /** App-level token for Socket Mode delivery (xapp-...). */
+    public final String appToken;
+    /** Bolt application instance for this workspace. */
+    public App app;
+    /** Socket Mode connection for this workspace. */
+    public SocketModeApp socketModeApp;
+    /** Bot's own Slack user ID; used to suppress echoed messages. */
+    public String botUserId;
+    /** Notifier backed by this workspace's bot token. */
+    public final SlackNotifier notifier;
+
+    /**
+     * Creates a workspace connection with the given tokens.
+     *
+     * @param workspaceId human-readable or team-ID label
+     * @param botToken    Slack bot user token (xoxb-...), or {@code null}
+     * @param appToken    Slack app-level token (xapp-...), or {@code null}
+     */
+    public WorkspaceConnection(String workspaceId, String botToken, String appToken) {
+        this.workspaceId = workspaceId;
+        this.botToken = botToken;
+        this.appToken = appToken;
+        this.notifier = new SlackNotifier(botToken);
+    }
+}

--- a/flowtree/runtime/src/main/java/io/flowtree/github/GitHubTokenValidator.java
+++ b/flowtree/runtime/src/main/java/io/flowtree/github/GitHubTokenValidator.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.Set;
 import io.flowtree.controller.FlowTreeController;
 import io.flowtree.workstream.WorkstreamConfig;
+import io.flowtree.workstream.WorkstreamEntry;
 
 /**
  * Validates GitHub API tokens at controller startup.
@@ -254,7 +255,7 @@ public class GitHubTokenValidator implements ConsoleFeatures {
 		}
 
 		// Scan workstreams to determine which token handles which repo
-		for (WorkstreamConfig.WorkstreamEntry ws : config.getWorkstreams()) {
+		for (WorkstreamEntry ws : config.getWorkstreams()) {
 			String ownerRepo = extractOwnerRepo(ws.getRepoUrl());
 			if (ownerRepo == null) continue;
 
@@ -286,7 +287,7 @@ public class GitHubTokenValidator implements ConsoleFeatures {
 	 * @param orgTokens map of org name to token
 	 * @return the resolved token, or null if none available
 	 */
-	private String resolveWorkstreamToken(WorkstreamConfig.WorkstreamEntry ws,
+	private String resolveWorkstreamToken(WorkstreamEntry ws,
 										  Map<String, String> orgTokens) {
 		// Per-org token via explicit githubOrg field
 		if (ws.getGithubOrg() != null && orgTokens.containsKey(ws.getGithubOrg())) {

--- a/flowtree/runtime/src/main/java/io/flowtree/jobs/CompletionListenerFanout.java
+++ b/flowtree/runtime/src/main/java/io/flowtree/jobs/CompletionListenerFanout.java
@@ -41,6 +41,7 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import io.flowtree.workstream.WorkspaceEntry;
 
 /**
  * Fans a finished job out to its completion listeners by submitting a
@@ -320,7 +321,7 @@ public class CompletionListenerFanout implements ConsoleFeatures {
     /** Pushed-tools config JSON forwarded to every job; may be {@code null}. */
     private final String pushedToolsConfig;
     /** Workspace lookup; {@code null} means workspace layer is skipped. */
-    private final Function<String, WorkstreamConfig.WorkspaceEntry> workspaceLookup;
+    private final Function<String, WorkspaceEntry> workspaceLookup;
     /** Default workspace path; propagated to wake-up factories when set. */
     private final String defaultWorkspacePath;
     /**
@@ -352,7 +353,7 @@ public class CompletionListenerFanout implements ConsoleFeatures {
                                     String arManagerUrl,
                                     String sharedSecret,
                                     String pushedToolsConfig,
-                                    Function<String, WorkstreamConfig.WorkspaceEntry> workspaceLookup,
+                                    Function<String, WorkspaceEntry> workspaceLookup,
                                     String defaultWorkspacePath) {
         this(acceptSupplier, allWorkstreams, server, statsStore,
                 workstreamUrlBuilder, arManagerUrl, sharedSecret,
@@ -376,7 +377,7 @@ public class CompletionListenerFanout implements ConsoleFeatures {
                                     String arManagerUrl,
                                     String sharedSecret,
                                     String pushedToolsConfig,
-                                    Function<String, WorkstreamConfig.WorkspaceEntry> workspaceLookup,
+                                    Function<String, WorkspaceEntry> workspaceLookup,
                                     String defaultWorkspacePath,
                                     Supplier<Long> clock) {
         this(acceptSupplier, allWorkstreams, server, statsStore,
@@ -403,7 +404,7 @@ public class CompletionListenerFanout implements ConsoleFeatures {
                                     String arManagerUrl,
                                     String sharedSecret,
                                     String pushedToolsConfig,
-                                    Function<String, WorkstreamConfig.WorkspaceEntry> workspaceLookup,
+                                    Function<String, WorkspaceEntry> workspaceLookup,
                                     String defaultWorkspacePath,
                                     ListenerNotifierLookup listenerNotifierLookup,
                                     Supplier<Long> clock) {
@@ -450,7 +451,7 @@ public class CompletionListenerFanout implements ConsoleFeatures {
             pushedToolsConfig = listener.getPushedToolsConfig();
             defaultWorkspacePath = listener.getDefaultWorkspacePath();
         }
-        Function<String, WorkstreamConfig.WorkspaceEntry> wsLookup = endpoint::workspaceLookupOrNull;
+        Function<String, WorkspaceEntry> wsLookup = endpoint::workspaceLookupOrNull;
         ListenerNotifierLookup listenerLookup = listenerWsId -> {
             SlackNotifier n = notifiers.notifierFor(listenerWsId);
             if (n == null || n.getWorkstream(listenerWsId) == null) return null;
@@ -773,7 +774,7 @@ public class CompletionListenerFanout implements ConsoleFeatures {
         if (workspaceLookup != null) {
             String wsId = listener.getWorkspaceId();
             if (wsId != null && !wsId.isEmpty()) {
-                WorkstreamConfig.WorkspaceEntry wsEntry = workspaceLookup.apply(wsId);
+                WorkspaceEntry wsEntry = workspaceLookup.apply(wsId);
                 if (wsEntry != null) {
                     Map<String, String> wsLabels = extractWorkspaceLabels();
                     if (wsLabels != null && !wsLabels.isEmpty()) {
@@ -794,7 +795,7 @@ public class CompletionListenerFanout implements ConsoleFeatures {
 
     /**
      * Reads required-labels from a workspace entry. The
-     * {@link WorkstreamConfig.WorkspaceEntry} class does not currently
+     * {@link WorkspaceEntry} class does not currently
      * carry a per-workspace {@code requiredLabels} map (that is a
      * workstream-level concept in v1), so this method is a no-op
      * stub; the listener's own {@code requiredLabels} already covers

--- a/flowtree/runtime/src/main/java/io/flowtree/slack/SlackSubmissionConfig.java
+++ b/flowtree/runtime/src/main/java/io/flowtree/slack/SlackSubmissionConfig.java
@@ -23,6 +23,7 @@ import java.util.function.Consumer;
 import io.flowtree.submission.SubmissionConfigResolver;
 import io.flowtree.workstream.Workstream;
 import io.flowtree.workstream.WorkstreamConfig;
+import io.flowtree.workstream.WorkspaceEntry;
 
 /**
  * Slack-specific glue that wires {@link SubmissionConfigResolver} into the
@@ -74,7 +75,7 @@ final class SlackSubmissionConfig {
                          WorkstreamConfig workstreamConfig,
                          SlackNotifier notifier,
                          Consumer<String> diagnostic) {
-        WorkstreamConfig.WorkspaceEntry wsEntry = null;
+        WorkspaceEntry wsEntry = null;
         if (workstreamConfig != null) {
             String wsId = workstream.getWorkspaceId();
             if (wsId != null && !wsId.isEmpty()) {

--- a/flowtree/runtime/src/main/java/io/flowtree/slack/SlackTokens.java
+++ b/flowtree/runtime/src/main/java/io/flowtree/slack/SlackTokens.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.IOException;
 import io.flowtree.controller.FlowTreeController;
 import io.flowtree.workstream.WorkstreamConfig;
+import io.flowtree.workstream.WorkspaceEntry;
 
 /**
  * Holds Slack API tokens (bot token and app token) and provides
@@ -99,7 +100,7 @@ public class SlackTokens {
 	 * @return a {@link SlackTokens} instance
 	 * @throws IOException if {@code tokensFile} is set but cannot be read
 	 */
-	public static SlackTokens from(WorkstreamConfig.WorkspaceEntry entry) throws IOException {
+	public static SlackTokens from(WorkspaceEntry entry) throws IOException {
 		if (entry.getTokensFile() != null && !entry.getTokensFile().isEmpty()) {
 			return loadFromFile(new File(entry.getTokensFile()));
 		}

--- a/flowtree/runtime/src/main/java/io/flowtree/submission/PhaseConfigResolver.java
+++ b/flowtree/runtime/src/main/java/io/flowtree/submission/PhaseConfigResolver.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.Set;
 import io.flowtree.workstream.Workstream;
 import io.flowtree.workstream.WorkstreamConfig;
+import io.flowtree.workstream.WorkspaceEntry;
 
 /**
  * Resolves per-phase agent configuration ({@link PhaseConfig}) by walking
@@ -526,7 +527,7 @@ public final class PhaseConfigResolver {
      * @param body  the raw request body JSON; may be {@code null} or empty
      * @return {@code null} on success; an error message on syntax-validation failure
      */
-    public static String applyToWorkspace(WorkstreamConfig.WorkspaceEntry entry, String body) {
+    public static String applyToWorkspace(WorkspaceEntry entry, String body) {
         if (entry == null) return null;
         JsonNode root = parseBodyRoot(body);
         if (root == null) return null;

--- a/flowtree/runtime/src/main/java/io/flowtree/submission/SubmissionConfigResolver.java
+++ b/flowtree/runtime/src/main/java/io/flowtree/submission/SubmissionConfigResolver.java
@@ -22,6 +22,7 @@ import io.flowtree.jobs.agent.PhaseConfigBundle;
 import java.util.Map;
 import io.flowtree.workstream.Workstream;
 import io.flowtree.workstream.WorkstreamConfig;
+import io.flowtree.workstream.WorkspaceEntry;
 
 /**
  * Orchestrator that runs {@link SubmissionRunnerResolver} and
@@ -50,7 +51,7 @@ public final class SubmissionConfigResolver {
     /** Underlying Phase-config resolver; never {@code null}. */
     private final PhaseConfigResolver phaseConfigResolver;
 
-    /** Private constructor; use {@link #resolve(PhaseConfigBundle, Workstream, WorkstreamConfig.WorkspaceEntry)}. */
+    /** Private constructor; use {@link #resolve(PhaseConfigBundle, Workstream, WorkspaceEntry)}. */
     private SubmissionConfigResolver(SubmissionRunnerResolver runnerResolver,
                                      PhaseConfigResolver phaseConfigResolver) {
         this.runnerResolver = runnerResolver;
@@ -76,7 +77,7 @@ public final class SubmissionConfigResolver {
      */
     public static SubmissionConfigResolver resolve(PhaseConfigBundle requestBundle,
                                                    Workstream workstream,
-                                                   WorkstreamConfig.WorkspaceEntry wsEntry) {
+                                                   WorkspaceEntry wsEntry) {
         PhaseConfigBundle req = requestBundle != null ? requestBundle : PhaseConfigBundle.EMPTY;
 
         // Legacy runner ladder. Request-side runners are no longer accepted on

--- a/flowtree/runtime/src/main/java/io/flowtree/submission/SubmissionRunnerResolver.java
+++ b/flowtree/runtime/src/main/java/io/flowtree/submission/SubmissionRunnerResolver.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.function.Consumer;
 import io.flowtree.workstream.Workstream;
 import io.flowtree.workstream.WorkstreamConfig;
+import io.flowtree.workstream.WorkspaceEntry;
 
 /**
  * Helper that resolves per-phase agent runner configuration for a submitted
@@ -37,9 +38,9 @@ import io.flowtree.workstream.WorkstreamConfig;
  *   <li>Workstream per-phase map ({@link Workstream#getRunners()})</li>
  *   <li>Workstream default ({@link Workstream#getDefaultRunner()})</li>
  *   <li>Workspace per-phase map
- *       ({@link WorkstreamConfig.WorkspaceEntry#getRunners()})</li>
+ *       ({@link WorkspaceEntry#getRunners()})</li>
  *   <li>Workspace default
- *       ({@link WorkstreamConfig.WorkspaceEntry#getDefaultRunner()})</li>
+ *       ({@link WorkspaceEntry#getDefaultRunner()})</li>
  *   <li>Controller default ({@code "claude"})</li>
  * </ol>
  *
@@ -241,7 +242,7 @@ public final class SubmissionRunnerResolver {
      * Applies a parsed {@code runners} object to a workspace as its
      * persistent runner configuration. The {@code "default"} key, when
      * present, becomes
-     * {@link WorkstreamConfig.WorkspaceEntry#setDefaultRunner(String)};
+     * {@link WorkspaceEntry#setDefaultRunner(String)};
      * remaining keys (which must be valid {@link Phase} wire names) replace
      * the workspace's per-phase map.
      *
@@ -255,7 +256,7 @@ public final class SubmissionRunnerResolver {
      * @return {@code null} on success, or a 400-able error message on
      *         unknown phase name or unknown runner name
      */
-    public static String applyToWorkspace(WorkstreamConfig.WorkspaceEntry entry,
+    public static String applyToWorkspace(WorkspaceEntry entry,
                                    Map<String, String> requestRunners) {
         return applyRunnerConfig(requestRunners,
                 entry::setDefaultRunner, entry::setRunners);

--- a/flowtree/runtime/src/main/java/io/flowtree/workstream/AgentEntry.java
+++ b/flowtree/runtime/src/main/java/io/flowtree/workstream/AgentEntry.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 Michael Murray
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.flowtree.workstream;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Configuration entry for an agent endpoint.
+ *
+ * <p>Agents connect inbound to the controller's FlowTree server, so the
+ * {@code agents} field on a workstream is optional and typically omitted in
+ * modern deployments. This entry retains backward-compatibility for
+ * configurations that still enumerate explicit outbound agent hosts.</p>
+ *
+ * @author Michael Murray
+ * @see WorkstreamConfig
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AgentEntry {
+
+    /** The agent hostname or IP address (default: {@code "localhost"}). */
+    private String host = "localhost";
+    /** The port the agent's FlowTree node listens on (default: 7766). */
+    private int port = 7766;
+
+    /** No-arg constructor for Jackson deserialization. */
+    public AgentEntry() {}
+
+    /**
+     * Creates a new agent entry with the specified host and port.
+     *
+     * @param host the agent hostname or IP address
+     * @param port the agent port number
+     */
+    public AgentEntry(String host, int port) {
+        this.host = host;
+        this.port = port;
+    }
+
+    /** Returns the agent hostname or IP address. */
+    public String getHost() { return host; }
+    /** Sets the agent hostname or IP address. */
+    public void setHost(String host) { this.host = host; }
+
+    /** Returns the agent port number. */
+    public int getPort() { return port; }
+    /** Sets the agent port number. */
+    public void setPort(int port) { this.port = port; }
+}

--- a/flowtree/runtime/src/main/java/io/flowtree/workstream/GitHubOrgEntry.java
+++ b/flowtree/runtime/src/main/java/io/flowtree/workstream/GitHubOrgEntry.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 Michael Murray
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.flowtree.workstream;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Configuration entry for a GitHub organization token.
+ *
+ * <p>Maps an organization name to a GitHub personal access token.
+ * When a workstream specifies a {@code githubOrg}, the controller
+ * proxy selects the matching token for GitHub API calls.</p>
+ *
+ * @author Michael Murray
+ * @see WorkstreamConfig#mergedGithubOrgTokens()
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class GitHubOrgEntry {
+
+    /** The GitHub personal access token for authenticating as this organization. */
+    private String token;
+
+    /** Returns the GitHub personal access token for this organization. */
+    public String getToken() { return token; }
+    /** Sets the GitHub personal access token for this organization. */
+    public void setToken(String token) { this.token = token; }
+}

--- a/flowtree/runtime/src/main/java/io/flowtree/workstream/McpServerEntry.java
+++ b/flowtree/runtime/src/main/java/io/flowtree/workstream/McpServerEntry.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2026 Michael Murray
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.flowtree.workstream;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+/**
+ * Configuration entry for a centralized MCP server.
+ *
+ * <p>When present in the YAML configuration, the controller starts
+ * each server as an HTTP process and agents connect over HTTP
+ * instead of stdio. This entry is legacy; ar-manager replaces all
+ * centralized MCP servers in current deployments.</p>
+ *
+ * @author Michael Murray
+ * @see WorkstreamConfig
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class McpServerEntry {
+
+    /** Python source file path relative to the project root (for managed servers). */
+    private String source;
+    /** HTTP port the managed server process listens on. */
+    private int port;
+    /** URL of an already-running external server; when set, no subprocess is launched. */
+    private String url;
+    /** Explicit tool names exposed by this server; required when {@code url} is set. */
+    private List<String> tools;
+
+    /** Returns the Python source file path (relative to project root). */
+    public String getSource() { return source; }
+    /** Sets the Python source file path (relative to project root). */
+    public void setSource(String source) { this.source = source; }
+
+    /** Returns the HTTP port to listen on. */
+    public int getPort() { return port; }
+    /** Sets the HTTP port for the managed MCP server process. */
+    public void setPort(int port) { this.port = port; }
+
+    /**
+     * Returns the URL of an already-running centralized server.
+     * When set, the controller does not launch a subprocess —
+     * it simply passes the URL through to agents.
+     */
+    public String getUrl() { return url; }
+    /** Sets the URL of an already-running external MCP server. */
+    public void setUrl(String url) { this.url = url; }
+
+    /**
+     * Returns the explicit tool names for this server.
+     * Required when {@code url} is set (no source file to discover from).
+     */
+    public List<String> getTools() { return tools; }
+    /** Sets the explicit tool names exposed by this server. */
+    public void setTools(List<String> tools) { this.tools = tools; }
+
+    /** Returns true if this entry references an external server by URL. */
+    public boolean isExternal() {
+        return url != null && !url.isEmpty();
+    }
+}

--- a/flowtree/runtime/src/main/java/io/flowtree/workstream/PushedToolEntry.java
+++ b/flowtree/runtime/src/main/java/io/flowtree/workstream/PushedToolEntry.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 Michael Murray
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.flowtree.workstream;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.Map;
+
+/**
+ * Configuration entry for a pushed MCP tool.
+ *
+ * <p>Pushed tools are served as files by the controller and downloaded
+ * into dev containers on first use. Unlike centralized servers (which
+ * run as HTTP processes on the controller), pushed tools run locally
+ * inside each container via stdio.</p>
+ *
+ * @author Michael Murray
+ * @see WorkstreamConfig
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PushedToolEntry {
+
+    /** Python source file path relative to the config directory. */
+    private String source;
+    /** Per-tool environment variables injected into the agent's MCP stdio config. */
+    private Map<String, String> env;
+
+    /** Returns the Python source file path (relative to config directory). */
+    public String getSource() { return source; }
+    /** Sets the Python source file path (relative to config directory). */
+    public void setSource(String source) { this.source = source; }
+
+    /** Returns per-tool environment variables to inject into the MCP stdio config. */
+    public Map<String, String> getEnv() { return env; }
+    /** Sets per-tool environment variables for the MCP stdio config. */
+    public void setEnv(Map<String, String> env) { this.env = env; }
+}

--- a/flowtree/runtime/src/main/java/io/flowtree/workstream/WorkspaceEntry.java
+++ b/flowtree/runtime/src/main/java/io/flowtree/workstream/WorkspaceEntry.java
@@ -1,0 +1,265 @@
+/*
+ * Copyright 2026 Michael Murray
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.flowtree.workstream;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.flowtree.jobs.agent.PhaseConfig;
+import io.flowtree.jobs.agent.PhaseConfigBundle;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Configuration entry for a workspace — the operator's organizational
+ * unit, optionally connected to a Slack team.
+ *
+ * <p>The {@code id} field is operator-chosen and is the identifier
+ * referenced by {@link WorkstreamEntry#getWorkspaceId()}. The optional
+ * {@code slackTeamId} field carries the Slack team ID (e.g.
+ * {@code "T0123456789"}) when the workspace is connected to Slack;
+ * when absent the workspace has no Slack integration and channel/notifier
+ * operations skip cleanly. Legacy {@code slackWorkspaces:} entries are
+ * auto-migrated on load so {@code id == slackTeamId}.</p>
+ *
+ * <p>Slack-credential fields ({@code tokensFile}/{@code botToken}/
+ * {@code appToken}) only have effect when {@code slackTeamId} is set.</p>
+ *
+ * @author Michael Murray
+ * @see WorkstreamConfig
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class WorkspaceEntry {
+
+    /**
+     * Operator-chosen workspace identifier. For legacy {@code slackWorkspaces:}
+     * entries the YAML key {@code workspaceId} is accepted via
+     * {@link JsonAlias} and double-loaded as both {@code id} and
+     * {@code slackTeamId} so that older configs continue to resolve.
+     */
+    @JsonAlias({"workspaceId"})
+    private String id;
+    /**
+     * Optional Slack team ID (e.g. {@code "T0123456789"}) identifying the
+     * Slack workspace this entry routes to. {@code null} when this
+     * workspace has no Slack connection.
+     */
+    private String slackTeamId;
+    /** Human-readable label for this workspace (used in logs and diagnostics). */
+    private String name;
+    /** Path to a JSON file with {@code botToken} and {@code appToken}. */
+    private String tokensFile;
+    /** Inline bot token (xoxb-...); used when {@code tokensFile} is absent. */
+    private String botToken;
+    /** Inline app token (xapp-...); used when {@code tokensFile} is absent. */
+    private String appToken;
+    /** Default Slack channel ID for fallback message delivery in this workspace. */
+    private String defaultChannel;
+    /**
+     * Single Slack user ID auto-invited to newly created channels in this
+     * workspace. Superseded by {@link #channelOwnerUserIds} when that list
+     * is non-empty; retained for backwards compatibility with configs that
+     * predate multi-user invites.
+     */
+    private String channelOwnerUserId;
+    /**
+     * Slack user IDs auto-invited to newly created channels in this
+     * workspace. When set, takes precedence over {@link #channelOwnerUserId}.
+     */
+    private List<String> channelOwnerUserIds;
+    /** Per-organization GitHub tokens scoped to this workspace. */
+    private Map<String, GitHubOrgEntry> githubOrgs = new LinkedHashMap<>();
+    /** Secrets declared as available to workstreams in this workspace. */
+    private List<WorkspaceSecretEntry> secrets = new ArrayList<>();
+    /**
+     * Workspace-level default {@link io.flowtree.jobs.agent.AgentRunner}
+     * applied to workstreams in this workspace when neither the workstream
+     * itself nor the per-job override sets one. Sits between the
+     * workstream default and the controller default in the routing
+     * ladder. Optional; {@code null} omits the field from serialized YAML.
+     *
+     * <p>Legacy field: still accepted on load and auto-migrated into
+     * {@link #defaultPhaseConfig}, but never written back — serialization
+     * is write-only so a save-then-load cycle drops it in favour of the
+     * per-phase shape.</p>
+     */
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    private String defaultRunner;
+    /**
+     * Workspace-level per-phase runner overrides keyed by phase wire name
+     * (e.g. {@code primary}, {@code commit-message}). Consulted by the
+     * resolver only when the workstream has no per-phase entry for the
+     * same phase and no workstream-level {@code defaultRunner}. Legacy
+     * field: accepted on load and auto-migrated into {@link #phaseConfigs},
+     * but write-only for serialization.
+     */
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    private Map<String, String> runners = new LinkedHashMap<>();
+
+    /**
+     * Workspace-level default {@link PhaseConfig} for the unified
+     * per-phase config ladder. Optional; {@code null} omits the field
+     * from serialized YAML. New form — supersedes the legacy
+     * {@link #defaultRunner} for runner selection, and is the only
+     * source of workspace-level {@code model} / {@code effort}.
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private PhaseConfig defaultPhaseConfig;
+    /**
+     * Workspace-level per-phase {@link PhaseConfig} overrides keyed by
+     * phase wire name (e.g. {@code review}). Supersedes the legacy
+     * {@link #runners} map. Optional; an empty map is omitted from
+     * serialized YAML.
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private Map<String, PhaseConfig> phaseConfigs = new LinkedHashMap<>();
+
+    /** Returns the operator-chosen workspace ID. */
+    public String getId() { return id; }
+    /** Sets the operator-chosen workspace ID. */
+    public void setId(String id) { this.id = id; }
+
+    /**
+     * Returns the Slack team ID this workspace is connected to, or
+     * {@code null} when the workspace has no Slack integration.
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public String getSlackTeamId() { return slackTeamId; }
+    /**
+     * Sets the Slack team ID for this workspace. Pass {@code null} or
+     * empty to clear the Slack connection — channel-routing operations
+     * will then skip this workspace cleanly.
+     */
+    public void setSlackTeamId(String slackTeamId) {
+        this.slackTeamId = (slackTeamId == null || slackTeamId.isEmpty()) ? null : slackTeamId;
+    }
+
+    /** Returns the human-readable workspace label. */
+    public String getName() { return name; }
+    /** Sets the human-readable workspace label. */
+    public void setName(String name) { this.name = name; }
+
+    /** Returns the path to the JSON tokens file, or {@code null} for inline tokens. */
+    public String getTokensFile() { return tokensFile; }
+    /** Sets the path to the JSON tokens file. */
+    public void setTokensFile(String tokensFile) { this.tokensFile = tokensFile; }
+
+    /** Returns the inline bot token (xoxb-...). */
+    public String getBotToken() { return botToken; }
+    /** Sets the inline bot token. */
+    public void setBotToken(String botToken) { this.botToken = botToken; }
+
+    /** Returns the inline app token (xapp-...). */
+    public String getAppToken() { return appToken; }
+    /** Sets the inline app token. */
+    public void setAppToken(String appToken) { this.appToken = appToken; }
+
+    /** Returns the default fallback channel ID for this workspace. */
+    public String getDefaultChannel() { return defaultChannel; }
+    /** Sets the default fallback channel ID. */
+    public void setDefaultChannel(String defaultChannel) { this.defaultChannel = defaultChannel; }
+
+    /** Returns the legacy single Slack user ID auto-invited to new channels in this workspace. */
+    public String getChannelOwnerUserId() { return channelOwnerUserId; }
+    /** Sets the legacy single Slack user ID for auto-invite on channel creation. */
+    public void setChannelOwnerUserId(String channelOwnerUserId) { this.channelOwnerUserId = channelOwnerUserId; }
+
+    /** Returns the list of Slack user IDs auto-invited to new channels (nullable). */
+    public List<String> getChannelOwnerUserIds() { return channelOwnerUserIds; }
+    /** Sets the list of Slack user IDs for auto-invite on channel creation. */
+    public void setChannelOwnerUserIds(List<String> channelOwnerUserIds) {
+        this.channelOwnerUserIds = channelOwnerUserIds;
+    }
+
+    /**
+     * Returns the effective list of Slack user IDs to auto-invite when a
+     * new channel is created in this workspace. Resolves the legacy single
+     * {@code channelOwnerUserId} field and the plural
+     * {@code channelOwnerUserIds} list into one canonical list: the plural
+     * list wins when non-empty; otherwise the singular value becomes a
+     * one-element list; otherwise an empty list is returned.
+     *
+     * @return never {@code null}; empty when no auto-invite is configured
+     */
+    public List<String> effectiveChannelOwnerUserIds() {
+        if (channelOwnerUserIds != null && !channelOwnerUserIds.isEmpty()) {
+            return channelOwnerUserIds;
+        }
+        if (channelOwnerUserId != null && !channelOwnerUserId.isEmpty()) {
+            return List.of(channelOwnerUserId);
+        }
+        return List.of();
+    }
+
+    /** Returns the per-organization GitHub token map for this workspace. */
+    public Map<String, GitHubOrgEntry> getGithubOrgs() { return githubOrgs; }
+    /** Sets the per-organization GitHub token map. */
+    public void setGithubOrgs(Map<String, GitHubOrgEntry> githubOrgs) { this.githubOrgs = githubOrgs; }
+
+    /** Returns the list of secrets declared for this workspace. */
+    public List<WorkspaceSecretEntry> getSecrets() { return secrets; }
+    /** Sets the list of secrets declared for this workspace. */
+    public void setSecrets(List<WorkspaceSecretEntry> secrets) {
+        this.secrets = secrets != null ? secrets : new ArrayList<>();
+    }
+
+    /** Returns the workspace-level default agent runner, or {@code null} when none is configured. */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public String getDefaultRunner() { return defaultRunner; }
+    /** Sets the workspace-level default agent runner. */
+    public void setDefaultRunner(String defaultRunner) { this.defaultRunner = defaultRunner; }
+
+    /** Returns the workspace-level per-phase runner overrides (keyed by phase wire name); never {@code null}. */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public Map<String, String> getRunners() { return runners; }
+    /** Replaces the workspace-level per-phase runner override map; {@code null} is treated as empty. */
+    public void setRunners(Map<String, String> runners) {
+        this.runners = runners != null ? new LinkedHashMap<>(runners) : new LinkedHashMap<>();
+    }
+
+    /** Returns the workspace-level default {@link PhaseConfig}, or {@code null}. */
+    public PhaseConfig getDefaultPhaseConfig() { return defaultPhaseConfig; }
+    /** Sets the workspace-level default {@link PhaseConfig}. */
+    public void setDefaultPhaseConfig(PhaseConfig defaultPhaseConfig) {
+        this.defaultPhaseConfig = defaultPhaseConfig;
+    }
+
+    /** Returns the workspace-level per-phase {@link PhaseConfig} overrides; never {@code null}. */
+    public Map<String, PhaseConfig> getPhaseConfigs() { return phaseConfigs; }
+    /** Replaces the workspace-level per-phase {@link PhaseConfig} overrides. */
+    public void setPhaseConfigs(Map<String, PhaseConfig> phaseConfigs) {
+        this.phaseConfigs = phaseConfigs != null ? new LinkedHashMap<>(phaseConfigs) : new LinkedHashMap<>();
+    }
+
+    /**
+     * Builds the effective {@link PhaseConfigBundle} for this workspace,
+     * merging the new {@code defaultPhaseConfig}/{@code phaseConfigs}
+     * fields with the legacy {@code defaultRunner}/{@code runners} fields.
+     * The new fields take precedence field-by-field when both are
+     * supplied; legacy fields fill in {@code null} positions.
+     *
+     * @return the merged bundle; never {@code null}
+     */
+    public PhaseConfigBundle toPhaseConfigBundle() {
+        return PhaseConfigBundle.mergeLegacyWithNew(defaultRunner, runners,
+                defaultPhaseConfig, phaseConfigs);
+    }
+}

--- a/flowtree/runtime/src/main/java/io/flowtree/workstream/WorkspaceSecretEntry.java
+++ b/flowtree/runtime/src/main/java/io/flowtree/workstream/WorkspaceSecretEntry.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 Michael Murray
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.flowtree.workstream;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Declares a single workspace-scoped secret available to agent workstreams.
+ *
+ * <p>Each entry maps a logical name to the JSON file on disk that holds
+ * the secret payload. The file must exist and must be readable only by the
+ * controller process (permissions {@code 0600}). The controller logs a
+ * warning at startup when a declared file is world- or group-readable.</p>
+ *
+ * @author Michael Murray
+ * @see WorkspaceEntry#getSecrets()
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class WorkspaceSecretEntry {
+
+    /** Unique name within the workspace; URL-safe (lowercase letters, digits, hyphens). */
+    private String name;
+    /** Absolute path to the JSON payload file on disk. */
+    private String file;
+
+    /** Returns the secret name. */
+    public String getName() { return name; }
+    /** Sets the secret name. */
+    public void setName(String name) { this.name = name; }
+
+    /** Returns the absolute path to the JSON payload file. */
+    public String getFile() { return file; }
+    /** Sets the path to the JSON payload file. */
+    public void setFile(String file) { this.file = file; }
+}

--- a/flowtree/runtime/src/main/java/io/flowtree/workstream/Workstream.java
+++ b/flowtree/runtime/src/main/java/io/flowtree/workstream/Workstream.java
@@ -196,7 +196,7 @@ public class Workstream {
      * Whether this workstream is archived. Archived workstreams remain in the
      * config (so historical job records and memories stay queryable) but are
      * hidden from default list responses. Persisted by
-     * {@link WorkstreamConfig.WorkstreamEntry#toWorkstream()} and the inverse
+     * {@link WorkstreamEntry#toWorkstream()} and the inverse
      * sync path, so editing {@code archived: true} into a workstream's YAML
      * entry brings it back hidden on the next controller load. The archive /
      * unarchive MCP tools are the intended runtime entry points.

--- a/flowtree/runtime/src/main/java/io/flowtree/workstream/WorkstreamConfig.java
+++ b/flowtree/runtime/src/main/java/io/flowtree/workstream/WorkstreamConfig.java
@@ -16,9 +16,7 @@
 
 package io.flowtree.workstream;
 
-import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -32,7 +30,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -40,13 +37,23 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Consumer;
-import io.flowtree.submission.SubmissionRunnerResolver;
 
 /**
  * Configuration for Slack workstreams, loadable from YAML or JSON files.
  *
  * <p>Agents connect inbound to the controller's FlowTree server, so the
  * {@code agents} field is optional and typically omitted.</p>
+ *
+ * <p>The configuration is organized into three tiers of entries:</p>
+ * <ul>
+ *   <li>{@link WorkspaceEntry} — operator's organizational unit, optionally
+ *       connected to a Slack team. Holds Slack credentials, GitHub org tokens,
+ *       and workspace-level phase config defaults.</li>
+ *   <li>{@link WorkstreamEntry} — binds a git branch to a Slack channel and
+ *       declares job parameters. One entry per active branch/project.</li>
+ *   <li>{@link PushedToolEntry} / {@link McpServerEntry} — MCP tool serving
+ *       configuration pushed to agent containers.</li>
+ * </ul>
  *
  * <p>Example YAML configuration:</p>
  * <pre>
@@ -64,8 +71,9 @@ import io.flowtree.submission.SubmissionRunnerResolver;
  *
  * @author Michael Murray
  * @see Workstream
+ * @see WorkspaceEntry
+ * @see WorkstreamEntry
  */
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class WorkstreamConfig {
 
     /** Global default path for repo checkouts; used when no workingDirectory is set. */
@@ -102,735 +110,6 @@ public class WorkstreamConfig {
     private List<WorkspaceEntry> workspaces = new ArrayList<>();
 
     /**
-     * Configuration entry for a workspace — the operator's organizational
-     * unit, optionally connected to a Slack team.
-     *
-     * <p>The {@code id} field is operator-chosen and is the identifier
-     * referenced by {@link WorkstreamEntry#getWorkspaceId()}. The optional
-     * {@code slackTeamId} field carries the Slack team ID (e.g.
-     * {@code "T0123456789"}) when the workspace is connected to Slack;
-     * when absent the workspace has no Slack integration and channel/notifier
-     * operations skip cleanly. Legacy {@code slackWorkspaces:} entries are
-     * auto-migrated on load so {@code id == slackTeamId}.</p>
-     *
-     * <p>Slack-credential fields ({@code tokensFile}/{@code botToken}/
-     * {@code appToken}) only have effect when {@code slackTeamId} is set.</p>
-     */
-    @JsonIgnoreProperties(ignoreUnknown = true)
-    public static class WorkspaceEntry {
-        /**
-         * Operator-chosen workspace identifier. For legacy {@code slackWorkspaces:}
-         * entries the YAML key {@code workspaceId} is accepted via
-         * {@link JsonAlias} and double-loaded as both {@code id} and
-         * {@code slackTeamId} so that older configs continue to resolve.
-         */
-        @JsonAlias({"workspaceId"})
-        private String id;
-        /**
-         * Optional Slack team ID (e.g. {@code "T0123456789"}) identifying the
-         * Slack workspace this entry routes to. {@code null} when this
-         * workspace has no Slack connection.
-         */
-        private String slackTeamId;
-        /** Human-readable label for this workspace (used in logs and diagnostics). */
-        private String name;
-        /** Path to a JSON file with {@code botToken} and {@code appToken}. */
-        private String tokensFile;
-        /** Inline bot token (xoxb-...); used when {@code tokensFile} is absent. */
-        private String botToken;
-        /** Inline app token (xapp-...); used when {@code tokensFile} is absent. */
-        private String appToken;
-        /** Default Slack channel ID for fallback message delivery in this workspace. */
-        private String defaultChannel;
-        /**
-         * Single Slack user ID auto-invited to newly created channels in this
-         * workspace. Superseded by {@link #channelOwnerUserIds} when that list
-         * is non-empty; retained for backwards compatibility with configs that
-         * predate multi-user invites.
-         */
-        private String channelOwnerUserId;
-        /**
-         * Slack user IDs auto-invited to newly created channels in this
-         * workspace. When set, takes precedence over {@link #channelOwnerUserId}.
-         */
-        private List<String> channelOwnerUserIds;
-        /** Per-organization GitHub tokens scoped to this workspace. */
-        private Map<String, GitHubOrgEntry> githubOrgs = new LinkedHashMap<>();
-        /** Secrets declared as available to workstreams in this workspace. */
-        private List<WorkspaceSecretEntry> secrets = new ArrayList<>();
-        /**
-         * Workspace-level default {@link io.flowtree.jobs.agent.AgentRunner}
-         * applied to workstreams in this workspace when neither the workstream
-         * itself nor the per-job override sets one. Sits between the
-         * workstream default and the controller default in the routing
-         * ladder. Optional; {@code null} omits the field from serialized YAML.
-         *
-         * <p>Legacy field: still accepted on load and auto-migrated into
-         * {@link #defaultPhaseConfig}, but never written back — serialization
-         * is write-only so a save-then-load cycle drops it in favour of the
-         * per-phase shape.</p>
-         */
-        @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
-        private String defaultRunner;
-        /**
-         * Workspace-level per-phase runner overrides keyed by phase wire name
-         * (e.g. {@code primary}, {@code commit-message}). Consulted by the
-         * resolver only when the workstream has no per-phase entry for the
-         * same phase <em>and</em> no workstream-level {@code defaultRunner};
-         * see {@link SubmissionRunnerResolver} for the full ladder.
-         *
-         * <p>Legacy field: accepted on load and auto-migrated into
-         * {@link #phaseConfigs}, but write-only for serialization.</p>
-         */
-        @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
-        private Map<String, String> runners = new LinkedHashMap<>();
-
-        /**
-         * Workspace-level default {@link PhaseConfig} for the unified
-         * per-phase config ladder. Optional; {@code null} omits the field
-         * from serialized YAML. New form — supersedes the legacy
-         * {@link #defaultRunner} for runner selection, and is the only
-         * source of workspace-level {@code model} / {@code effort}.
-         */
-        @JsonInclude(JsonInclude.Include.NON_NULL)
-        private PhaseConfig defaultPhaseConfig;
-        /**
-         * Workspace-level per-phase {@link PhaseConfig} overrides keyed by
-         * phase wire name (e.g. {@code review}). Supersedes the legacy
-         * {@link #runners} map. Optional; an empty map is omitted from
-         * serialized YAML.
-         */
-        @JsonInclude(JsonInclude.Include.NON_EMPTY)
-        private Map<String, PhaseConfig> phaseConfigs = new LinkedHashMap<>();
-
-        /** Returns the operator-chosen workspace ID. */
-        public String getId() { return id; }
-        /** Sets the operator-chosen workspace ID. */
-        public void setId(String id) { this.id = id; }
-
-        /**
-         * Returns the Slack team ID this workspace is connected to, or
-         * {@code null} when the workspace has no Slack integration.
-         */
-        @JsonInclude(JsonInclude.Include.NON_NULL)
-        public String getSlackTeamId() { return slackTeamId; }
-        /**
-         * Sets the Slack team ID for this workspace. Pass {@code null} or
-         * empty to clear the Slack connection — channel-routing operations
-         * will then skip this workspace cleanly.
-         */
-        public void setSlackTeamId(String slackTeamId) {
-            this.slackTeamId = (slackTeamId == null || slackTeamId.isEmpty()) ? null : slackTeamId;
-        }
-
-        /** Returns the human-readable workspace label. */
-        public String getName() { return name; }
-        /** Sets the human-readable workspace label. */
-        public void setName(String name) { this.name = name; }
-
-        /** Returns the path to the JSON tokens file, or {@code null} for inline tokens. */
-        public String getTokensFile() { return tokensFile; }
-        /** Sets the path to the JSON tokens file. */
-        public void setTokensFile(String tokensFile) { this.tokensFile = tokensFile; }
-
-        /** Returns the inline bot token (xoxb-...). */
-        public String getBotToken() { return botToken; }
-        /** Sets the inline bot token. */
-        public void setBotToken(String botToken) { this.botToken = botToken; }
-
-        /** Returns the inline app token (xapp-...). */
-        public String getAppToken() { return appToken; }
-        /** Sets the inline app token. */
-        public void setAppToken(String appToken) { this.appToken = appToken; }
-
-        /** Returns the default fallback channel ID for this workspace. */
-        public String getDefaultChannel() { return defaultChannel; }
-        /** Sets the default fallback channel ID. */
-        public void setDefaultChannel(String defaultChannel) { this.defaultChannel = defaultChannel; }
-
-        /** Returns the legacy single Slack user ID auto-invited to new channels in this workspace. */
-        public String getChannelOwnerUserId() { return channelOwnerUserId; }
-        /** Sets the legacy single Slack user ID for auto-invite on channel creation. */
-        public void setChannelOwnerUserId(String channelOwnerUserId) { this.channelOwnerUserId = channelOwnerUserId; }
-
-        /** Returns the list of Slack user IDs auto-invited to new channels (nullable). */
-        public List<String> getChannelOwnerUserIds() { return channelOwnerUserIds; }
-        /** Sets the list of Slack user IDs for auto-invite on channel creation. */
-        public void setChannelOwnerUserIds(List<String> channelOwnerUserIds) {
-            this.channelOwnerUserIds = channelOwnerUserIds;
-        }
-
-        /**
-         * Returns the effective list of Slack user IDs to auto-invite when a
-         * new channel is created in this workspace. Resolves the legacy single
-         * {@code channelOwnerUserId} field and the plural
-         * {@code channelOwnerUserIds} list into one canonical list: the plural
-         * list wins when non-empty; otherwise the singular value becomes a
-         * one-element list; otherwise an empty list is returned.
-         *
-         * @return never {@code null}; empty when no auto-invite is configured
-         */
-        public List<String> effectiveChannelOwnerUserIds() {
-            if (channelOwnerUserIds != null && !channelOwnerUserIds.isEmpty()) {
-                return channelOwnerUserIds;
-            }
-            if (channelOwnerUserId != null && !channelOwnerUserId.isEmpty()) {
-                return List.of(channelOwnerUserId);
-            }
-            return List.of();
-        }
-
-        /** Returns the per-organization GitHub token map for this workspace. */
-        public Map<String, GitHubOrgEntry> getGithubOrgs() { return githubOrgs; }
-        /** Sets the per-organization GitHub token map. */
-        public void setGithubOrgs(Map<String, GitHubOrgEntry> githubOrgs) { this.githubOrgs = githubOrgs; }
-
-        /** Returns the list of secrets declared for this workspace. */
-        public List<WorkspaceSecretEntry> getSecrets() { return secrets; }
-        /** Sets the list of secrets declared for this workspace. */
-        public void setSecrets(List<WorkspaceSecretEntry> secrets) {
-            this.secrets = secrets != null ? secrets : new ArrayList<>();
-        }
-
-        /** Returns the workspace-level default agent runner, or {@code null} when none is configured. */
-        @JsonInclude(JsonInclude.Include.NON_NULL)
-        public String getDefaultRunner() { return defaultRunner; }
-        /** Sets the workspace-level default agent runner. */
-        public void setDefaultRunner(String defaultRunner) { this.defaultRunner = defaultRunner; }
-
-        /** Returns the workspace-level per-phase runner overrides (keyed by phase wire name); never {@code null}. */
-        @JsonInclude(JsonInclude.Include.NON_EMPTY)
-        public Map<String, String> getRunners() { return runners; }
-        /** Replaces the workspace-level per-phase runner override map; {@code null} is treated as empty. */
-        public void setRunners(Map<String, String> runners) {
-            this.runners = runners != null ? new LinkedHashMap<>(runners) : new LinkedHashMap<>();
-        }
-
-        /** Returns the workspace-level default {@link PhaseConfig}, or {@code null}. */
-        public PhaseConfig getDefaultPhaseConfig() { return defaultPhaseConfig; }
-        /** Sets the workspace-level default {@link PhaseConfig}. */
-        public void setDefaultPhaseConfig(PhaseConfig defaultPhaseConfig) {
-            this.defaultPhaseConfig = defaultPhaseConfig;
-        }
-
-        /** Returns the workspace-level per-phase {@link PhaseConfig} overrides; never {@code null}. */
-        public Map<String, PhaseConfig> getPhaseConfigs() { return phaseConfigs; }
-        /** Replaces the workspace-level per-phase {@link PhaseConfig} overrides. */
-        public void setPhaseConfigs(Map<String, PhaseConfig> phaseConfigs) {
-            this.phaseConfigs = phaseConfigs != null ? new LinkedHashMap<>(phaseConfigs) : new LinkedHashMap<>();
-        }
-
-        /**
-         * Builds the effective {@link PhaseConfigBundle} for this workspace,
-         * merging the new {@code defaultPhaseConfig}/{@code phaseConfigs}
-         * fields with the legacy {@code defaultRunner}/{@code runners} fields.
-         * The new fields take precedence field-by-field when both are
-         * supplied; legacy fields fill in {@code null} positions.
-         *
-         * @return the merged bundle; never {@code null}
-         */
-        public PhaseConfigBundle toPhaseConfigBundle() {
-            return PhaseConfigBundle.mergeLegacyWithNew(defaultRunner, runners,
-                    defaultPhaseConfig, phaseConfigs);
-        }
-    }
-
-    /**
-     * Declares a single workspace-scoped secret available to agent workstreams.
-     *
-     * <p>Each entry maps a logical name to the JSON file on disk that holds
-     * the secret payload. The file must exist and must be readable only by the
-     * controller process (permissions {@code 0600}). The controller logs a
-     * warning at startup when a declared file is world- or group-readable.</p>
-     */
-    @JsonIgnoreProperties(ignoreUnknown = true)
-    public static class WorkspaceSecretEntry {
-        /** Unique name within the workspace; URL-safe (lowercase letters, digits, hyphens). */
-        private String name;
-        /** Absolute path to the JSON payload file on disk. */
-        private String file;
-
-        /** Returns the secret name. */
-        public String getName() { return name; }
-        /** Sets the secret name. */
-        public void setName(String name) { this.name = name; }
-
-        /** Returns the absolute path to the JSON payload file. */
-        public String getFile() { return file; }
-        /** Sets the path to the JSON payload file. */
-        public void setFile(String file) { this.file = file; }
-    }
-
-    /**
-     * Configuration entry for a single workstream.
-     */
-    @JsonIgnoreProperties(ignoreUnknown = true)
-    public static class WorkstreamEntry {
-        /** Persistent identifier; generated if absent and saved back to YAML. */
-        private String workstreamId;
-        /** The Slack channel ID this workstream is bound to. */
-        private String channelId;
-        /** The human-readable Slack channel name. */
-        private String channelName;
-        /** Optional agent endpoints; typically empty since agents connect inbound. */
-        private List<AgentEntry> agents = new ArrayList<>();
-        /** Branch agents commit to by default. */
-        private String defaultBranch;
-        /** Branch used as the base when the controller creates a new branch. */
-        private String baseBranch;
-        /** Whether agents push commits to the remote origin. */
-        private boolean pushToOrigin = true;
-        /** Local filesystem path to the checked-out repository. */
-        private String workingDirectory;
-        /** Git clone URL for automatic repository checkout. */
-        private String repoUrl;
-        /** Comma-separated list of Claude Code tool names the agent may use. */
-        private String allowedTools = "Read,Edit,Write,Bash,Glob,Grep";
-        /** Maximum number of agent turns per job. */
-        private int maxTurns = 800;
-        /** Maximum spending budget per job in USD. */
-        private double maxBudgetUsd = 100.0;
-        /** Git author name for commits. */
-        private String gitUserName;
-        /** Git author email for commits. */
-        private String gitUserEmail;
-        /** Per-workstream environment variables injected into pushed tool MCP configs. */
-        private Map<String, String> env;
-        /** Per-workstream environment variables set on the agent subprocess itself. */
-        private Map<String, String> agentEnv;
-        /** Optional path to a planning document the agent consults for context. */
-        private String planningDocument;
-        /** GitHub organization name for org-based token selection. */
-        private String githubOrg;
-        /** Additional repository URLs cloned alongside the primary repo. */
-        private List<String> dependentRepos;
-        /**
-         * Workstream IDs of completion listeners that should be woken up
-         * automatically when a job on this workstream reaches a terminal
-         * status. The listener graph must be a DAG; the cycle check runs
-         * on register / update and rejects configurations that would
-         * introduce a cycle, including self-listing. See
-         * {@link Workstream#setCompletionListeners(List)} for the kill
-         * switch and reconciliation-invariant details.
-         */
-        private List<String> completionListeners;
-        /** Node labels that jobs submitted to this workstream must match by default. */
-        private Map<String, String> requiredLabels;
-        /**
-         * The workspace ID this workstream is bound to. Accepts the legacy
-         * YAML key {@code slackWorkspaceId} via {@link JsonAlias} so existing
-         * configs continue to load; the field now holds an operator-chosen
-         * workspace ID rather than a Slack team ID.
-         */
-        @JsonAlias({"slackWorkspaceId"})
-        private String workspaceId;
-        /**
-         * Default {@link io.flowtree.jobs.agent.AgentRunner} applied to jobs
-         * in this workstream when no per-phase or per-job override is set.
-         * Legacy field: accepted on load and auto-migrated into
-         * {@link #defaultPhaseConfig}, but write-only for serialization.
-         */
-        @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
-        private String defaultRunner;
-        /**
-         * Per-phase runner overrides keyed by phase wire name (e.g.
-         * {@code primary}, {@code deduplication}). Phases not listed inherit
-         * {@link #defaultRunner}. Legacy field: accepted on load and
-         * auto-migrated into {@link #phaseConfigs}, but write-only for
-         * serialization.
-         */
-        @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
-        private Map<String, String> runners = new LinkedHashMap<>();
-        /**
-         * Workstream-level default {@link PhaseConfig}; new form for the
-         * unified per-phase config ladder. Optional; {@code null} omits the
-         * field from serialized YAML.
-         */
-        @JsonInclude(JsonInclude.Include.NON_NULL)
-        private PhaseConfig defaultPhaseConfig;
-        /**
-         * Workstream-level per-phase {@link PhaseConfig} overrides keyed by
-         * phase wire name. Optional; an empty map is omitted from
-         * serialized YAML.
-         */
-        @JsonInclude(JsonInclude.Include.NON_EMPTY)
-        private Map<String, PhaseConfig> phaseConfigs = new LinkedHashMap<>();
-        /**
-         * Whether this workstream is archived. Archived workstreams are
-         * hidden from default {@code workstream_list} responses but their
-         * job history and memories remain queryable.
-         */
-        private boolean archived;
-
-        /** Returns the persistent workstream identifier. */
-        public String getWorkstreamId() { return workstreamId; }
-        /** Sets the persistent workstream identifier. */
-        public void setWorkstreamId(String workstreamId) { this.workstreamId = workstreamId; }
-
-        /** Returns the Slack channel ID (e.g., "C0123456789"). */
-        public String getChannelId() { return channelId; }
-        /** Sets the Slack channel ID. */
-        public void setChannelId(String channelId) { this.channelId = channelId; }
-
-        /** Returns the human-readable Slack channel name (e.g., "#project-agent"). */
-        public String getChannelName() { return channelName; }
-        /** Sets the human-readable Slack channel name. */
-        public void setChannelName(String channelName) { this.channelName = channelName; }
-
-        /** Returns the list of agent endpoint entries for this workstream. */
-        public List<AgentEntry> getAgents() { return agents; }
-        /** Sets the list of agent endpoint entries for this workstream. */
-        public void setAgents(List<AgentEntry> agents) { this.agents = agents; }
-
-        /** Returns the default git branch for agent commits. */
-        public String getDefaultBranch() { return defaultBranch; }
-        /** Sets the default git branch for agent commits. */
-        public void setDefaultBranch(String defaultBranch) { this.defaultBranch = defaultBranch; }
-
-        /** Returns the base branch used as the starting point for new branch creation. */
-        public String getBaseBranch() { return baseBranch; }
-        /** Sets the base branch used when creating new target branches. */
-        public void setBaseBranch(String baseBranch) { this.baseBranch = baseBranch; }
-
-        /** Returns whether agents should push commits to the remote origin. */
-        public boolean isPushToOrigin() { return pushToOrigin; }
-        /** Sets whether agents should push commits to the remote origin. */
-        public void setPushToOrigin(boolean pushToOrigin) { this.pushToOrigin = pushToOrigin; }
-
-        /** Returns the local working directory for the agent's git repository. */
-        public String getWorkingDirectory() { return workingDirectory; }
-        /** Sets the local working directory for the agent's git repository. */
-        public void setWorkingDirectory(String workingDirectory) { this.workingDirectory = workingDirectory; }
-
-        /** Returns the git repository URL for automatic checkout. */
-        public String getRepoUrl() { return repoUrl; }
-        /** Sets the git repository URL for automatic checkout. */
-        public void setRepoUrl(String repoUrl) { this.repoUrl = repoUrl; }
-
-        /** Returns the comma-separated list of Claude Code tool names the agent may use. */
-        public String getAllowedTools() { return allowedTools; }
-        /** Sets the comma-separated list of allowed Claude Code tool names. */
-        public void setAllowedTools(String allowedTools) { this.allowedTools = allowedTools; }
-
-        /** Returns the maximum number of turns a Claude Code agent may take per job. */
-        public int getMaxTurns() { return maxTurns; }
-        /** Sets the maximum number of turns per job. */
-        public void setMaxTurns(int maxTurns) { this.maxTurns = maxTurns; }
-
-        /** Returns the maximum spending budget per job in USD. */
-        public double getMaxBudgetUsd() { return maxBudgetUsd; }
-        /** Sets the maximum spending budget per job in USD. */
-        public void setMaxBudgetUsd(double maxBudgetUsd) { this.maxBudgetUsd = maxBudgetUsd; }
-
-        /** Returns the git author name used for commits made by this workstream. */
-        public String getGitUserName() { return gitUserName; }
-        /** Sets the git author name used for commits. */
-        public void setGitUserName(String gitUserName) { this.gitUserName = gitUserName; }
-
-        /** Returns the git author email used for commits made by this workstream. */
-        public String getGitUserEmail() { return gitUserEmail; }
-        /** Sets the git author email used for commits. */
-        public void setGitUserEmail(String gitUserEmail) { this.gitUserEmail = gitUserEmail; }
-
-        /** Returns per-workstream environment variables injected into pushed tool MCP configs. */
-        public Map<String, String> getEnv() { return env; }
-        /** Sets per-workstream environment variables for pushed tools. */
-        public void setEnv(Map<String, String> env) { this.env = env; }
-        /** Returns per-workstream environment variables set on the agent subprocess. */
-        public Map<String, String> getAgentEnv() { return agentEnv; }
-        /** Sets per-workstream environment variables for the agent subprocess. */
-        public void setAgentEnv(Map<String, String> agentEnv) { this.agentEnv = agentEnv; }
-
-        /** Returns the optional planning document path for broader goal context. */
-        public String getPlanningDocument() { return planningDocument; }
-        /** Sets the planning document path for this workstream. */
-        public void setPlanningDocument(String planningDocument) { this.planningDocument = planningDocument; }
-
-        /** Returns the GitHub organization name for org-based token selection. */
-        public String getGithubOrg() { return githubOrg; }
-        /** Sets the GitHub organization name for org-based token selection. */
-        public void setGithubOrg(String githubOrg) { this.githubOrg = githubOrg; }
-
-        /**
-         * Returns the list of dependent repository URLs that should be
-         * checked out alongside the primary repo. Each repo is cloned
-         * as a sibling directory and managed with the same branch/commit
-         * lifecycle as the primary repo.
-         */
-        public List<String> getDependentRepos() { return dependentRepos; }
-        /** Sets the dependent repository URLs. */
-        public void setDependentRepos(List<String> dependentRepos) { this.dependentRepos = dependentRepos; }
-
-        /**
-         * Returns the workstream IDs of completion listeners that should
-         * be woken up automatically when a job on this workstream reaches
-         * a terminal status. The cycle check rejects configurations that
-         * would create a cycle in the listener graph at config time.
-         *
-         * <p>The returned list is never {@code null}: a YAML entry that
-         * omits {@code completionListeners} (older configs that pre-date
-         * the field) loads with an empty list, the inert default. Callers
-         * can iterate without null-guarding.</p>
-         *
-         * @return listener workstream IDs; never {@code null}, may be empty
-         */
-        public List<String> getCompletionListeners() {
-            return completionListeners == null
-                    ? Collections.emptyList() : completionListeners;
-        }
-        /**
-         * Sets the listener workstream IDs. Pass {@code null} or empty
-         * to clear (the inert default, which spawns no wake-up jobs).
-         */
-        public void setCompletionListeners(List<String> completionListeners) {
-            this.completionListeners = (completionListeners == null)
-                    ? new ArrayList<>() : new ArrayList<>(completionListeners);
-        }
-
-        /**
-         * Returns the Node labels that jobs submitted to this workstream must match by default.
-         * When a job submission does not include {@code requiredLabels}, these are applied.
-         */
-        public Map<String, String> getRequiredLabels() { return requiredLabels; }
-        /** Sets the default Node label requirements for jobs in this workstream. */
-        public void setRequiredLabels(Map<String, String> requiredLabels) { this.requiredLabels = requiredLabels; }
-
-        /**
-         * Returns the workspace ID this workstream is assigned to. Accepts
-         * the legacy YAML alias {@code slackWorkspaceId} on load; the value is
-         * now an operator-chosen workspace ID, not necessarily a Slack team
-         * ID. When absent, the workstream is assigned to the first (or only)
-         * workspace connection in the {@code workspaces} list.
-         */
-        public String getWorkspaceId() { return workspaceId; }
-        /** Sets the workspace ID for this workstream. */
-        public void setWorkspaceId(String workspaceId) { this.workspaceId = workspaceId; }
-
-        /** Returns the default agent runner for jobs in this workstream, or {@code null}. */
-        public String getDefaultRunner() { return defaultRunner; }
-        /** Sets the default agent runner for jobs in this workstream. */
-        public void setDefaultRunner(String defaultRunner) { this.defaultRunner = defaultRunner; }
-
-        /** Returns the per-phase runner override map (keyed by phase wire name); never {@code null}. */
-        public Map<String, String> getRunners() { return runners; }
-        /** Replaces the per-phase runner override map; {@code null} is treated as empty. */
-        public void setRunners(Map<String, String> runners) {
-            this.runners = runners != null ? new LinkedHashMap<>(runners) : new LinkedHashMap<>();
-        }
-
-        /** Returns the workstream-level default {@link PhaseConfig}, or {@code null}. */
-        public PhaseConfig getDefaultPhaseConfig() { return defaultPhaseConfig; }
-        /** Sets the workstream-level default {@link PhaseConfig}. */
-        public void setDefaultPhaseConfig(PhaseConfig defaultPhaseConfig) {
-            this.defaultPhaseConfig = defaultPhaseConfig;
-        }
-
-        /** Returns the workstream-level per-phase {@link PhaseConfig} overrides; never {@code null}. */
-        public Map<String, PhaseConfig> getPhaseConfigs() { return phaseConfigs; }
-        /** Replaces the workstream-level per-phase {@link PhaseConfig} overrides. */
-        public void setPhaseConfigs(Map<String, PhaseConfig> phaseConfigs) {
-            this.phaseConfigs = phaseConfigs != null ? new LinkedHashMap<>(phaseConfigs) : new LinkedHashMap<>();
-        }
-
-        /**
-         * Builds the effective {@link PhaseConfigBundle} for this workstream
-         * entry, merging the new fields with the legacy
-         * {@code defaultRunner}/{@code runners} runner fields. The new fields
-         * take precedence field-by-field. Model, effort, and provider come
-         * solely from {@code defaultPhaseConfig}/{@code phaseConfigs}.
-         *
-         * @return the merged bundle; never {@code null}
-         */
-        public PhaseConfigBundle toPhaseConfigBundle() {
-            return PhaseConfigBundle.mergeLegacyWithNew(
-                    defaultRunner, runners, defaultPhaseConfig, phaseConfigs);
-        }
-
-        /** Returns {@code true} when this workstream is archived. */
-        public boolean isArchived() { return archived; }
-        /** Sets the archived flag. */
-        public void setArchived(boolean archived) { this.archived = archived; }
-
-        /**
-         * Converts this entry to a {@link Workstream} instance.
-         *
-         * <p>If a {@code workstreamId} is present, it is used as the persistent
-         * identifier. Otherwise, a random UUID is generated.</p>
-         */
-        public Workstream toWorkstream() {
-            Workstream ws;
-            if (workstreamId != null && !workstreamId.isEmpty()) {
-                ws = new Workstream(workstreamId, channelId, channelName);
-            } else {
-                ws = new Workstream(channelId, channelName);
-            }
-            for (AgentEntry agent : agents) {
-                ws.addAgent(agent.getHost(), agent.getPort());
-            }
-            ws.setDefaultBranch(defaultBranch);
-            ws.setBaseBranch(baseBranch);
-            ws.setPushToOrigin(pushToOrigin);
-            ws.setWorkingDirectory(workingDirectory);
-            ws.setRepoUrl(repoUrl);
-            ws.setAllowedTools(allowedTools);
-            ws.setMaxTurns(maxTurns);
-            ws.setMaxBudgetUsd(maxBudgetUsd);
-            ws.setGitUserName(gitUserName);
-            ws.setGitUserEmail(gitUserEmail);
-            ws.setEnv(env);
-            ws.setAgentEnv(agentEnv);
-            ws.setPlanningDocument(planningDocument);
-            ws.setGithubOrg(githubOrg);
-            ws.setDependentRepos(dependentRepos);
-            ws.setRequiredLabels(requiredLabels);
-            ws.setWorkspaceId(workspaceId);
-            ws.setDefaultRunner(defaultRunner);
-            ws.setRunners(runners);
-            // Layer the new bundle fields on top of the legacy runner values
-            // just applied above. The bundle setter rewrites the runner-
-            // resolution fields, so any runner present in the bundle wins over
-            // the legacy values (matching "new wins" precedence on YAML load).
-            PhaseConfigBundle bundle = toPhaseConfigBundle();
-            if (!bundle.isEmpty()) {
-                ws.setPhaseConfigBundle(bundle);
-            }
-            ws.setArchived(archived);
-            ws.setCompletionListeners(completionListeners);
-            return ws;
-        }
-    }
-
-    /**
-     * Configuration entry for an agent endpoint.
-     */
-    @JsonIgnoreProperties(ignoreUnknown = true)
-    public static class AgentEntry {
-        /** The agent hostname or IP address (default: {@code "localhost"}). */
-        private String host = "localhost";
-        /** The port the agent's FlowTree node listens on (default: 7766). */
-        private int port = 7766;
-
-        /** No-arg constructor for Jackson deserialization. */
-        public AgentEntry() {}
-
-        /**
-         * Creates a new agent entry with the specified host and port.
-         *
-         * @param host the agent hostname or IP address
-         * @param port the agent port number
-         */
-        public AgentEntry(String host, int port) {
-            this.host = host;
-            this.port = port;
-        }
-
-        /** Returns the agent hostname or IP address. */
-        public String getHost() { return host; }
-        /** Sets the agent hostname or IP address. */
-        public void setHost(String host) { this.host = host; }
-
-        /** Returns the agent port number. */
-        public int getPort() { return port; }
-        /** Sets the agent port number. */
-        public void setPort(int port) { this.port = port; }
-    }
-
-    /**
-     * Configuration entry for a centralized MCP server.
-     *
-     * <p>When present in the YAML configuration, the controller starts
-     * each server as an HTTP process and agents connect over HTTP
-     * instead of stdio.</p>
-     */
-    @JsonIgnoreProperties(ignoreUnknown = true)
-    public static class McpServerEntry {
-        /** Python source file path relative to the project root (for managed servers). */
-        private String source;
-        /** HTTP port the managed server process listens on. */
-        private int port;
-        /** URL of an already-running external server; when set, no subprocess is launched. */
-        private String url;
-        /** Explicit tool names exposed by this server; required when {@code url} is set. */
-        private List<String> tools;
-
-        /** Returns the Python source file path (relative to project root). */
-        public String getSource() { return source; }
-        /** Sets the Python source file path (relative to project root). */
-        public void setSource(String source) { this.source = source; }
-
-        /** Returns the HTTP port to listen on. */
-        public int getPort() { return port; }
-        /** Sets the HTTP port for the managed MCP server process. */
-        public void setPort(int port) { this.port = port; }
-
-        /**
-         * Returns the URL of an already-running centralized server.
-         * When set, the controller does not launch a subprocess —
-         * it simply passes the URL through to agents.
-         */
-        public String getUrl() { return url; }
-        /** Sets the URL of an already-running external MCP server. */
-        public void setUrl(String url) { this.url = url; }
-
-        /**
-         * Returns the explicit tool names for this server.
-         * Required when {@code url} is set (no source file to discover from).
-         */
-        public List<String> getTools() { return tools; }
-        /** Sets the explicit tool names exposed by this server. */
-        public void setTools(List<String> tools) { this.tools = tools; }
-
-        /** Returns true if this entry references an external server by URL. */
-        public boolean isExternal() {
-            return url != null && !url.isEmpty();
-        }
-    }
-
-    /**
-     * Configuration entry for a pushed MCP tool.
-     *
-     * <p>Pushed tools are served as files by the controller and downloaded
-     * into dev containers on first use. Unlike centralized servers (which
-     * run as HTTP processes on the controller), pushed tools run locally
-     * inside each container via stdio.</p>
-     */
-    @JsonIgnoreProperties(ignoreUnknown = true)
-    public static class PushedToolEntry {
-        /** Python source file path relative to the config directory. */
-        private String source;
-        /** Per-tool environment variables injected into the agent's MCP stdio config. */
-        private Map<String, String> env;
-
-        /** Returns the Python source file path (relative to config directory). */
-        public String getSource() { return source; }
-        /** Sets the Python source file path (relative to config directory). */
-        public void setSource(String source) { this.source = source; }
-
-        /** Returns per-tool environment variables to inject into the MCP stdio config. */
-        public Map<String, String> getEnv() { return env; }
-        /** Sets per-tool environment variables for the MCP stdio config. */
-        public void setEnv(Map<String, String> env) { this.env = env; }
-    }
-
-    /**
-     * Configuration entry for a GitHub organization token.
-     *
-     * <p>Maps an organization name to a GitHub personal access token.
-     * When a workstream specifies a {@code githubOrg}, the controller
-     * proxy selects the matching token for GitHub API calls.</p>
-     */
-    @JsonIgnoreProperties(ignoreUnknown = true)
-    public static class GitHubOrgEntry {
-        /** The GitHub personal access token for authenticating as this organization. */
-        private String token;
-
-        /** Returns the GitHub personal access token for this organization. */
-        public String getToken() { return token; }
-        /** Sets the GitHub personal access token for this organization. */
-        public void setToken(String token) { this.token = token; }
-    }
-
-    /**
      * Returns the global default workspace path for repo checkouts.
      *
      * <p>When a workstream specifies {@code repoUrl} but no
@@ -839,6 +118,7 @@ public class WorkstreamConfig {
      * or a temporary directory under {@code /tmp}.</p>
      */
     public String getDefaultWorkspacePath() { return defaultWorkspacePath; }
+    /** Sets the global default workspace path. */
     public void setDefaultWorkspacePath(String defaultWorkspacePath) { this.defaultWorkspacePath = defaultWorkspacePath; }
 
     /**
@@ -848,6 +128,7 @@ public class WorkstreamConfig {
      * invite this user. This is typically the project owner's Slack user ID.</p>
      */
     public String getChannelOwnerUserId() { return channelOwnerUserId; }
+    /** Sets the legacy single Slack user ID for auto-invite on channel creation. */
     public void setChannelOwnerUserId(String channelOwnerUserId) { this.channelOwnerUserId = channelOwnerUserId; }
 
     /** Returns the list of Slack user IDs auto-invited to new channels (nullable). */
@@ -880,24 +161,24 @@ public class WorkstreamConfig {
      * Returns the default Slack channel ID to use as a fallback when a
      * workstream has no channel configured or when publishing to the
      * configured channel fails.
-     *
-     * <p>This is a global setting. When set in the YAML configuration,
-     * all workstreams without a valid channel will fall back to this
-     * channel instead of silently dropping messages.</p>
      */
     public String getDefaultChannel() { return defaultChannel; }
+    /** Sets the global fallback Slack channel ID. */
     public void setDefaultChannel(String defaultChannel) { this.defaultChannel = defaultChannel; }
 
     /** Returns the centralized MCP server configurations. */
     public Map<String, McpServerEntry> getMcpServers() { return mcpServers; }
+    /** Sets the centralized MCP server configurations. */
     public void setMcpServers(Map<String, McpServerEntry> mcpServers) { this.mcpServers = mcpServers; }
 
     /** Returns the pushed MCP tool configurations. */
     public Map<String, PushedToolEntry> getPushedTools() { return pushedTools; }
+    /** Sets the pushed MCP tool configurations. */
     public void setPushedTools(Map<String, PushedToolEntry> pushedTools) { this.pushedTools = pushedTools; }
 
     /** Returns the per-organization GitHub token configurations. */
     public Map<String, GitHubOrgEntry> getGithubOrgs() { return githubOrgs; }
+    /** Sets the per-organization GitHub token configurations. */
     public void setGithubOrgs(Map<String, GitHubOrgEntry> githubOrgs) { this.githubOrgs = githubOrgs; }
 
     /**
@@ -935,13 +216,8 @@ public class WorkstreamConfig {
 
     /**
      * Returns a map from GitHub org name to the workspace ID that owns it.
-     * Only orgs that are declared inside a workspace's {@code githubOrgs}
-     * section produce a mapping; globally-declared orgs (top-level
-     * {@code githubOrgs}) are excluded because the multi-workspace schema
-     * treats top-level orgs as unscoped fallbacks.
-     *
-     * <p>When the same org is declared under multiple workspaces the last
-     * workspace wins, matching the merge order of {@link #mergedGithubOrgTokens()}.</p>
+     * Only orgs declared inside a workspace's {@code githubOrgs} section
+     * produce a mapping; globally-declared orgs are excluded.
      *
      * @return org-name → workspace-ID map, in insertion order
      */
@@ -981,8 +257,7 @@ public class WorkstreamConfig {
      * entries already present (e.g. those previously added by the legacy
      * {@code slackWorkspaces:} setter) so that both YAML keys can appear in
      * the same file during the migration window. Entries with the same
-     * {@code id} as a pre-existing entry are skipped on the assumption that
-     * the existing entry is the authoritative one.
+     * {@code id} as a pre-existing entry are skipped.
      */
     @JsonProperty("workspaces")
     public void setWorkspaces(List<WorkspaceEntry> workspaces) {
@@ -1007,9 +282,8 @@ public class WorkstreamConfig {
 
     /**
      * Returns the workspace entries as a "Slack workspaces" view for callers
-     * that still iterate the legacy projection (each entry treated as a Slack
-     * workspace connection). Identical to {@link #getWorkspaces()} for now;
-     * preserved so older callers compile.
+     * that still iterate the legacy projection. Identical to
+     * {@link #getWorkspaces()} for now; preserved so older callers compile.
      */
     @JsonIgnore
     public List<WorkspaceEntry> getSlackWorkspaces() { return workspaces; }
@@ -1019,16 +293,10 @@ public class WorkstreamConfig {
      * entries into the unified {@link #workspaces} list. Each legacy entry is
      * migrated on the fly so that its operator-chosen {@code id} doubles as
      * its {@code slackTeamId} — this preserves the historical invariant that
-     * the workspace identifier IS the Slack team ID, while letting operators
-     * later rename the workspace via the {@code workspace_update_config} MCP
-     * tool without losing the Slack connection.
+     * the workspace identifier IS the Slack team ID.
      *
      * <p>De-duplicates by {@code id} against any entries already present in
-     * {@link #workspaces}. Jackson invokes the setters in the order the keys
-     * appear in the YAML file, so when a file lists both {@code workspaces:}
-     * and {@code slackWorkspaces:} the canonical {@code workspaces:} entries
-     * win regardless of which key comes first; legacy entries that share an
-     * id with a canonical entry are silently dropped.</p>
+     * {@link #workspaces}.</p>
      *
      * @param legacy parsed entries from the legacy YAML key; never serialized back
      */
@@ -1124,13 +392,10 @@ public class WorkstreamConfig {
 
     /**
      * Returns the {@link WorkspaceEntry} matching the given workspace ID, or
-     * {@code null} when no entry has been configured with that ID. The lookup
-     * is linear over {@link #workspaces} — acceptable because the list is
-     * small (one entry per workspace).
+     * {@code null} when no entry has been configured with that ID.
      *
-     * @param id the operator-chosen workspace ID (or, for legacy entries that
-     *           have not been renamed, the Slack team ID); {@code null} or
-     *           empty always returns {@code null}
+     * @param id the operator-chosen workspace ID; {@code null} or empty always
+     *           returns {@code null}
      * @return the matching entry, or {@code null} when no match
      */
     public WorkspaceEntry findWorkspace(String id) {
@@ -1143,9 +408,7 @@ public class WorkstreamConfig {
     }
 
     /**
-     * Backward-compatible alias for {@link #findWorkspace(String)}. Retained so
-     * callers (including external scripts and the test suite) that have not
-     * migrated to the new name continue to compile.
+     * Backward-compatible alias for {@link #findWorkspace(String)}.
      *
      * @param id the workspace ID
      * @return the matching entry, or {@code null}
@@ -1156,11 +419,7 @@ public class WorkstreamConfig {
 
     /**
      * Renames a workspace, updating every workstream that referenced the old
-     * ID. Used by the {@code workspace_update_config} MCP tool when an
-     * operator passes a new {@code new_id}. The Slack-team-ID connection
-     * (when set) is preserved unchanged so renaming a workspace from
-     * {@code "T0123456789"} to {@code "almostrealism"} does not disrupt
-     * channel routing.
+     * ID. The Slack-team-ID connection (when set) is preserved unchanged.
      *
      * @param oldId current workspace ID; must match an existing entry
      * @param newId new workspace ID; must not collide with another entry
@@ -1175,20 +434,15 @@ public class WorkstreamConfig {
 
     /**
      * Renames a workspace and propagates the new ID to live {@link Workstream}
-     * instances in addition to the persisted entries. Callers that hold live
-     * {@code Workstream} objects (e.g. {@code SlackListener.channelToWorkstream})
-     * MUST use this overload so that a subsequent
-     * {@link #syncFromWorkstreams(Collection)} does not see a stale workspaceId
-     * on the live object and revert the rename.
+     * instances in addition to the persisted entries.
      *
-     * @param oldId current workspace ID; must match an existing entry
-     * @param newId new workspace ID; must not collide with another entry
+     * @param oldId          current workspace ID; must match an existing entry
+     * @param newId          new workspace ID; must not collide with another entry
      * @param liveWorkstreams live workstream objects to update in place; may
      *        be {@code null} when the caller manages no live state
      * @return {@code true} when the rename happened, {@code false} when the
      *         old ID was not found
-     * @throws IllegalArgumentException when {@code newId} collides with an
-     *         existing different workspace
+     * @throws IllegalArgumentException when {@code newId} collides
      */
     public boolean renameWorkspace(String oldId, String newId,
                                    Collection<Workstream> liveWorkstreams) {
@@ -1199,8 +453,7 @@ public class WorkstreamConfig {
         WorkspaceEntry target = findWorkspace(oldId);
         if (target == null) return false;
         if (findWorkspace(newId) != null) {
-            throw new IllegalArgumentException("Workspace ID '" + newId
-                    + "' is already taken");
+            throw new IllegalArgumentException("Workspace ID '" + newId + "' is already taken");
         }
         target.setId(newId);
         for (WorkstreamEntry entry : workstreams) {
@@ -1220,18 +473,8 @@ public class WorkstreamConfig {
 
     /**
      * Validates the workspace-level runner configuration. Unknown phase keys
-     * in any {@code slackWorkspaces[].runners} map are rejected with a clear
-     * message naming the offending workspace; the rest of the config is left
-     * intact. Called automatically after every {@code loadFromYaml*} /
-     * {@code loadFromJson*}.
-     *
-     * <p>Workstream-level {@code runners} maps are <strong>not</strong>
-     * validated here; bad keys there are silently skipped by
-     * {@link SubmissionRunnerResolver} at submission time so a single mistyped
-     * workstream cannot brick the entire controller. Workspace-level entries
-     * apply to many workstreams at once, so the same forgiveness would
-     * silently mis-route every workstream sharing the workspace — the
-     * stricter load-time check is the safer default.</p>
+     * in any workspace's {@code runners} map are rejected with a clear message.
+     * Called automatically after every {@code loadFromYaml*} / {@code loadFromJson*}.
      *
      * @throws IOException when any workspace runner map references an unknown
      *                     phase wire name
@@ -1241,8 +484,7 @@ public class WorkstreamConfig {
         for (WorkspaceEntry entry : workspaces) {
             Map<String, String> entryRunners = entry.getRunners();
             if (entryRunners == null || entryRunners.isEmpty()) continue;
-            String label = entry.getId() != null
-                    ? entry.getId() : entry.getName();
+            String label = entry.getId() != null ? entry.getId() : entry.getName();
             for (String phaseKey : entryRunners.keySet()) {
                 try {
                     Phase.fromWireName(phaseKey);
@@ -1256,8 +498,7 @@ public class WorkstreamConfig {
                     throw new IOException("Unknown phase '" + phaseKey
                             + "' in workspaces["
                             + (label != null ? label : "<unnamed>")
-                            + "].runners; expected one of "
-                            + known);
+                            + "].runners; expected one of " + known);
                 }
             }
         }
@@ -1278,14 +519,7 @@ public class WorkstreamConfig {
 
     /**
      * Returns INFO-level deprecation messages for any legacy configuration
-     * fields still present in the loaded configuration. The legacy runner
-     * fields ({@code defaultRunner}, {@code runners})
-     * are accepted on load and auto-migrated into the per-phase shape
-     * ({@code defaultPhaseConfig} / {@code phaseConfigs}) by
-     * {@link WorkstreamEntry#toPhaseConfigBundle()} and
-     * {@link WorkspaceEntry#toPhaseConfigBundle()}, but are never written
-     * back — a save-then-load cycle drops them. Operators should migrate
-     * their YAML to the per-phase shape.
+     * fields still present in the loaded configuration.
      *
      * @return one message per entry that still carries a legacy field; empty
      *         when the configuration is already fully migrated
@@ -1351,9 +585,9 @@ public class WorkstreamConfig {
 
     /**
      * Copies every mutable field from a live {@link Workstream} onto the
-     * supplied {@link WorkstreamEntry}. Shared by {@link #addWorkstream} (which
-     * creates a new entry) and {@link #syncFromWorkstreams} (which updates an
-     * existing one) so the canonical field list is maintained in exactly one place.
+     * supplied {@link WorkstreamEntry}. Shared by {@link #addWorkstream} and
+     * {@link #syncFromWorkstreams} so the canonical field list is maintained
+     * in exactly one place.
      *
      * @param entry the entry to populate
      * @param ws    the live workstream whose current state to copy
@@ -1386,29 +620,18 @@ public class WorkstreamConfig {
     }
 
     /**
-     * Copies every non-empty per-phase entry of {@code bundle} — runner,
-     * model, effort, and provider alike — onto {@code entry}'s new
-     * {@code phaseConfigs} field so the full configuration round-trips through
-     * YAML serialization. The legacy {@code runners} map is write-only and is
-     * no longer serialized, so per-phase runner values must be carried by
-     * {@code phaseConfigs} rather than mirrored to {@code runners}.
+     * Copies every non-empty per-phase entry of {@code bundle} onto
+     * {@code entry}'s new {@code phaseConfigs} field so the full configuration
+     * round-trips through YAML serialization.
      */
     private static void applyBundleToEntry(WorkstreamEntry entry, PhaseConfigBundle bundle) {
         applyBundleToFields(bundle, entry::setDefaultPhaseConfig, entry::setPhaseConfigs);
     }
 
     /**
-     * Writes the contents of {@code bundle} into a container's new
+     * Writes the contents of {@code bundle} into a container's
      * {@code defaultPhaseConfig} / {@code phaseConfigs} fields via the
-     * supplied setters. Every non-empty per-phase entry is emitted; the
-     * bundle default is written when non-empty and cleared otherwise.
-     *
-     * <p>Unlike a phase-only copy, a bundle that carries only a default —
-     * e.g. a model-only workstream or a {@code defaultRunner}-only workspace
-     * with no per-phase overrides — still has that default persisted. This
-     * matters under write-only legacy serialization: the default is the only
-     * place a migrated {@code model} / {@code effort} / {@code defaultRunner}
-     * survives once the legacy fields stop being written.</p>
+     * supplied setters.
      *
      * @param bundle          the bundle to copy; {@code null} clears both fields
      * @param setDefault      receives the bundle's default, or {@code null}
@@ -1435,13 +658,8 @@ public class WorkstreamConfig {
      * Synchronizes the configuration entries from the in-memory workstream state.
      *
      * <p>For each active workstream, locates the matching entry via
-     * {@link #findEntryToSync} (workstreamId first, channelId as fallback) and
-     * updates its mutable fields; otherwise adds a new entry via
-     * {@link #addWorkstream}. Matching by ID prevents the duplicate-entry
-     * defect where a {@code /flowtree setup} call wrote an entry with a null
-     * {@code channelId} and a later sync — after Slack assigned the channel —
-     * could not find that entry by channel and appended a second entry with
-     * the same workstreamId.</p>
+     * {@link #findEntryToSync} and updates its mutable fields; otherwise adds
+     * a new entry via {@link #addWorkstream}.</p>
      *
      * @param activeWorkstreams the current in-memory workstreams
      */
@@ -1459,8 +677,7 @@ public class WorkstreamConfig {
     /**
      * Locates the {@link WorkstreamEntry} that should receive sync updates for
      * the given live {@link Workstream}. Matching by {@code workstreamId} is
-     * preferred; {@code channelId} is a fallback for legacy entries created
-     * before IDs were universal.
+     * preferred; {@code channelId} is a fallback for legacy entries.
      *
      * @param ws the active workstream being synced
      * @return the matching entry, or {@code null} when no entry exists yet
@@ -1497,25 +714,9 @@ public class WorkstreamConfig {
     }
 
     /**
-     * Folds every container's legacy configuration fields
-     * ({@code model} / {@code effort} / {@code defaultRunner} /
-     * {@code runners}) into the new per-phase shape
-     * ({@code defaultPhaseConfig} / {@code phaseConfigs}) and clears the
-     * legacy fields.
-     *
-     * <p>Called by {@link #saveToYaml(File)} so that persisted YAML only ever
-     * contains the new shape: a save-then-load cycle migrates legacy YAML in
-     * place without losing data. The fold reads {@link
-     * WorkstreamEntry#toPhaseConfigBundle()} /
-     * {@link WorkspaceEntry#toPhaseConfigBundle()}, which already merge the
-     * legacy and new fields field-by-field (new wins), so any value present
-     * in either form survives. Idempotent: a container already in the new
-     * shape is left unchanged.</p>
-     *
-     * <p>This is the only migration trigger. Loading legacy YAML leaves the
-     * legacy fields readable (so the controller keeps functioning across a
-     * restart on an unmigrated file); the rewrite to the new shape happens
-     * the next time the configuration is written back.</p>
+     * Folds every container's legacy configuration fields into the new per-phase
+     * shape and clears the legacy fields. Called by {@link #saveToYaml(File)}.
+     * Idempotent: a container already in the new shape is left unchanged.
      */
     void migrateLegacyConfigToPhaseConfig() {
         for (WorkstreamEntry entry : workstreams) {

--- a/flowtree/runtime/src/main/java/io/flowtree/workstream/WorkstreamEntry.java
+++ b/flowtree/runtime/src/main/java/io/flowtree/workstream/WorkstreamEntry.java
@@ -1,0 +1,366 @@
+/*
+ * Copyright 2026 Michael Murray
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.flowtree.workstream;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.flowtree.jobs.agent.PhaseConfig;
+import io.flowtree.jobs.agent.PhaseConfigBundle;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Configuration entry for a single workstream.
+ *
+ * <p>A workstream binds a git branch to a Slack channel (or runs headlessly
+ * without Slack) and declares the operational parameters for agent jobs
+ * submitted against that branch. Instances are loaded from the
+ * {@code workstreams:} YAML list and converted to live {@link Workstream}
+ * objects via {@link #toWorkstream()}.</p>
+ *
+ * @author Michael Murray
+ * @see WorkstreamConfig
+ * @see Workstream
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class WorkstreamEntry {
+
+    /** Persistent identifier; generated if absent and saved back to YAML. */
+    private String workstreamId;
+    /** The Slack channel ID this workstream is bound to. */
+    private String channelId;
+    /** The human-readable Slack channel name. */
+    private String channelName;
+    /** Optional agent endpoints; typically empty since agents connect inbound. */
+    private List<AgentEntry> agents = new ArrayList<>();
+    /** Branch agents commit to by default. */
+    private String defaultBranch;
+    /** Branch used as the base when the controller creates a new branch. */
+    private String baseBranch;
+    /** Whether agents push commits to the remote origin. */
+    private boolean pushToOrigin = true;
+    /** Local filesystem path to the checked-out repository. */
+    private String workingDirectory;
+    /** Git clone URL for automatic repository checkout. */
+    private String repoUrl;
+    /** Comma-separated list of Claude Code tool names the agent may use. */
+    private String allowedTools = "Read,Edit,Write,Bash,Glob,Grep";
+    /** Maximum number of agent turns per job. */
+    private int maxTurns = 800;
+    /** Maximum spending budget per job in USD. */
+    private double maxBudgetUsd = 100.0;
+    /** Git author name for commits. */
+    private String gitUserName;
+    /** Git author email for commits. */
+    private String gitUserEmail;
+    /** Per-workstream environment variables injected into pushed tool MCP configs. */
+    private Map<String, String> env;
+    /** Per-workstream environment variables set on the agent subprocess itself. */
+    private Map<String, String> agentEnv;
+    /** Optional path to a planning document the agent consults for context. */
+    private String planningDocument;
+    /** GitHub organization name for org-based token selection. */
+    private String githubOrg;
+    /** Additional repository URLs cloned alongside the primary repo. */
+    private List<String> dependentRepos;
+    /**
+     * Workstream IDs of completion listeners that should be woken up
+     * automatically when a job on this workstream reaches a terminal
+     * status. The listener graph must be a DAG; the cycle check runs
+     * on register / update and rejects configurations that would
+     * introduce a cycle, including self-listing.
+     */
+    private List<String> completionListeners;
+    /** Node labels that jobs submitted to this workstream must match by default. */
+    private Map<String, String> requiredLabels;
+    /**
+     * The workspace ID this workstream is bound to. Accepts the legacy
+     * YAML key {@code slackWorkspaceId} via {@link JsonAlias} so existing
+     * configs continue to load; the field now holds an operator-chosen
+     * workspace ID rather than a Slack team ID.
+     */
+    @JsonAlias({"slackWorkspaceId"})
+    private String workspaceId;
+    /**
+     * Default {@link io.flowtree.jobs.agent.AgentRunner} applied to jobs
+     * in this workstream when no per-phase or per-job override is set.
+     * Legacy field: accepted on load and auto-migrated into
+     * {@link #defaultPhaseConfig}, but write-only for serialization.
+     */
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    private String defaultRunner;
+    /**
+     * Per-phase runner overrides keyed by phase wire name (e.g.
+     * {@code primary}, {@code deduplication}). Phases not listed inherit
+     * {@link #defaultRunner}. Legacy field: accepted on load and
+     * auto-migrated into {@link #phaseConfigs}, but write-only for
+     * serialization.
+     */
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    private Map<String, String> runners = new LinkedHashMap<>();
+    /**
+     * Workstream-level default {@link PhaseConfig}; new form for the
+     * unified per-phase config ladder. Optional; {@code null} omits the
+     * field from serialized YAML.
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private PhaseConfig defaultPhaseConfig;
+    /**
+     * Workstream-level per-phase {@link PhaseConfig} overrides keyed by
+     * phase wire name. Optional; an empty map is omitted from
+     * serialized YAML.
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private Map<String, PhaseConfig> phaseConfigs = new LinkedHashMap<>();
+    /**
+     * Whether this workstream is archived. Archived workstreams are
+     * hidden from default {@code workstream_list} responses but their
+     * job history and memories remain queryable.
+     */
+    private boolean archived;
+
+    /** Returns the persistent workstream identifier. */
+    public String getWorkstreamId() { return workstreamId; }
+    /** Sets the persistent workstream identifier. */
+    public void setWorkstreamId(String workstreamId) { this.workstreamId = workstreamId; }
+
+    /** Returns the Slack channel ID (e.g., "C0123456789"). */
+    public String getChannelId() { return channelId; }
+    /** Sets the Slack channel ID. */
+    public void setChannelId(String channelId) { this.channelId = channelId; }
+
+    /** Returns the human-readable Slack channel name (e.g., "#project-agent"). */
+    public String getChannelName() { return channelName; }
+    /** Sets the human-readable Slack channel name. */
+    public void setChannelName(String channelName) { this.channelName = channelName; }
+
+    /** Returns the list of agent endpoint entries for this workstream. */
+    public List<AgentEntry> getAgents() { return agents; }
+    /** Sets the list of agent endpoint entries for this workstream. */
+    public void setAgents(List<AgentEntry> agents) { this.agents = agents; }
+
+    /** Returns the default git branch for agent commits. */
+    public String getDefaultBranch() { return defaultBranch; }
+    /** Sets the default git branch for agent commits. */
+    public void setDefaultBranch(String defaultBranch) { this.defaultBranch = defaultBranch; }
+
+    /** Returns the base branch used as the starting point for new branch creation. */
+    public String getBaseBranch() { return baseBranch; }
+    /** Sets the base branch used when creating new target branches. */
+    public void setBaseBranch(String baseBranch) { this.baseBranch = baseBranch; }
+
+    /** Returns whether agents should push commits to the remote origin. */
+    public boolean isPushToOrigin() { return pushToOrigin; }
+    /** Sets whether agents should push commits to the remote origin. */
+    public void setPushToOrigin(boolean pushToOrigin) { this.pushToOrigin = pushToOrigin; }
+
+    /** Returns the local working directory for the agent's git repository. */
+    public String getWorkingDirectory() { return workingDirectory; }
+    /** Sets the local working directory for the agent's git repository. */
+    public void setWorkingDirectory(String workingDirectory) { this.workingDirectory = workingDirectory; }
+
+    /** Returns the git repository URL for automatic checkout. */
+    public String getRepoUrl() { return repoUrl; }
+    /** Sets the git repository URL for automatic checkout. */
+    public void setRepoUrl(String repoUrl) { this.repoUrl = repoUrl; }
+
+    /** Returns the comma-separated list of Claude Code tool names the agent may use. */
+    public String getAllowedTools() { return allowedTools; }
+    /** Sets the comma-separated list of allowed Claude Code tool names. */
+    public void setAllowedTools(String allowedTools) { this.allowedTools = allowedTools; }
+
+    /** Returns the maximum number of turns a Claude Code agent may take per job. */
+    public int getMaxTurns() { return maxTurns; }
+    /** Sets the maximum number of turns per job. */
+    public void setMaxTurns(int maxTurns) { this.maxTurns = maxTurns; }
+
+    /** Returns the maximum spending budget per job in USD. */
+    public double getMaxBudgetUsd() { return maxBudgetUsd; }
+    /** Sets the maximum spending budget per job in USD. */
+    public void setMaxBudgetUsd(double maxBudgetUsd) { this.maxBudgetUsd = maxBudgetUsd; }
+
+    /** Returns the git author name used for commits made by this workstream. */
+    public String getGitUserName() { return gitUserName; }
+    /** Sets the git author name used for commits. */
+    public void setGitUserName(String gitUserName) { this.gitUserName = gitUserName; }
+
+    /** Returns the git author email used for commits made by this workstream. */
+    public String getGitUserEmail() { return gitUserEmail; }
+    /** Sets the git author email used for commits. */
+    public void setGitUserEmail(String gitUserEmail) { this.gitUserEmail = gitUserEmail; }
+
+    /** Returns per-workstream environment variables injected into pushed tool MCP configs. */
+    public Map<String, String> getEnv() { return env; }
+    /** Sets per-workstream environment variables for pushed tools. */
+    public void setEnv(Map<String, String> env) { this.env = env; }
+
+    /** Returns per-workstream environment variables set on the agent subprocess. */
+    public Map<String, String> getAgentEnv() { return agentEnv; }
+    /** Sets per-workstream environment variables for the agent subprocess. */
+    public void setAgentEnv(Map<String, String> agentEnv) { this.agentEnv = agentEnv; }
+
+    /** Returns the optional planning document path for broader goal context. */
+    public String getPlanningDocument() { return planningDocument; }
+    /** Sets the planning document path for this workstream. */
+    public void setPlanningDocument(String planningDocument) { this.planningDocument = planningDocument; }
+
+    /** Returns the GitHub organization name for org-based token selection. */
+    public String getGithubOrg() { return githubOrg; }
+    /** Sets the GitHub organization name for org-based token selection. */
+    public void setGithubOrg(String githubOrg) { this.githubOrg = githubOrg; }
+
+    /**
+     * Returns the list of dependent repository URLs that should be
+     * checked out alongside the primary repo. Each repo is cloned
+     * as a sibling directory and managed with the same branch/commit
+     * lifecycle as the primary repo.
+     */
+    public List<String> getDependentRepos() { return dependentRepos; }
+    /** Sets the dependent repository URLs. */
+    public void setDependentRepos(List<String> dependentRepos) { this.dependentRepos = dependentRepos; }
+
+    /**
+     * Returns the workstream IDs of completion listeners that should
+     * be woken up automatically when a job on this workstream reaches
+     * a terminal status. The cycle check rejects configurations that
+     * would create a cycle in the listener graph at config time.
+     *
+     * @return listener workstream IDs; never {@code null}, may be empty
+     */
+    public List<String> getCompletionListeners() {
+        return completionListeners == null
+                ? Collections.emptyList() : completionListeners;
+    }
+    /**
+     * Sets the listener workstream IDs. Pass {@code null} or empty
+     * to clear (the inert default, which spawns no wake-up jobs).
+     */
+    public void setCompletionListeners(List<String> completionListeners) {
+        this.completionListeners = (completionListeners == null)
+                ? new ArrayList<>() : new ArrayList<>(completionListeners);
+    }
+
+    /**
+     * Returns the Node labels that jobs submitted to this workstream must match by default.
+     * When a job submission does not include {@code requiredLabels}, these are applied.
+     */
+    public Map<String, String> getRequiredLabels() { return requiredLabels; }
+    /** Sets the default Node label requirements for jobs in this workstream. */
+    public void setRequiredLabels(Map<String, String> requiredLabels) { this.requiredLabels = requiredLabels; }
+
+    /**
+     * Returns the workspace ID this workstream is assigned to. When absent,
+     * the workstream is assigned to the first workspace connection.
+     */
+    public String getWorkspaceId() { return workspaceId; }
+    /** Sets the workspace ID for this workstream. */
+    public void setWorkspaceId(String workspaceId) { this.workspaceId = workspaceId; }
+
+    /** Returns the default agent runner for jobs in this workstream, or {@code null}. */
+    public String getDefaultRunner() { return defaultRunner; }
+    /** Sets the default agent runner for jobs in this workstream. */
+    public void setDefaultRunner(String defaultRunner) { this.defaultRunner = defaultRunner; }
+
+    /** Returns the per-phase runner override map (keyed by phase wire name); never {@code null}. */
+    public Map<String, String> getRunners() { return runners; }
+    /** Replaces the per-phase runner override map; {@code null} is treated as empty. */
+    public void setRunners(Map<String, String> runners) {
+        this.runners = runners != null ? new LinkedHashMap<>(runners) : new LinkedHashMap<>();
+    }
+
+    /** Returns the workstream-level default {@link PhaseConfig}, or {@code null}. */
+    public PhaseConfig getDefaultPhaseConfig() { return defaultPhaseConfig; }
+    /** Sets the workstream-level default {@link PhaseConfig}. */
+    public void setDefaultPhaseConfig(PhaseConfig defaultPhaseConfig) {
+        this.defaultPhaseConfig = defaultPhaseConfig;
+    }
+
+    /** Returns the workstream-level per-phase {@link PhaseConfig} overrides; never {@code null}. */
+    public Map<String, PhaseConfig> getPhaseConfigs() { return phaseConfigs; }
+    /** Replaces the workstream-level per-phase {@link PhaseConfig} overrides. */
+    public void setPhaseConfigs(Map<String, PhaseConfig> phaseConfigs) {
+        this.phaseConfigs = phaseConfigs != null ? new LinkedHashMap<>(phaseConfigs) : new LinkedHashMap<>();
+    }
+
+    /**
+     * Builds the effective {@link PhaseConfigBundle} for this workstream
+     * entry, merging the new fields with the legacy
+     * {@code defaultRunner}/{@code runners} runner fields. The new fields
+     * take precedence field-by-field.
+     *
+     * @return the merged bundle; never {@code null}
+     */
+    public PhaseConfigBundle toPhaseConfigBundle() {
+        return PhaseConfigBundle.mergeLegacyWithNew(
+                defaultRunner, runners, defaultPhaseConfig, phaseConfigs);
+    }
+
+    /** Returns {@code true} when this workstream is archived. */
+    public boolean isArchived() { return archived; }
+    /** Sets the archived flag. */
+    public void setArchived(boolean archived) { this.archived = archived; }
+
+    /**
+     * Converts this entry to a {@link Workstream} instance.
+     *
+     * <p>If a {@code workstreamId} is present, it is used as the persistent
+     * identifier. Otherwise, a random UUID is generated.</p>
+     */
+    public Workstream toWorkstream() {
+        Workstream ws;
+        if (workstreamId != null && !workstreamId.isEmpty()) {
+            ws = new Workstream(workstreamId, channelId, channelName);
+        } else {
+            ws = new Workstream(channelId, channelName);
+        }
+        for (AgentEntry agent : agents) {
+            ws.addAgent(agent.getHost(), agent.getPort());
+        }
+        ws.setDefaultBranch(defaultBranch);
+        ws.setBaseBranch(baseBranch);
+        ws.setPushToOrigin(pushToOrigin);
+        ws.setWorkingDirectory(workingDirectory);
+        ws.setRepoUrl(repoUrl);
+        ws.setAllowedTools(allowedTools);
+        ws.setMaxTurns(maxTurns);
+        ws.setMaxBudgetUsd(maxBudgetUsd);
+        ws.setGitUserName(gitUserName);
+        ws.setGitUserEmail(gitUserEmail);
+        ws.setEnv(env);
+        ws.setAgentEnv(agentEnv);
+        ws.setPlanningDocument(planningDocument);
+        ws.setGithubOrg(githubOrg);
+        ws.setDependentRepos(dependentRepos);
+        ws.setRequiredLabels(requiredLabels);
+        ws.setWorkspaceId(workspaceId);
+        ws.setDefaultRunner(defaultRunner);
+        ws.setRunners(runners);
+        PhaseConfigBundle bundle = toPhaseConfigBundle();
+        if (!bundle.isEmpty()) {
+            ws.setPhaseConfigBundle(bundle);
+        }
+        ws.setArchived(archived);
+        ws.setCompletionListeners(completionListeners);
+        return ws;
+    }
+}

--- a/flowtree/runtime/src/test/java/io/flowtree/api/SecretsEndpointTest.java
+++ b/flowtree/runtime/src/test/java/io/flowtree/api/SecretsEndpointTest.java
@@ -47,6 +47,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import io.flowtree.workstream.WorkspaceSecretEntry;
 
 /**
  * Integration tests for the {@code /api/secrets/*} endpoints in
@@ -111,14 +112,14 @@ public class SecretsEndpointTest extends TestSuiteBase {
         Console.root().addListener(auditListener);
 
         // Build secrets cache
-        WorkstreamConfig.WorkspaceSecretEntry entry = new WorkstreamConfig.WorkspaceSecretEntry();
+        WorkspaceSecretEntry entry = new WorkspaceSecretEntry();
         entry.setName("aws-prod");
         entry.setFile(secretFile.toAbsolutePath().toString());
 
-        Map<String, WorkstreamConfig.WorkspaceSecretEntry> wsASecrets = new HashMap<>();
+        Map<String, WorkspaceSecretEntry> wsASecrets = new HashMap<>();
         wsASecrets.put("aws-prod", entry);
 
-        Map<String, Map<String, WorkstreamConfig.WorkspaceSecretEntry>> cache = new HashMap<>();
+        Map<String, Map<String, WorkspaceSecretEntry>> cache = new HashMap<>();
         cache.put(WORKSPACE_A, wsASecrets);
 
         // Workstream registered on notifier for workspace-A
@@ -302,7 +303,7 @@ public class SecretsEndpointTest extends TestSuiteBase {
     @Test(timeout = 10000)
     public void testAdminCreateWritesFile() throws Exception {
         Path newFile = secretsDir.resolve(WORKSPACE_A + "__gh-token.json");
-        WorkstreamConfig.WorkspaceSecretEntry newEntry = new WorkstreamConfig.WorkspaceSecretEntry();
+        WorkspaceSecretEntry newEntry = new WorkspaceSecretEntry();
         newEntry.setName("gh-token");
         newEntry.setFile(newFile.toAbsolutePath().toString());
 
@@ -313,15 +314,15 @@ public class SecretsEndpointTest extends TestSuiteBase {
         ws.setWorkspaceId(WORKSPACE_A);
         notifier.registerWorkstream(ws);
 
-        WorkstreamConfig.WorkspaceSecretEntry existEntry = new WorkstreamConfig.WorkspaceSecretEntry();
+        WorkspaceSecretEntry existEntry = new WorkspaceSecretEntry();
         existEntry.setName("aws-prod");
         existEntry.setFile(secretFile.toAbsolutePath().toString());
 
-        Map<String, WorkstreamConfig.WorkspaceSecretEntry> wsASecrets = new HashMap<>();
+        Map<String, WorkspaceSecretEntry> wsASecrets = new HashMap<>();
         wsASecrets.put("aws-prod", existEntry);
         wsASecrets.put("gh-token", newEntry);
 
-        Map<String, Map<String, WorkstreamConfig.WorkspaceSecretEntry>> cache = new HashMap<>();
+        Map<String, Map<String, WorkspaceSecretEntry>> cache = new HashMap<>();
         cache.put(WORKSPACE_A, wsASecrets);
 
         endpoint = new FlowTreeApiEndpoint(0, notifier);

--- a/flowtree/runtime/src/test/java/io/flowtree/api/WorkspaceConfigEndpointTest.java
+++ b/flowtree/runtime/src/test/java/io/flowtree/api/WorkspaceConfigEndpointTest.java
@@ -40,6 +40,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import io.flowtree.workstream.WorkspaceEntry;
+import io.flowtree.workstream.WorkstreamEntry;
 
 /**
  * Integration tests for the {@code POST /api/workspaces/{id}/config}
@@ -55,7 +57,7 @@ public class WorkspaceConfigEndpointTest extends TestSuiteBase {
     private static final String WORKSPACE_ID = "T1234567890";
 
     /** The configured workspace entry under test; mutated by the endpoint. */
-    private WorkstreamConfig.WorkspaceEntry workspaceEntry;
+    private WorkspaceEntry workspaceEntry;
     /** Loaded config used to back the workspace lookup and persistence. */
     private WorkstreamConfig config;
     /** YAML file backing the listener's persistence; tests verify content lands here. */
@@ -71,7 +73,7 @@ public class WorkspaceConfigEndpointTest extends TestSuiteBase {
     @Before
     public void setUp() throws Exception {
         config = new WorkstreamConfig();
-        workspaceEntry = new WorkstreamConfig.WorkspaceEntry();
+        workspaceEntry = new WorkspaceEntry();
         workspaceEntry.setId(WORKSPACE_ID);
         workspaceEntry.setSlackTeamId(WORKSPACE_ID);
         workspaceEntry.setName("Initial Name");
@@ -200,7 +202,7 @@ public class WorkspaceConfigEndpointTest extends TestSuiteBase {
         // shared in-memory reference. The per-phase shape (not the removed
         // legacy runner fields) is what survives the round-trip.
         WorkstreamConfig reloaded = WorkstreamConfig.loadFromYaml(configFile);
-        WorkstreamConfig.WorkspaceEntry reloadedEntry =
+        WorkspaceEntry reloadedEntry =
                 reloaded.findSlackWorkspace(WORKSPACE_ID);
         assertNotNull(reloadedEntry);
         assertEquals("Persisted Name", reloadedEntry.getName());
@@ -243,8 +245,8 @@ public class WorkspaceConfigEndpointTest extends TestSuiteBase {
         // Seed a workstream that references the workspace by its current ID.
         Workstream ws = new Workstream("ws-1", "C-x", "#x");
         ws.setWorkspaceId(WORKSPACE_ID);
-        WorkstreamConfig.WorkstreamEntry wsEntry =
-                new WorkstreamConfig.WorkstreamEntry();
+        WorkstreamEntry wsEntry =
+                new WorkstreamEntry();
         wsEntry.setChannelId("C-x");
         wsEntry.setChannelName("#x");
         wsEntry.setWorkspaceId(WORKSPACE_ID);
@@ -310,7 +312,7 @@ public class WorkspaceConfigEndpointTest extends TestSuiteBase {
         // gap-fix sessions only verified in-memory state, which would pass
         // even if persistConfig() dropped the new fields on the floor.
         WorkstreamConfig reloaded = WorkstreamConfig.loadFromYaml(configFile);
-        WorkstreamConfig.WorkspaceEntry reloadedEntry =
+        WorkspaceEntry reloadedEntry =
                 reloaded.findSlackWorkspace(WORKSPACE_ID);
         assertNotNull(reloadedEntry);
         assertNotNull("defaultPhaseConfig must survive YAML round-trip",

--- a/flowtree/runtime/src/test/java/io/flowtree/controller/FlowTreeControllerMultiWorkspaceTest.java
+++ b/flowtree/runtime/src/test/java/io/flowtree/controller/FlowTreeControllerMultiWorkspaceTest.java
@@ -80,7 +80,7 @@ public class FlowTreeControllerMultiWorkspaceTest extends TestSuiteBase {
         assertTrue("No workspace connections in single-token mode",
                 controller.getWorkspaceConnections().isEmpty());
 
-        FlowTreeController.WorkspaceConnection conn = controller.getDefaultConnection();
+        WorkspaceConnection conn = controller.getDefaultConnection();
         assertNotNull(conn);
         assertEquals("xoxb-test", conn.botToken);
         assertEquals("xapp-test", conn.appToken);
@@ -139,7 +139,7 @@ public class FlowTreeControllerMultiWorkspaceTest extends TestSuiteBase {
         assertEquals("One workspace connection expected", 1,
                 controller.getWorkspaceConnections().size());
 
-        FlowTreeController.WorkspaceConnection conn =
+        WorkspaceConnection conn =
                 controller.getWorkspaceConnections().get("T111");
         assertNotNull("Workspace T111 connection should exist", conn);
         assertEquals("T111", conn.workspaceId);
@@ -166,7 +166,7 @@ public class FlowTreeControllerMultiWorkspaceTest extends TestSuiteBase {
         controller.loadConfig(tmpFile);
 
         // After loading, defaultConnection should point to the first workspace
-        FlowTreeController.WorkspaceConnection defaultConn = controller.getDefaultConnection();
+        WorkspaceConnection defaultConn = controller.getDefaultConnection();
         assertNotNull(defaultConn);
         Assert.assertEquals("Default connection should be the first workspace",
                 "T111", defaultConn.workspaceId);
@@ -203,12 +203,12 @@ public class FlowTreeControllerMultiWorkspaceTest extends TestSuiteBase {
         assertEquals("Two workspace connections expected", 2,
                 controller.getWorkspaceConnections().size());
 
-        FlowTreeController.WorkspaceConnection alpha =
+        WorkspaceConnection alpha =
                 controller.getWorkspaceConnections().get("T111");
         assertNotNull(alpha);
         assertEquals("xoxb-alpha", alpha.botToken);
 
-        FlowTreeController.WorkspaceConnection beta =
+        WorkspaceConnection beta =
                 controller.getWorkspaceConnections().get("T222");
         assertNotNull(beta);
         assertEquals("xoxb-beta", beta.botToken);
@@ -233,9 +233,9 @@ public class FlowTreeControllerMultiWorkspaceTest extends TestSuiteBase {
         FlowTreeController controller = new FlowTreeController(null, null);
         controller.loadConfig(tmpFile);
 
-        FlowTreeController.WorkspaceConnection alpha =
+        WorkspaceConnection alpha =
                 controller.getWorkspaceConnections().get("T111");
-        FlowTreeController.WorkspaceConnection beta =
+        WorkspaceConnection beta =
                 controller.getWorkspaceConnections().get("T222");
 
         assertNotNull(alpha.notifier);
@@ -264,7 +264,7 @@ public class FlowTreeControllerMultiWorkspaceTest extends TestSuiteBase {
                 controller.getWorkspaceConnections().isEmpty());
 
         // Default connection still holds the original tokens
-        FlowTreeController.WorkspaceConnection conn = controller.getDefaultConnection();
+        WorkspaceConnection conn = controller.getDefaultConnection();
         assertNotNull(conn);
         assertEquals("xoxb-legacy", conn.botToken);
         assertEquals("xapp-legacy", conn.appToken);
@@ -331,7 +331,7 @@ public class FlowTreeControllerMultiWorkspaceTest extends TestSuiteBase {
     }
 
     /**
-     * Verifies that a loaded {@link FlowTreeController.WorkspaceConnection} stores
+     * Verifies that a loaded {@link WorkspaceConnection} stores
      * the workspace ID exactly as declared in the config file.
      */
     @Test(timeout = 10000)
@@ -346,7 +346,7 @@ public class FlowTreeControllerMultiWorkspaceTest extends TestSuiteBase {
         FlowTreeController controller = new FlowTreeController(null, null);
         controller.loadConfig(tmpFile);
 
-        FlowTreeController.WorkspaceConnection conn =
+        WorkspaceConnection conn =
                 controller.getWorkspaceConnections().get("T_EXPECTED");
         assertNotNull(conn);
         Assert.assertEquals("WorkspaceConnection must store the workspace ID",
@@ -407,7 +407,7 @@ public class FlowTreeControllerMultiWorkspaceTest extends TestSuiteBase {
      * reloaded its config.
      *
      * <p>Root cause: {@link FlowTreeController#buildWorkspaceConnections} was
-     * rebuilding every {@link FlowTreeController.WorkspaceConnection} (and
+     * rebuilding every {@link WorkspaceConnection} (and
      * therefore every {@link SlackNotifier}) on each reload, without
      * propagating the controller-owned {@link JobStatsStore} onto the freshly
      * constructed notifiers. The listener's primary notifier was then a
@@ -534,7 +534,7 @@ public class FlowTreeControllerMultiWorkspaceTest extends TestSuiteBase {
         FlowTreeController controller = new FlowTreeController(null, null);
         controller.loadConfig(tmpFile);
 
-        FlowTreeController.WorkspaceConnection conn =
+        WorkspaceConnection conn =
                 controller.getWorkspaceConnections().get("T111");
         assertNotNull(conn);
 

--- a/flowtree/runtime/src/test/java/io/flowtree/slack/SlackIntegrationTest.java
+++ b/flowtree/runtime/src/test/java/io/flowtree/slack/SlackIntegrationTest.java
@@ -45,6 +45,7 @@ import io.flowtree.workstream.Workstream;
 import io.flowtree.workstream.WorkstreamConfig;
 
 import static org.junit.Assert.*;
+import io.flowtree.workstream.WorkstreamEntry;
 
 /**
  * Tests for the FlowTree orchestration and Slack integration components.
@@ -852,8 +853,8 @@ public class SlackIntegrationTest extends TestSuiteBase {
         assertEquals(2, reloaded.getWorkstreams().size());
 
         // Find the new entry
-        WorkstreamConfig.WorkstreamEntry newEntry = null;
-        for (WorkstreamConfig.WorkstreamEntry entry : reloaded.getWorkstreams()) {
+        WorkstreamEntry newEntry = null;
+        for (WorkstreamEntry entry : reloaded.getWorkstreams()) {
             if ("C_NEW".equals(entry.getChannelId())) {
                 newEntry = entry;
                 break;

--- a/flowtree/runtime/src/test/java/io/flowtree/slack/SlackMultiTenantConfigTest.java
+++ b/flowtree/runtime/src/test/java/io/flowtree/slack/SlackMultiTenantConfigTest.java
@@ -31,6 +31,8 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.*;
+import io.flowtree.workstream.WorkspaceEntry;
+import io.flowtree.workstream.WorkstreamEntry;
 
 /**
  * Tests for multi-tenant Slack workspace configuration, channel-key routing,
@@ -43,7 +45,7 @@ import static org.junit.Assert.*;
  */
 public class SlackMultiTenantConfigTest extends TestSuiteBase {
 
-    /** WorkstreamConfig.WorkspaceEntry serializes and deserializes all Slack fields. */
+    /** WorkspaceEntry serializes and deserializes all Slack fields. */
     @Test(timeout = 10000)
     public void testWorkspaceEntryYamlRoundTrip() throws IOException {
         String yaml = "slackWorkspaces:\n" +
@@ -60,7 +62,7 @@ public class SlackMultiTenantConfigTest extends TestSuiteBase {
         assertNotNull(config.getSlackWorkspaces());
         assertEquals(1, config.getSlackWorkspaces().size());
 
-        WorkstreamConfig.WorkspaceEntry entry = config.getSlackWorkspaces().get(0);
+        WorkspaceEntry entry = config.getSlackWorkspaces().get(0);
         assertEquals("T0123456789", entry.getId());
         assertEquals("T0123456789", entry.getSlackTeamId());
         assertEquals("my-org", entry.getName());
@@ -90,14 +92,14 @@ public class SlackMultiTenantConfigTest extends TestSuiteBase {
 
         assertEquals(2, config.getSlackWorkspaces().size());
 
-        WorkstreamConfig.WorkspaceEntry ws1 = config.getSlackWorkspaces().get(0);
+        WorkspaceEntry ws1 = config.getSlackWorkspaces().get(0);
         assertEquals("T111", ws1.getId());
         assertEquals("workspace-one", ws1.getName());
         assertEquals("xoxb-one", ws1.getBotToken());
         assertNotNull(ws1.getGithubOrgs());
         assertEquals("ghp_one", ws1.getGithubOrgs().get("my-org").getToken());
 
-        WorkstreamConfig.WorkspaceEntry ws2 = config.getSlackWorkspaces().get(1);
+        WorkspaceEntry ws2 = config.getSlackWorkspaces().get(1);
         assertEquals("T222", ws2.getId());
         assertEquals("/config/slack-tokens.json", ws2.getTokensFile());
     }
@@ -146,11 +148,11 @@ public class SlackMultiTenantConfigTest extends TestSuiteBase {
 
         assertEquals(2, config.getWorkstreams().size());
 
-        WorkstreamConfig.WorkstreamEntry entryWithId = config.getWorkstreams().get(0);
+        WorkstreamEntry entryWithId = config.getWorkstreams().get(0);
         assertEquals("C001", entryWithId.getChannelId());
         assertEquals("T111", entryWithId.getWorkspaceId());
 
-        WorkstreamConfig.WorkstreamEntry entryWithoutId = config.getWorkstreams().get(1);
+        WorkstreamEntry entryWithoutId = config.getWorkstreams().get(1);
         assertEquals("C002", entryWithoutId.getChannelId());
         assertNull(entryWithoutId.getWorkspaceId());
 
@@ -162,7 +164,7 @@ public class SlackMultiTenantConfigTest extends TestSuiteBase {
     /** SlackTokens.from(entry) extracts inline botToken and appToken. */
     @Test(timeout = 10000)
     public void testSlackTokensFromEntryInlineTokens() throws IOException {
-        WorkstreamConfig.WorkspaceEntry entry = new WorkstreamConfig.WorkspaceEntry();
+        WorkspaceEntry entry = new WorkspaceEntry();
         entry.setId("T999");
         entry.setBotToken("xoxb-inline-bot");
         entry.setAppToken("xapp-inline-app");
@@ -181,7 +183,7 @@ public class SlackMultiTenantConfigTest extends TestSuiteBase {
         Files.write(tempFile.toPath(),
                 "{ \"botToken\": \"xoxb-from-file\", \"appToken\": \"xapp-from-file\" }".getBytes());
 
-        WorkstreamConfig.WorkspaceEntry entry = new WorkstreamConfig.WorkspaceEntry();
+        WorkspaceEntry entry = new WorkspaceEntry();
         entry.setId("T888");
         entry.setTokensFile(tempFile.getAbsolutePath());
         entry.setBotToken("xoxb-should-be-ignored");

--- a/flowtree/runtime/src/test/java/io/flowtree/submission/PhaseConfigResolverTest.java
+++ b/flowtree/runtime/src/test/java/io/flowtree/submission/PhaseConfigResolverTest.java
@@ -39,6 +39,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import io.flowtree.workstream.WorkspaceEntry;
 
 /**
  * Tests for {@link PhaseConfigResolver}. Walks the seven-level precedence
@@ -701,7 +702,7 @@ public class PhaseConfigResolverTest extends TestSuiteBase {
      */
     @Test(timeout = 5000)
     public void clearAllPhaseOverridesOnWorkspace() {
-        WorkstreamConfig.WorkspaceEntry entry = new WorkstreamConfig.WorkspaceEntry();
+        WorkspaceEntry entry = new WorkspaceEntry();
         entry.setDefaultPhaseConfig(
                 new PhaseConfig(AgentRunnerRegistry.OPENCODE, null, null, "openrouter"));
         Map<String, PhaseConfig> pc = new LinkedHashMap<>();
@@ -723,7 +724,7 @@ public class PhaseConfigResolverTest extends TestSuiteBase {
      */
     @Test(timeout = 5000)
     public void clearDefaultConfigOnWorkspace() {
-        WorkstreamConfig.WorkspaceEntry entry = new WorkstreamConfig.WorkspaceEntry();
+        WorkspaceEntry entry = new WorkspaceEntry();
         entry.setDefaultPhaseConfig(
                 new PhaseConfig(AgentRunnerRegistry.OPENCODE, null, null, "openrouter"));
         Map<String, PhaseConfig> pc = new LinkedHashMap<>();
@@ -745,7 +746,7 @@ public class PhaseConfigResolverTest extends TestSuiteBase {
      */
     @Test(timeout = 5000)
     public void clearOnePhaseOverrideOnWorkspace() {
-        WorkstreamConfig.WorkspaceEntry entry = new WorkstreamConfig.WorkspaceEntry();
+        WorkspaceEntry entry = new WorkspaceEntry();
         entry.setDefaultPhaseConfig(
                 new PhaseConfig(AgentRunnerRegistry.CLAUDE, null, null));
         Map<String, PhaseConfig> pc = new LinkedHashMap<>();
@@ -904,7 +905,7 @@ public class PhaseConfigResolverTest extends TestSuiteBase {
                 + "      effort: \"high\"\n";
 
         WorkstreamConfig config = WorkstreamConfig.loadFromYamlString(yaml);
-        WorkstreamConfig.WorkspaceEntry wsp = config.findWorkspace("almostrealism");
+        WorkspaceEntry wsp = config.findWorkspace("almostrealism");
         assertNotNull("workspace entry must deserialize", wsp);
 
         PhaseConfigBundle workspaceBundle = wsp.toPhaseConfigBundle();

--- a/flowtree/runtime/src/test/java/io/flowtree/submission/SubmissionConfigResolverTest.java
+++ b/flowtree/runtime/src/test/java/io/flowtree/submission/SubmissionConfigResolverTest.java
@@ -34,6 +34,7 @@ import io.flowtree.workstream.WorkstreamConfig;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import io.flowtree.workstream.WorkspaceEntry;
 
 /**
  * Tests for {@link SubmissionConfigResolver}. The runner-only and Phase-config
@@ -64,11 +65,11 @@ public class SubmissionConfigResolverTest extends TestSuiteBase {
     }
 
     /**
-     * Returns a {@link WorkstreamConfig.WorkspaceEntry} with the given identifier
+     * Returns a {@link WorkspaceEntry} with the given identifier
      * and no other configuration.
      */
-    private static WorkstreamConfig.WorkspaceEntry workspace(String id) {
-        WorkstreamConfig.WorkspaceEntry entry = new WorkstreamConfig.WorkspaceEntry();
+    private static WorkspaceEntry workspace(String id) {
+        WorkspaceEntry entry = new WorkspaceEntry();
         entry.setId(id);
         return entry;
     }
@@ -110,7 +111,7 @@ public class SubmissionConfigResolverTest extends TestSuiteBase {
      */
     @Test(timeout = 5000)
     public void workspaceDefaultRunnerPropagatesWhenWorkstreamEmpty() {
-        WorkstreamConfig.WorkspaceEntry wsEntry = workspace("acme");
+        WorkspaceEntry wsEntry = workspace("acme");
         wsEntry.setDefaultRunner(TEST_RUNNER);
         SubmissionConfigResolver r = SubmissionConfigResolver.resolve(
                 PhaseConfigBundle.EMPTY, workstream(), wsEntry);
@@ -126,7 +127,7 @@ public class SubmissionConfigResolverTest extends TestSuiteBase {
      */
     @Test(timeout = 5000)
     public void workspacePhaseConfigBundleReachesFactory() {
-        WorkstreamConfig.WorkspaceEntry wsEntry = workspace("acme");
+        WorkspaceEntry wsEntry = workspace("acme");
         wsEntry.setDefaultPhaseConfig(new PhaseConfig(TEST_RUNNER, "model-x", null));
         SubmissionConfigResolver r = SubmissionConfigResolver.resolve(
                 PhaseConfigBundle.EMPTY, workstream(), wsEntry);
@@ -146,7 +147,7 @@ public class SubmissionConfigResolverTest extends TestSuiteBase {
      */
     @Test(timeout = 5000)
     public void workstreamDefaultBeatsWorkspaceDefault() {
-        WorkstreamConfig.WorkspaceEntry wsEntry = workspace("acme");
+        WorkspaceEntry wsEntry = workspace("acme");
         wsEntry.setDefaultRunner(TEST_RUNNER);
         Workstream ws = workstream();
         ws.setDefaultRunner(AgentRunnerRegistry.CLAUDE);
@@ -172,7 +173,7 @@ public class SubmissionConfigResolverTest extends TestSuiteBase {
         Workstream ws = workstream();
         ws.setPhaseConfigBundle(bundle(
                 new PhaseConfig(AgentRunnerRegistry.CLAUDE, null, null), null, null));
-        WorkstreamConfig.WorkspaceEntry wsEntry = workspace("acme");
+        WorkspaceEntry wsEntry = workspace("acme");
         wsEntry.setDefaultPhaseConfig(new PhaseConfig(AgentRunnerRegistry.CLAUDE, "ws-model", null));
         PhaseConfigBundle request = bundle(
                 new PhaseConfig(TEST_RUNNER, "req-model", null), null, null);

--- a/flowtree/runtime/src/test/java/io/flowtree/workstream/WorkstreamCompletionListenersConfigTest.java
+++ b/flowtree/runtime/src/test/java/io/flowtree/workstream/WorkstreamCompletionListenersConfigTest.java
@@ -29,10 +29,11 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import io.flowtree.workstream.WorkstreamEntry;
 
 /**
  * Tests for the {@code completionListeners} field on
- * {@link WorkstreamConfig.WorkstreamEntry} and its
+ * {@link WorkstreamEntry} and its
  * round-trip through YAML load / save.
  *
  * <p>The listener list is a new workstream-level field with the
@@ -47,7 +48,7 @@ public class WorkstreamCompletionListenersConfigTest extends TestSuiteBase {
     /**
      * A non-empty listener list survives a YAML save-and-reload
      * round-trip on the entry, and propagates to the runtime
-     * {@link Workstream} when {@link WorkstreamConfig.WorkstreamEntry#toWorkstream()}
+     * {@link Workstream} when {@link WorkstreamEntry#toWorkstream()}
      * is called.
      */
     @Test(timeout = 10000)
@@ -61,7 +62,7 @@ public class WorkstreamCompletionListenersConfigTest extends TestSuiteBase {
                 + "      - \"ws-orchestrator\"\n"
                 + "      - \"ws-monitor\"\n";
         WorkstreamConfig config = WorkstreamConfig.loadFromYamlString(yaml);
-        WorkstreamConfig.WorkstreamEntry entry = config.getWorkstreams().get(0);
+        WorkstreamEntry entry = config.getWorkstreams().get(0);
         List<String> listeners = entry.getCompletionListeners();
         assertNotNull(listeners);
         assertEquals(2, listeners.size());
@@ -77,7 +78,7 @@ public class WorkstreamCompletionListenersConfigTest extends TestSuiteBase {
         tempFile.deleteOnExit();
         config.saveToYaml(tempFile);
         WorkstreamConfig reloaded = WorkstreamConfig.loadFromYaml(tempFile);
-        WorkstreamConfig.WorkstreamEntry reloadedEntry =
+        WorkstreamEntry reloadedEntry =
                 reloaded.getWorkstreams().get(0);
         assertEquals(2, reloadedEntry.getCompletionListeners().size());
         assertTrue(reloadedEntry.getCompletionListeners()
@@ -101,7 +102,7 @@ public class WorkstreamCompletionListenersConfigTest extends TestSuiteBase {
                 + "    channelName: \"#X\"\n"
                 + "    defaultBranch: \"feature/X\"\n";
         WorkstreamConfig config = WorkstreamConfig.loadFromYamlString(yaml);
-        WorkstreamConfig.WorkstreamEntry entry = config.getWorkstreams().get(0);
+        WorkstreamEntry entry = config.getWorkstreams().get(0);
         assertNotNull("entry must have a non-null listener list",
                 entry.getCompletionListeners());
         assertTrue("entry must default to empty listener list",

--- a/flowtree/runtime/src/test/java/io/flowtree/workstream/WorkstreamConfigTest.java
+++ b/flowtree/runtime/src/test/java/io/flowtree/workstream/WorkstreamConfigTest.java
@@ -31,6 +31,8 @@ import io.flowtree.slack.SlackNotifier;
 import io.flowtree.slack.SlackTokens;
 
 import static org.junit.Assert.*;
+import io.flowtree.workstream.WorkspaceEntry;
+import io.flowtree.workstream.WorkstreamEntry;
 
 /**
  * Tests for {@link WorkstreamConfig} loading, defaults, persistence, and
@@ -68,7 +70,7 @@ public class WorkstreamConfigTest extends TestSuiteBase {
         assertEquals(2, config.getWorkstreams().size());
 
         // First workstream
-        WorkstreamConfig.WorkstreamEntry entry1 = config.getWorkstreams().get(0);
+        WorkstreamEntry entry1 = config.getWorkstreams().get(0);
         assertEquals("C0123456789", entry1.getChannelId());
         assertEquals("#project-alpha", entry1.getChannelName());
         assertEquals(2, entry1.getAgents().size());
@@ -79,7 +81,7 @@ public class WorkstreamConfigTest extends TestSuiteBase {
         assertEquals(25.0, entry1.getMaxBudgetUsd(), 0.001);
 
         // Second workstream
-        WorkstreamConfig.WorkstreamEntry entry2 = config.getWorkstreams().get(1);
+        WorkstreamEntry entry2 = config.getWorkstreams().get(1);
         assertEquals("C9876543210", entry2.getChannelId());
         assertEquals("192.168.1.100", entry2.getAgents().get(0).getHost());
 
@@ -182,7 +184,7 @@ public class WorkstreamConfigTest extends TestSuiteBase {
                       "      - host: \"localhost\"\n";
 
         WorkstreamConfig config = WorkstreamConfig.loadFromYamlString(yaml);
-        WorkstreamConfig.WorkstreamEntry entry = config.getWorkstreams().get(0);
+        WorkstreamEntry entry = config.getWorkstreams().get(0);
 
         // Check defaults
         assertEquals(7766, entry.getAgents().get(0).getPort()); // default port
@@ -210,7 +212,7 @@ public class WorkstreamConfigTest extends TestSuiteBase {
         config.addWorkstream(ws);
 
         assertEquals(1, config.getWorkstreams().size());
-        WorkstreamConfig.WorkstreamEntry entry = config.getWorkstreams().get(0);
+        WorkstreamEntry entry = config.getWorkstreams().get(0);
         assertEquals("C_ADD_1", entry.getChannelId());
         assertEquals("#add-channel", entry.getChannelName());
         assertEquals("/workspace/test", entry.getWorkingDirectory());
@@ -248,7 +250,7 @@ public class WorkstreamConfigTest extends TestSuiteBase {
         config.syncFromWorkstreams(wsList);
 
         // Verify the entry was updated
-        WorkstreamConfig.WorkstreamEntry entry = config.getWorkstreams().get(0);
+        WorkstreamEntry entry = config.getWorkstreams().get(0);
         assertEquals("develop", entry.getDefaultBranch());
         assertEquals(25.0, entry.getMaxBudgetUsd(), 0.001);
         assertEquals("/new/path", entry.getWorkingDirectory());
@@ -283,7 +285,7 @@ public class WorkstreamConfigTest extends TestSuiteBase {
 
         // slackWorkspaces must survive the round-trip
         assertEquals(1, reloaded.getSlackWorkspaces().size());
-        WorkstreamConfig.WorkspaceEntry ws = reloaded.getSlackWorkspaces().get(0);
+        WorkspaceEntry ws = reloaded.getSlackWorkspaces().get(0);
         assertEquals("T111", ws.getId());
         // Legacy slackWorkspaces entries auto-migrate so slackTeamId mirrors
         // the original workspace ID — preserving channel routing after the
@@ -335,7 +337,7 @@ public class WorkstreamConfigTest extends TestSuiteBase {
 
         // Verify the migrated structure loads correctly
         assertEquals(1, config.getSlackWorkspaces().size());
-        WorkstreamConfig.WorkspaceEntry migratedWs = config.getSlackWorkspaces().get(0);
+        WorkspaceEntry migratedWs = config.getSlackWorkspaces().get(0);
         assertEquals("T111", migratedWs.getId());
         // Legacy migration also populates slackTeamId from the YAML
         // workspaceId so existing Slack routing continues to work.
@@ -347,7 +349,7 @@ public class WorkstreamConfigTest extends TestSuiteBase {
         assertEquals(3, config.getWorkstreams().size());
 
         // All workstreams must have slackWorkspaceId
-        for (WorkstreamConfig.WorkstreamEntry entry : config.getWorkstreams()) {
+        for (WorkstreamEntry entry : config.getWorkstreams()) {
             assertEquals("T111", entry.getWorkspaceId());
         }
 
@@ -377,7 +379,7 @@ public class WorkstreamConfigTest extends TestSuiteBase {
                 + "  tokensFile: /t.json\n"
                 + "  channelOwnerUserId: U0222\n";
         WorkstreamConfig cfg = WorkstreamConfig.loadFromYamlString(yaml);
-        WorkstreamConfig.WorkspaceEntry ws = cfg.getSlackWorkspaces().get(0);
+        WorkspaceEntry ws = cfg.getSlackWorkspaces().get(0);
         assertEquals(List.of("U0222"), ws.effectiveChannelOwnerUserIds());
     }
 
@@ -405,7 +407,7 @@ public class WorkstreamConfigTest extends TestSuiteBase {
                 + "  - U0BBB\n"
                 + "  - U0CCC\n";
         WorkstreamConfig cfg = WorkstreamConfig.loadFromYamlString(wsYaml);
-        WorkstreamConfig.WorkspaceEntry ws = cfg.getSlackWorkspaces().get(0);
+        WorkspaceEntry ws = cfg.getSlackWorkspaces().get(0);
         assertEquals(List.of("U0BBB", "U0CCC"), ws.effectiveChannelOwnerUserIds());
     }
 
@@ -487,7 +489,7 @@ public class WorkstreamConfigTest extends TestSuiteBase {
             + "    archived: true\n";
 
         WorkstreamConfig config = WorkstreamConfig.loadFromYamlString(yaml);
-        WorkstreamConfig.WorkstreamEntry entry = config.getWorkstreams().get(0);
+        WorkstreamEntry entry = config.getWorkstreams().get(0);
         assertTrue("entry must reflect archived=true", entry.isArchived());
 
         Workstream ws = entry.toWorkstream();
@@ -553,10 +555,10 @@ public class WorkstreamConfigTest extends TestSuiteBase {
         // Reloaded legacy getters being empty proves no legacy entry-level
         // key was written (a legacy key in the output would repopulate them).
         WorkstreamConfig reloaded = WorkstreamConfig.loadFromYaml(tempFile);
-        WorkstreamConfig.WorkstreamEntry wsEntry = reloaded.getWorkstreams().get(0);
+        WorkstreamEntry wsEntry = reloaded.getWorkstreams().get(0);
         assertNull(wsEntry.getDefaultRunner());
         assertTrue(wsEntry.getRunners().isEmpty());
-        WorkstreamConfig.WorkspaceEntry wspEntry = reloaded.findSlackWorkspace("T-LEGACY");
+        WorkspaceEntry wspEntry = reloaded.findSlackWorkspace("T-LEGACY");
         assertNull(wspEntry.getDefaultRunner());
         assertTrue(wspEntry.getRunners().isEmpty());
 
@@ -585,7 +587,7 @@ public class WorkstreamConfigTest extends TestSuiteBase {
             + "      commit-message: \"claude\"\n";
 
         WorkstreamConfig config = WorkstreamConfig.loadFromYamlString(yaml);
-        WorkstreamConfig.WorkstreamEntry entry = config.getWorkstreams().get(0);
+        WorkstreamEntry entry = config.getWorkstreams().get(0);
         assertEquals("opencode", entry.getDefaultRunner());
         assertEquals("claude", entry.getRunners().get("primary"));
         assertEquals("opencode", entry.getRunners().get("deduplication"));
@@ -603,7 +605,7 @@ public class WorkstreamConfigTest extends TestSuiteBase {
         tempFile.deleteOnExit();
         config.saveToYaml(tempFile);
         WorkstreamConfig reloaded = WorkstreamConfig.loadFromYaml(tempFile);
-        WorkstreamConfig.WorkstreamEntry rEntry = reloaded.getWorkstreams().get(0);
+        WorkstreamEntry rEntry = reloaded.getWorkstreams().get(0);
         assertNull("legacy defaultRunner must not survive a save", rEntry.getDefaultRunner());
         assertTrue("legacy runners map must not survive a save", rEntry.getRunners().isEmpty());
         PhaseConfigBundle rBundle = rEntry.toPhaseConfigBundle();
@@ -623,7 +625,7 @@ public class WorkstreamConfigTest extends TestSuiteBase {
             + "    defaultBranch: \"feature/no-runners\"\n";
 
         WorkstreamConfig config = WorkstreamConfig.loadFromYamlString(yaml);
-        WorkstreamConfig.WorkstreamEntry entry = config.getWorkstreams().get(0);
+        WorkstreamEntry entry = config.getWorkstreams().get(0);
         assertNull(entry.getDefaultRunner());
         assertTrue("runners map must default to empty",
                 entry.getRunners().isEmpty());
@@ -651,7 +653,7 @@ public class WorkstreamConfigTest extends TestSuiteBase {
             + "      commit-message: \"opencode\"\n";
 
         WorkstreamConfig config = WorkstreamConfig.loadFromYamlString(yaml);
-        WorkstreamConfig.WorkspaceEntry entry =
+        WorkspaceEntry entry =
                 config.findSlackWorkspace("T-RUNNERS");
         assertNotNull(entry);
         assertEquals("opencode", entry.getDefaultRunner());
@@ -662,7 +664,7 @@ public class WorkstreamConfigTest extends TestSuiteBase {
         tempFile.deleteOnExit();
         config.saveToYaml(tempFile);
         WorkstreamConfig reloaded = WorkstreamConfig.loadFromYaml(tempFile);
-        WorkstreamConfig.WorkspaceEntry rEntry =
+        WorkspaceEntry rEntry =
                 reloaded.findSlackWorkspace("T-RUNNERS");
         assertNotNull(rEntry);
         // Legacy runner fields are dropped on save; the configuration is
@@ -688,7 +690,7 @@ public class WorkstreamConfigTest extends TestSuiteBase {
             + "    defaultRunner: \"opencode\"\n";
 
         WorkstreamConfig config = WorkstreamConfig.loadFromYamlString(yaml);
-        WorkstreamConfig.WorkspaceEntry entry =
+        WorkspaceEntry entry =
                 config.findSlackWorkspace("T-DEF");
         assertNotNull(entry);
         assertEquals("opencode", entry.getDefaultRunner());
@@ -699,7 +701,7 @@ public class WorkstreamConfigTest extends TestSuiteBase {
         tempFile.deleteOnExit();
         config.saveToYaml(tempFile);
         WorkstreamConfig reloaded = WorkstreamConfig.loadFromYaml(tempFile);
-        WorkstreamConfig.WorkspaceEntry rEntry =
+        WorkspaceEntry rEntry =
                 reloaded.findSlackWorkspace("T-DEF");
         assertNotNull(rEntry);
         // The legacy defaultRunner is dropped on save but migrated into the
@@ -722,7 +724,7 @@ public class WorkstreamConfigTest extends TestSuiteBase {
             + "    appToken: \"xapp\"\n";
 
         WorkstreamConfig config = WorkstreamConfig.loadFromYamlString(yaml);
-        WorkstreamConfig.WorkspaceEntry entry =
+        WorkspaceEntry entry =
                 config.findSlackWorkspace("T-PLAIN");
         assertNotNull(entry);
         assertNull(entry.getDefaultRunner());
@@ -732,7 +734,7 @@ public class WorkstreamConfigTest extends TestSuiteBase {
         tempFile.deleteOnExit();
         config.saveToYaml(tempFile);
         WorkstreamConfig reloaded = WorkstreamConfig.loadFromYaml(tempFile);
-        WorkstreamConfig.WorkspaceEntry rEntry =
+        WorkspaceEntry rEntry =
                 reloaded.findSlackWorkspace("T-PLAIN");
         assertNotNull(rEntry);
         assertNull(rEntry.getDefaultRunner());
@@ -761,7 +763,7 @@ public class WorkstreamConfigTest extends TestSuiteBase {
             + "        model: \"claude-haiku-4-5-20251001\"\n";
 
         WorkstreamConfig config = WorkstreamConfig.loadFromYamlString(yaml);
-        WorkstreamConfig.WorkspaceEntry entry =
+        WorkspaceEntry entry =
                 config.findSlackWorkspace("T-PC");
         assertNotNull(entry);
         assertNotNull(entry.getDefaultPhaseConfig());
@@ -775,7 +777,7 @@ public class WorkstreamConfigTest extends TestSuiteBase {
         tempFile.deleteOnExit();
         config.saveToYaml(tempFile);
         WorkstreamConfig reloaded = WorkstreamConfig.loadFromYaml(tempFile);
-        WorkstreamConfig.WorkspaceEntry rEntry =
+        WorkspaceEntry rEntry =
                 reloaded.findSlackWorkspace("T-PC");
         assertNotNull(rEntry);
         assertNotNull("defaultPhaseConfig must survive round-trip",
@@ -808,7 +810,7 @@ public class WorkstreamConfigTest extends TestSuiteBase {
             + "        model: \"claude-haiku-4-5-20251001\"\n";
 
         WorkstreamConfig config = WorkstreamConfig.loadFromYamlString(yaml);
-        WorkstreamConfig.WorkstreamEntry entry = config.getWorkstreams().get(0);
+        WorkstreamEntry entry = config.getWorkstreams().get(0);
         assertNotNull(entry.getDefaultPhaseConfig());
         assertEquals("claude-opus-4-7", entry.getDefaultPhaseConfig().model());
         assertEquals("claude-haiku-4-5-20251001",
@@ -818,7 +820,7 @@ public class WorkstreamConfigTest extends TestSuiteBase {
         tempFile.deleteOnExit();
         config.saveToYaml(tempFile);
         WorkstreamConfig reloaded = WorkstreamConfig.loadFromYaml(tempFile);
-        WorkstreamConfig.WorkstreamEntry rEntry =
+        WorkstreamEntry rEntry =
                 reloaded.getWorkstreams().get(0);
         assertNotNull("defaultPhaseConfig must survive round-trip",
                 rEntry.getDefaultPhaseConfig());
@@ -896,7 +898,7 @@ public class WorkstreamConfigTest extends TestSuiteBase {
 
         WorkstreamConfig config = WorkstreamConfig.loadFromYamlString(yaml);
         assertEquals(1, config.getWorkspaces().size());
-        WorkstreamConfig.WorkspaceEntry ws = config.getWorkspaces().get(0);
+        WorkspaceEntry ws = config.getWorkspaces().get(0);
         assertEquals("almostrealism", ws.getId());
         assertEquals("T0123456789", ws.getSlackTeamId());
         assertEquals(1, config.getWorkstreams().size());
@@ -917,7 +919,7 @@ public class WorkstreamConfigTest extends TestSuiteBase {
             + "workstreams: []\n";
 
         WorkstreamConfig config = WorkstreamConfig.loadFromYamlString(yaml);
-        WorkstreamConfig.WorkspaceEntry ws =
+        WorkspaceEntry ws =
                 config.findWorkspace("local-only");
         assertNotNull(ws);
         assertNull("slackTeamId must be absent when no Slack integration",
@@ -999,7 +1001,7 @@ public class WorkstreamConfigTest extends TestSuiteBase {
         // Slack team binding is preserved across the rename.
         assertEquals("T0123456789",
                 config.findWorkspace("almostrealism").getSlackTeamId());
-        for (WorkstreamConfig.WorkstreamEntry entry : config.getWorkstreams()) {
+        for (WorkstreamEntry entry : config.getWorkstreams()) {
             assertEquals("almostrealism", entry.getWorkspaceId());
         }
     }
@@ -1007,8 +1009,8 @@ public class WorkstreamConfigTest extends TestSuiteBase {
     /**
      * Regression test for the lost-provider defect: a workspace-level
      * {@code phaseConfigs.primary.provider} entry must survive YAML
-     * deserialization into the {@link WorkstreamConfig.WorkspaceEntry}
-     * and emerge from {@link WorkstreamConfig.WorkspaceEntry#toPhaseConfigBundle()}
+     * deserialization into the {@link WorkspaceEntry}
+     * and emerge from {@link WorkspaceEntry#toPhaseConfigBundle()}
      * in the per-phase entry where the resolver can read it. Without this,
      * agents fall back to the runner's default provider (e.g. opencode →
      * "local"), bypassing the configured openrouter/anthropic route.
@@ -1029,7 +1031,7 @@ public class WorkstreamConfigTest extends TestSuiteBase {
             + "        provider: \"openrouter\"\n";
 
         WorkstreamConfig config = WorkstreamConfig.loadFromYamlString(yaml);
-        WorkstreamConfig.WorkspaceEntry ws = config.findWorkspace("almostrealism");
+        WorkspaceEntry ws = config.findWorkspace("almostrealism");
         assertNotNull(ws);
 
         PhaseConfigBundle bundle = ws.toPhaseConfigBundle();


### PR DESCRIPTION
Produces docs/plans/SHARED_SCHEMA_CONTRACT.md, a go/no-go investigation into whether the FlowTree controller API and ar-manager MCP server can derive from a single shared OpenAPI-style spec to eliminate the dual-copy schema divergence problem.

Verdict: NO-GO. The two-copy problem relocates rather than disappears:
- The controller validates fields via JsonFieldExtractor calls in Java with no mechanism to derive from an external spec without a full redesign.
- FastMCP from_openapi() belongs to the standalone fastmcp library, not the mcp>=1.0.0 package this codebase uses — switching requires rewriting the 6,510-line server.py.
- MCP docstrings contain context-specific multi-sentence descriptions that have no auto-generation source; they require human authoring regardless.
- Legitimate surface differences (internal-only fields, MCP-only params) would require per-field curation markers — reintroducing the exact manual bookkeeping the approach was meant to eliminate.

The existing McpToolWorkstreamConfigSurfaceTest.java already provides CI-enforced divergence detection. Extending that test is the recommended path forward.