### PR TITLE
Respect dependent Semaphore in argument preparation

### DIFF
--- a/base/code/src/main/java/io/almostrealism/concurrent/DependentStreamingEvaluable.java
+++ b/base/code/src/main/java/io/almostrealism/concurrent/DependentStreamingEvaluable.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 Michael Murray
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.almostrealism.concurrent;
+
+import io.almostrealism.streams.StreamingEvaluable;
+
+/**
+ * A {@link StreamingEvaluable} whose computation can be ordered after the
+ * completion of prior work, expressed as a {@link Semaphore}.
+ *
+ * <p>This is the streaming counterpart of {@link Submittable#submit(Semaphore)}:
+ * where a plain {@link StreamingEvaluable#request(Object[])} begins its work
+ * immediately, {@link #request(Object[], Semaphore)} orders the computation's
+ * dispatch after the given completion by chaining it through the provider —
+ * without blocking the requesting thread, since a request (like a submit) must
+ * return while its dependency may still be outstanding.</p>
+ *
+ * <p>This ordering matters most for argument preparation: when an operation is
+ * dispatched with a {@code dependsOn} completion, an argument whose evaluation is
+ * itself a dispatch that reads memory written by that prior work must not execute
+ * until it has finished. Delivery remains asynchronous — results may still arrive
+ * with their own completion via {@link CompletionConsumer}.</p>
+ *
+ * @param <T> the type of result produced by the computation
+ *
+ * @see StreamingEvaluable
+ * @see Submittable
+ * @see CompletionConsumer
+ */
+public interface DependentStreamingEvaluable<T> extends StreamingEvaluable<T> {
+	/**
+	 * Initiates an asynchronous computation request whose dispatch is ordered
+	 * after the given completion, without blocking the requesting thread. The
+	 * result will be delivered to the downstream consumer when available.
+	 *
+	 * @param args      the arguments required for computation, in the same format
+	 *                  as {@link StreamingEvaluable#request(Object[])}
+	 * @param dependsOn completion the dispatch must chain on, or {@code null}
+	 *                  when there is no dependency
+	 */
+	void request(Object[] args, Semaphore dependsOn);
+}

--- a/base/hardware/src/main/java/org/almostrealism/hardware/AcceleratedComputationEvaluable.java
+++ b/base/hardware/src/main/java/org/almostrealism/hardware/AcceleratedComputationEvaluable.java
@@ -20,6 +20,8 @@ import io.almostrealism.code.Computation;
 import io.almostrealism.code.ComputeContext;
 import io.almostrealism.code.ProducerComputation;
 import io.almostrealism.concurrent.CompletionConsumer;
+import io.almostrealism.concurrent.DependentStreamingEvaluable;
+import io.almostrealism.concurrent.Semaphore;
 import io.almostrealism.relation.Evaluable;
 import io.almostrealism.scope.ArrayVariable;
 import io.almostrealism.streams.EvaluableStreamingAdapter;
@@ -184,7 +186,7 @@ import java.util.function.IntFunction;
  */
 public class AcceleratedComputationEvaluable<T extends MemoryData>
 		extends AcceleratedComputationOperation<T>
-		implements StreamingEvaluable<T>, Evaluable<T> {
+		implements DependentStreamingEvaluable<T>, Evaluable<T> {
 	/**
 	 * Controls whether multiple evaluables with the same signature can compile independently.
 	 *
@@ -457,12 +459,28 @@ public class AcceleratedComputationEvaluable<T extends MemoryData>
 	 */
 	@Override
 	public void request(Object[] args) {
+		request(args, null);
+	}
+
+	/**
+	 * Initiates evaluation ordered after the given completion. The kernel
+	 * dispatch (and its own argument preparation) chains on {@code dependsOn}
+	 * through the provider, so the dependency costs no host wait; delivery
+	 * is unchanged.
+	 *
+	 * @param args      The input arguments for the computation
+	 * @param dependsOn completion that must fire before the dispatch (and its
+	 *                  argument preparation) reads memory, or {@code null}
+	 * @throws NullPointerException if {@link #downstream} is not set
+	 */
+	@Override
+	public void request(Object[] args, Semaphore dependsOn) {
 		confirmLoad();
 
 		int outputArgIndex = getInstructionSetManager().getOutputArgumentIndex(getExecutionKey());
 		int offset = getInstructionSetManager().getOutputOffset(getExecutionKey());
 
-		AcceleratedProcessDetails process = apply(null, args);
+		AcceleratedProcessDetails process = apply(null, args, dependsOn);
 		process.awaitReady();
 
 		if (downstream instanceof CompletionConsumer && !outputMonitoring) {

--- a/base/hardware/src/main/java/org/almostrealism/hardware/AcceleratedOperation.java
+++ b/base/hardware/src/main/java/org/almostrealism/hardware/AcceleratedOperation.java
@@ -476,7 +476,26 @@ public abstract class AcceleratedOperation<T extends MemoryData> extends Operati
 	 * @return Process details ready for execution
 	 */
 	protected AcceleratedProcessDetails getProcessDetails(MemoryBank output, Object[] args) {
-		return getDetailsFactory().init(output, args).construct();
+		return getProcessDetails(output, args, null);
+	}
+
+	/**
+	 * Creates process details with argument configuration, ordering every argument
+	 * evaluation after the given completion.
+	 *
+	 * <p>Arguments backed by a hardware dispatch chain the dependency through the
+	 * provider; arguments evaluated on the host wait for the completion on their
+	 * evaluation thread before reading. This guarantees that argument preparation
+	 * never observes memory from before the work this operation depends on.</p>
+	 *
+	 * @param output    The destination memory bank for operation results
+	 * @param args      The input arguments for the operation
+	 * @param dependsOn completion that must fire before argument evaluation reads
+	 *                  memory, or {@code null} when there is no dependency
+	 * @return Process details ready for execution
+	 */
+	protected AcceleratedProcessDetails getProcessDetails(MemoryBank output, Object[] args, Semaphore dependsOn) {
+		return getDetailsFactory().init(output, args).construct(dependsOn);
 	}
 
 	/**
@@ -563,8 +582,8 @@ public abstract class AcceleratedOperation<T extends MemoryData> extends Operati
 			throw new UnsupportedOperationException("Operation was not compiled");
 		}
 
-		// Load the inputs
-		AcceleratedProcessDetails process = getProcessDetails(output, args);
+		// Load the inputs, ordering argument evaluation after the prior completion
+		AcceleratedProcessDetails process = getProcessDetails(output, args, dependsOn);
 		process.setReadyLatch(new DefaultLatchSemaphore(getMetadata(), 1));
 
 		// Requirements are thread-local, and the listener below may run on another

--- a/base/hardware/src/main/java/org/almostrealism/hardware/DestinationEvaluable.java
+++ b/base/hardware/src/main/java/org/almostrealism/hardware/DestinationEvaluable.java
@@ -18,6 +18,8 @@ package org.almostrealism.hardware;
 
 import io.almostrealism.code.OperationAdapter;
 import io.almostrealism.concurrent.CompletionConsumer;
+import io.almostrealism.concurrent.DependentStreamingEvaluable;
+import io.almostrealism.concurrent.Semaphore;
 import io.almostrealism.lifecycle.Destroyable;
 import io.almostrealism.relation.Evaluable;
 import io.almostrealism.relation.Provider;
@@ -181,7 +183,7 @@ import java.util.stream.Stream;
  * @see Provider
  */
 public class DestinationEvaluable<T extends MemoryBank> implements
-		Evaluable<T>, StreamingEvaluable<T>, Runnable, Destroyable, ConsoleFeatures {
+		Evaluable<T>, DependentStreamingEvaluable<T>, Runnable, Destroyable, ConsoleFeatures {
 	/** The wrapped evaluable operation that produces results. */
 	private Evaluable<T> operation;
 
@@ -358,9 +360,26 @@ public class DestinationEvaluable<T extends MemoryBank> implements
 	 */
 	@Override
 	public void request(Object[] args) {
+		request(args, null);
+	}
+
+	/**
+	 * Initiates evaluation ordered after the given completion. The wrapped
+	 * operation's dispatch chains on {@code dependsOn} through the provider,
+	 * so the dependency costs no host wait; delivery is unchanged.
+	 *
+	 * @param args      The input arguments ({@link MemoryData} instances)
+	 * @param dependsOn completion that must fire before the dispatch (and its
+	 *                  argument preparation) reads memory, or {@code null}
+	 * @throws UnsupportedOperationException if operation is not an accelerated kernel
+	 */
+	@Override
+	public void request(Object[] args, Semaphore dependsOn) {
 		if (operation instanceof AcceleratedOperation) {
 			AcceleratedProcessDetails details = ((AcceleratedOperation) operation)
-					.apply(destination, Stream.of(args).map(arg -> (MemoryData) arg).toArray(MemoryData[]::new));
+					.apply(destination,
+							Stream.of(args).map(arg -> (MemoryData) arg).toArray(MemoryData[]::new),
+							dependsOn);
 			// Required before getSemaphore(); see the method javadoc
 			details.awaitReady();
 

--- a/base/hardware/src/main/java/org/almostrealism/hardware/ProcessDetailsFactory.java
+++ b/base/hardware/src/main/java/org/almostrealism/hardware/ProcessDetailsFactory.java
@@ -18,6 +18,8 @@ package org.almostrealism.hardware;
 
 import io.almostrealism.code.ProducerArgumentReference;
 import io.almostrealism.concurrent.CompletionConsumer;
+import io.almostrealism.concurrent.DependentStreamingEvaluable;
+import io.almostrealism.concurrent.Semaphore;
 import io.almostrealism.relation.Countable;
 import io.almostrealism.relation.Delegated;
 import io.almostrealism.relation.Evaluable;
@@ -448,6 +450,30 @@ public class ProcessDetailsFactory<T> implements Factory<AcceleratedProcessDetai
 	 */
 	@Override
 	public AcceleratedProcessDetails construct() {
+		return construct(null);
+	}
+
+	/**
+	 * Constructs an {@link AcceleratedProcessDetails} whose dispatch-backed argument
+	 * evaluations are ordered after the given completion.
+	 *
+	 * <p>Arguments whose evaluation is itself a hardware dispatch
+	 * ({@link DependentStreamingEvaluable}) chain the dependency through the provider,
+	 * so an argument kernel never reads memory written by the work {@code dependsOn}
+	 * represents before that work has completed — without any host wait. Plain host
+	 * evaluables are handle-producers (they return {@link MemoryData} handles; the
+	 * kernel reads the contents on the device, ordered by its own chained dispatch)
+	 * and are evaluated immediately: blocking them on {@code dependsOn} would violate
+	 * the non-blocking submission contract (a submit with an outstanding foreign
+	 * dependency must return, and a same-provider dependency must remain free), so a
+	 * host function that reads memory <em>contents</em> rather than returning a handle
+	 * is responsible for its own ordering.</p>
+	 *
+	 * @param dependsOn completion that dispatch-backed argument evaluations must chain
+	 *                  on, or {@code null} when there is no dependency
+	 * @return the fully configured process details ready for execution
+	 */
+	public AcceleratedProcessDetails construct(Semaphore dependsOn) {
 		MemoryData kernelArgs[] = new MemoryData[arguments.size()];
 
 		for (int i = 0; i < kernelArgs.length; i++) {
@@ -552,7 +578,12 @@ public class ProcessDetailsFactory<T> implements Factory<AcceleratedProcessDetai
 		 */
 		for (int i = 0; i < asyncEvaluables.length; i++) {
 			if (asyncEvaluables[i] == null || kernelArgs[i] != null) continue;
-			asyncEvaluables[i].request(args);
+
+			if (asyncEvaluables[i] instanceof DependentStreamingEvaluable) {
+				((DependentStreamingEvaluable) asyncEvaluables[i]).request(args, dependsOn);
+			} else {
+				asyncEvaluables[i].request(args);
+			}
 		}
 
 		/* The details are ready */

--- a/base/hardware/src/main/java/org/almostrealism/hardware/computations/HardwareEvaluable.java
+++ b/base/hardware/src/main/java/org/almostrealism/hardware/computations/HardwareEvaluable.java
@@ -20,6 +20,8 @@ import io.almostrealism.lifecycle.Destroyable;
 import io.almostrealism.relation.Evaluable;
 import io.almostrealism.scope.Argument;
 import io.almostrealism.scope.ArgumentList;
+import io.almostrealism.concurrent.DependentStreamingEvaluable;
+import io.almostrealism.concurrent.Semaphore;
 import io.almostrealism.streams.StreamingEvaluable;
 import io.almostrealism.uml.Multiple;
 import org.almostrealism.hardware.DestinationEvaluable;
@@ -164,7 +166,7 @@ import java.util.function.UnaryOperator;
  * @author Michael Murray
  */
 public class HardwareEvaluable<T> implements
-		Evaluable<T>, StreamingEvaluable<T>, Destroyable, Runnable, ArgumentList<T> {
+		Evaluable<T>, DependentStreamingEvaluable<T>, Destroyable, Runnable, ArgumentList<T> {
 	/** Supplier that produces the underlying {@link Evaluable} for this computation. */
 	private Supplier<Evaluable<T>> ev;
 	/** Evaluable used to allocate and provide the output destination buffer. */
@@ -330,6 +332,23 @@ public class HardwareEvaluable<T> implements
 
 	@Override
 	public void request(Object[] args) {
+		request(args, null);
+	}
+
+	/**
+	 * Initiates evaluation ordered after the given completion. The dependency is
+	 * delegated to the underlying kernel evaluable, which chains it through the
+	 * provider without blocking. The short-circuit path (and a kernel evaluable
+	 * that cannot chain) evaluates immediately, like
+	 * {@link #request(Object[])} — host-side evaluation is never blocked on the
+	 * dependency, because submission must not wait for outstanding completions.
+	 *
+	 * @param args      the arguments for the evaluation
+	 * @param dependsOn completion the underlying dispatch must chain on, or
+	 *                  {@code null} when there is no dependency
+	 */
+	@Override
+	public void request(Object[] args, Semaphore dependsOn) {
 		if (Arrays.stream(args).anyMatch(i -> i instanceof Object[])) {
 			throw new IllegalArgumentException("Embedded array provided to request");
 		}
@@ -340,7 +359,11 @@ public class HardwareEvaluable<T> implements
 		}
 
 		Evaluable<T> cev = getKernel().getValue();
-		if (cev instanceof StreamingEvaluable<?>) {
+		if (cev instanceof DependentStreamingEvaluable<?>) {
+			((DependentStreamingEvaluable<T>) cev).setDownstream(downstream);
+			((DependentStreamingEvaluable<T>) cev).request(args, dependsOn);
+			return;
+		} else if (cev instanceof StreamingEvaluable<?>) {
 			((StreamingEvaluable<T>) cev).setDownstream(downstream);
 			((StreamingEvaluable<T>) cev).request(args);
 			return;

--- a/base/hardware/src/main/java/org/almostrealism/hardware/computations/HardwareEvaluable.java
+++ b/base/hardware/src/main/java/org/almostrealism/hardware/computations/HardwareEvaluable.java
@@ -338,13 +338,14 @@ public class HardwareEvaluable<T> implements
 	/**
 	 * Initiates evaluation ordered after the given completion. The dependency is
 	 * delegated to the underlying kernel evaluable, which chains it through the
-	 * provider without blocking. The short-circuit path (and a kernel evaluable
-	 * that cannot chain) evaluates immediately, like
-	 * {@link #request(Object[])} — host-side evaluation is never blocked on the
-	 * dependency, because submission must not wait for outstanding completions.
+	 * provider without blocking. The short-circuit path is a genuine host
+	 * evaluation (for example a reshape wrapper that evaluates the underlying
+	 * kernel synchronously) — it cannot chain the dependency into a dispatch, so
+	 * it waits for the completion on the thread performing the evaluation before
+	 * reading. A kernel evaluable that cannot chain waits the same way.
 	 *
 	 * @param args      the arguments for the evaluation
-	 * @param dependsOn completion the underlying dispatch must chain on, or
+	 * @param dependsOn completion this evaluation must be ordered after, or
 	 *                  {@code null} when there is no dependency
 	 */
 	@Override
@@ -354,6 +355,7 @@ public class HardwareEvaluable<T> implements
 		}
 
 		if (shortCircuit != null) {
+			if (dependsOn != null) dependsOn.waitFor();
 			downstream.accept(shortCircuit.evaluate(args));
 			return;
 		}
@@ -364,6 +366,7 @@ public class HardwareEvaluable<T> implements
 			((DependentStreamingEvaluable<T>) cev).request(args, dependsOn);
 			return;
 		} else if (cev instanceof StreamingEvaluable<?>) {
+			if (dependsOn != null) dependsOn.waitFor();
 			((StreamingEvaluable<T>) cev).setDownstream(downstream);
 			((StreamingEvaluable<T>) cev).request(args);
 			return;

--- a/docs/plans/ARGUMENT_PREPARATION_SEMAPHORE.md
+++ b/docs/plans/ARGUMENT_PREPARATION_SEMAPHORE.md
@@ -1,0 +1,118 @@
+# Plan — Argument preparation must respect the Semaphore chain
+
+> **Intent.** When an `AcceleratedOperation` is dispatched with a `dependsOn` completion
+> (`AcceleratedOperation.apply(output, args, dependsOn)`), every part of its execution must be
+> ordered after that completion — including the evaluation of its producer arguments. Today only
+> the kernel dispatch is ordered (`Semaphore.all` over argument-delivery completions plus
+> `dependsOn`); the argument evaluations themselves are launched unchained at submit time from
+> `ProcessDetailsFactory.construct()`. A hoisted argument evaluation (an isolated subtree, a
+> `DynamicProducer` lambda, a `HardwareEvaluable.into` destination evaluation) can therefore read
+> memory before the operation it depends on has completed — on Metal, before the writing
+> dispatch's command buffer has even committed.
+
+## 1. Why now
+
+This surfaced while root-causing the assignment-based layer recording divergence (the
+`enableAssignmentCopy` flip-blocker; see `ASSIGNMENT_COPY_MIGRATION.md`). That investigation
+found two distinct correctness gaps:
+
+- **(A) Fused-composite hazard** — when an all-computation `OperationList` fuses into a single
+  compiled operation, an isolated subtree of a later member is evaluated at argument-preparation
+  time, before the fused kernel executes — so it reads memory that an *earlier member of the same
+  fused operation* writes, one run late. Deterministic one-pass lag; reproduced minimally by
+  `AssignmentIsolationDiagTest.compositeVariants` (`variantAll` vs `variantProvider`), and the
+  cause of the `NormTests.normModel` failures on `feature/assignment-copy-migration`. Fixing (A)
+  requires subdividing the list at write→read boundaries (segments; no semaphore can order a
+  kernel after itself) and is **not addressed by this plan** — it is the follow-on.
+- **(B) Unchained argument preparation** — this plan. Independent of fusion: even with members
+  compiled separately and chained via `Submittable.submit(pending)`, the *next* member's argument
+  evaluations run at submit time, unordered against `pending`. The runner's host wait before
+  non-submittable members (`OperationListRunner.run()`) masks this for `DestinationEvaluable`
+  members, and near-synchronous native execution masks it on the CPU backend — but a submittable
+  member whose hoisted argument reads a buffer written by a still-uncommitted Metal dispatch
+  reads stale data.
+
+Fixing (B) first was chosen deliberately (2026-07-06): it repairs machinery that is already load
+bearing everywhere, before any new subdivision behavior is introduced.
+
+## 2. Current mechanics (all verified on master)
+
+- `AcceleratedOperation.apply(output, args, dependsOn)` → `getProcessDetails(output, args)` →
+  `ProcessDetailsFactory.init(output, args).construct()`. `construct()` creates
+  `StreamingEvaluable`s for unresolved arguments and calls `request(args)` immediately — no
+  dependency is available to it.
+- Delivery is already dependency-aware: arguments delivered via `CompletionConsumer` carry a
+  completion `Semaphore`, recorded by `AcceleratedProcessDetails.result(index, result,
+  completion)`; `apply` merges `getArgumentCompletions()` with `dependsOn` (`Semaphore.all`) and
+  chains aggregation copy-ins, replacement copies, and the kernel on the merged `ready`. The gap
+  is only that the evaluations are *launched* before `dependsOn` has fired.
+- The three `StreamingEvaluable` implementations reached from `construct()`:
+  - `EvaluableStreamingAdapter` (plain host evaluation on an executor),
+  - `DestinationEvaluable` (nested `apply(destination, args)` of a compiled kernel; delivers the
+    destination with the nested completion),
+  - `HardwareEvaluable` (delegates to its kernel's streaming evaluable, or evaluates its
+    short-circuit on the host).
+  All three either are created with, or override `async(Executor)` to preserve, their own
+  `request` implementations — so threading a dependency through `request` reaches the right code.
+
+## 3. The change
+
+Add a dependency-aware request to the streaming protocol and thread `dependsOn` from `apply`
+into argument preparation:
+
+1. **`StreamingEvaluable.request(Object[] args, Semaphore dependsOn)`** — new default method:
+   wait for `dependsOn`, then `request(args)`. The default is the conservative correctness
+   fallback for implementations that cannot chain.
+2. **`EvaluableStreamingAdapter`** — override: the executor task waits `dependsOn` *on the
+   executor thread*, then evaluates. The host must genuinely wait before a host read; moving the
+   wait off the submitting thread preserves non-blocking submission where the hardware is async.
+3. **`DestinationEvaluable`** — override: pass `dependsOn` to the nested
+   `apply(destination, args, dependsOn)`, so the nested kernel chains on the device with no host
+   wait. Delivery is unchanged (already carries the nested completion).
+4. **`HardwareEvaluable`** — override: delegate `dependsOn` to the kernel's streaming evaluable;
+   the short-circuit branch waits before host evaluation.
+5. **`ProcessDetailsFactory.construct(Semaphore dependsOn)`** — both `request` call sites pass
+   the dependency through; the no-argument `construct()` (from the `Factory` contract) delegates
+   with `null`.
+6. **`AcceleratedOperation.getProcessDetails(output, args, dependsOn)`** — `apply` passes its
+   `dependsOn` through.
+
+Out of scope, recorded for later: the constant-argument cache
+(`ProcessDetailsFactory.init`, `enableConstantCache`) evaluates `isConstant()` arguments once
+and reuses the result across invocations. If a producer that reads mutable memory ever reports
+`isConstant()`, that is a staleness defect in its own right, independent of chaining — it should
+be audited separately.
+
+## 4. Reproduction (written before the fix)
+
+`ArgumentPreparationChainTest` (engine/utils, `org.almostrealism.hardware.test`): a two-member
+`OperationList` with mismatched counts (so it cannot fuse and takes the `OperationListRunner`
+path with submittable members): member 1 is a compiled kernel writing buffer `X`; member 2 is a
+compiled kernel whose source contains a `DynamicCollectionProducer` whose lambda reads `X` on
+the host. On Metal, member 1 is encoded but uncommitted when member 2's argument preparation
+runs the lambda, which reads stale contents deterministically. On the native backend the
+near-synchronous dispatch masks the defect (the test still asserts correctness there).
+
+## 5. Validation
+
+- The reproduction passes on `AR_HARDWARE_DRIVER=mtl` after the change.
+- Semaphore batteries: `SemaphoreChainBatchingTest`, `AssignmentSemaphoreChainTest`,
+  `SemaphoreCompositionTest`, `AsyncResultDeliveryTest`, `StreamingEvaluableTests`.
+- Model battery on default and `mtl` drivers (`BackPropagationTests`, `TrainModelTest`,
+  `SyntheticDenseTrainingTest`, `ConvolutionModelTests`, `LayerTrackingTest`).
+- Deadlock watch: a `dependsOn.waitFor()` on an executor thread that must commit a Metal buffer
+  is the same shape as existing host waits (`MetalSemaphore.waitFor` requests the commit on the
+  command runner's executor); the new waits occur only on argument-evaluation threads, never on
+  the `MetalCommandRunner` executor itself. `MetalCommandRunner` commit-cause counters
+  (`getHostCompleteCommitCount`, `hostCompleteRequesters`) can attribute any unexpected new
+  waits.
+
+## 6. Relationship to the follow-on (A)
+
+With (B) in place, the hazard-aware subdivision of fused `OperationList`s (cut only at
+RAW dependencies between an earlier member's writes and a later member's *hoisted* read set;
+overlap by root delegate and offset range; partitioned lists must resist re-fusion at `get()`)
+becomes cheap: a segment boundary costs a chained dependency rather than a host wait. That work
+un-parks `feature/assignment-copy-migration` (whose CompiledModel output-capture migration is
+correct only once fused composites honor cross-member ordering) and is the prerequisite for the
+layer-recording migration and the `enableAssignmentCopy` flip.

--- a/engine/utils/src/test/java/org/almostrealism/graph/model/test/AssignmentIsolationDiagTest.java
+++ b/engine/utils/src/test/java/org/almostrealism/graph/model/test/AssignmentIsolationDiagTest.java
@@ -1,0 +1,717 @@
+/*
+ * Copyright 2026 Michael Murray
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.almostrealism.graph.model.test;
+
+import io.almostrealism.compute.ParallelProcess;
+import io.almostrealism.profile.OperationInfo;
+import io.almostrealism.profile.OperationProfile;
+import io.almostrealism.relation.Producer;
+import org.almostrealism.collect.CollectionProducer;
+import org.almostrealism.collect.CollectionProducerComputation;
+import org.almostrealism.collect.PackedCollection;
+import org.almostrealism.collect.computations.DynamicCollectionProducer;
+import org.almostrealism.hardware.HardwareOperator;
+import org.almostrealism.hardware.OperationList;
+import org.almostrealism.hardware.OperationListRunner;
+import org.almostrealism.hardware.ProcessDetailsFactory;
+import org.almostrealism.hardware.mem.MemoryDataArgumentMap;
+import org.almostrealism.layers.CellularLayer;
+import org.almostrealism.layers.DefaultCellularLayer;
+import org.almostrealism.model.CompiledModel;
+import org.almostrealism.model.Model;
+import org.almostrealism.model.SequentialBlock;
+import org.almostrealism.util.ModelTestFeatures;
+import org.almostrealism.util.TestSuiteBase;
+import org.junit.Test;
+
+import java.util.List;
+
+/**
+ * Discriminating diagnostics for the assignment-based layer recording divergence:
+ * a {@code dense(2, 1)} forward pass returns the bias alone (the weights-input
+ * product contributes zero) when {@link DefaultCellularLayer#enableMemoryDataCopy}
+ * is {@code false}. Profile comparison shows the isolated forward multiply never
+ * executes on that path, while it does execute under copy-based recording.
+ *
+ * <p>Each test runs the same single forward pass under a different configuration
+ * and reports the observed output next to the expected value, so the failing
+ * mechanism can be identified by which configuration corrects the result.</p>
+ */
+public class AssignmentIsolationDiagTest extends TestSuiteBase implements ModelTestFeatures {
+
+	/** Expected forward value: 0.5 * 2.0 - 0.25 * 3.0 + 0.1 */
+	private static final double EXPECTED = 0.35;
+
+	/**
+	 * Baseline reproduction: assignment-based recording with default settings.
+	 */
+	@Test(timeout = 120000)
+	public void assignmentRecordingBaseline() {
+		double result = forwardWithAssignmentRecording();
+		log("assignmentRecordingBaseline result=" + result + " expected=" + EXPECTED);
+	}
+
+	/**
+	 * Hypothesis A: the isolated multiply is treated as a constant argument and
+	 * cached (or skipped) by {@link ProcessDetailsFactory}. If disabling the
+	 * constant cache corrects the result, the isolation-argument constant
+	 * classification is the failing mechanism.
+	 */
+	@Test(timeout = 120000)
+	public void assignmentRecordingWithoutConstantCache() {
+		boolean original = ProcessDetailsFactory.enableConstantCache;
+		ProcessDetailsFactory.enableConstantCache = false;
+
+		try {
+			double result = forwardWithAssignmentRecording();
+			log("assignmentRecordingWithoutConstantCache result=" + result + " expected=" + EXPECTED);
+		} finally {
+			ProcessDetailsFactory.enableConstantCache = original;
+		}
+	}
+
+	/**
+	 * Hypothesis B: the kernel dispatch path silently skips the isolated child.
+	 * Verbose kernel logging records every hardware dispatch, so the log shows
+	 * whether the isolated multiply is ever dispatched during the forward pass.
+	 */
+	@Test(timeout = 120000)
+	public void assignmentRecordingVerboseDispatch() {
+		boolean original = HardwareOperator.enableVerboseLog;
+		HardwareOperator.enableVerboseLog = true;
+
+		try {
+			double result = forwardWithAssignmentRecording();
+			log("assignmentRecordingVerboseDispatch result=" + result + " expected=" + EXPECTED);
+		} finally {
+			HardwareOperator.enableVerboseLog = original;
+		}
+	}
+
+	/**
+	 * Hypothesis C: the isolated multiply's evaluation is mis-ordered relative to
+	 * the input-record member on the first pass only. By the second forward pass
+	 * the layer input buffer already holds the values from the first pass, so a
+	 * per-run (but mis-ordered) evaluation produces the correct value from pass
+	 * two onward, while a never-evaluated (or permanently cached) argument stays
+	 * wrong on every pass.
+	 */
+	@Test(timeout = 120000)
+	public void assignmentRecordingRepeatedForward() {
+		boolean original = DefaultCellularLayer.enableMemoryDataCopy;
+		DefaultCellularLayer.enableMemoryDataCopy = false;
+
+		try {
+			double[] results = forwardDense(3);
+			for (int i = 0; i < results.length; i++) {
+				log("assignmentRecordingRepeatedForward pass=" + (i + 1) +
+						" result=" + results[i] + " expected=" + EXPECTED);
+			}
+		} finally {
+			DefaultCellularLayer.enableMemoryDataCopy = original;
+		}
+	}
+
+	/**
+	 * Confirms the lag semantics precisely: each pass supplies a different input,
+	 * so a one-pass lag produces the previous pass's expected value while correct
+	 * ordering produces the current pass's expected value. Inputs are (2, 3),
+	 * (4, 6), and (8, 12); the correct outputs are 0.35, 0.6, and 1.1.
+	 */
+	@Test(timeout = 120000)
+	public void assignmentRecordingVaryingInput() {
+		boolean original = DefaultCellularLayer.enableMemoryDataCopy;
+		DefaultCellularLayer.enableMemoryDataCopy = false;
+
+		try {
+			double[][] inputs = { { 2.0, 3.0 }, { 4.0, 6.0 }, { 8.0, 12.0 } };
+			double[] expected = { 0.35, 0.6, 1.1 };
+			double[] results = forwardDense(inputs);
+
+			for (int i = 0; i < results.length; i++) {
+				log("assignmentRecordingVaryingInput pass=" + (i + 1) +
+						" result=" + results[i] + " expected=" + expected[i]);
+			}
+		} finally {
+			DefaultCellularLayer.enableMemoryDataCopy = original;
+		}
+	}
+
+	/**
+	 * Hypothesis D: the one-pass lag enters through compile-time argument
+	 * aggregation — the aggregate copy-in snapshots the isolated multiply's
+	 * destination buffer before the multiply's evaluation for the current pass
+	 * has written it. If disabling aggregation corrects the result, the
+	 * coupling between aggregation copy-in and asynchronous argument delivery
+	 * is the failing mechanism.
+	 */
+	@Test(timeout = 120000)
+	public void assignmentRecordingWithoutAggregation() {
+		boolean original = MemoryDataArgumentMap.enableArgumentAggregation;
+		MemoryDataArgumentMap.enableArgumentAggregation = false;
+
+		try {
+			double[][] inputs = { { 2.0, 3.0 }, { 4.0, 6.0 }, { 8.0, 12.0 } };
+			double[] expected = { 0.35, 0.6, 1.1 };
+			double[] results;
+
+			boolean recording = DefaultCellularLayer.enableMemoryDataCopy;
+			DefaultCellularLayer.enableMemoryDataCopy = false;
+
+			try {
+				results = forwardDense(inputs);
+			} finally {
+				DefaultCellularLayer.enableMemoryDataCopy = recording;
+			}
+
+			for (int i = 0; i < results.length; i++) {
+				log("assignmentRecordingWithoutAggregation pass=" + (i + 1) +
+						" result=" + results[i] + " expected=" + expected[i]);
+			}
+		} finally {
+			MemoryDataArgumentMap.enableArgumentAggregation = original;
+		}
+	}
+
+	/**
+	 * Standalone reproduction attempt without any model machinery: an
+	 * {@link org.almostrealism.hardware.computations.Assignment} whose source is
+	 * a computation containing an explicitly isolated multiply, evaluated twice
+	 * with different input contents. A one-pass lag here localizes the defect to
+	 * the Assignment/isolation compilation itself; correct values localize it to
+	 * the model composite context.
+	 */
+	@Test(timeout = 120000)
+	public void standaloneIsolatedSourceAssignment() {
+		PackedCollection weights = new PackedCollection(shape(2));
+		weights.setMem(0, 0.5, -0.25);
+
+		PackedCollection in = new PackedCollection(shape(2));
+		PackedCollection bias = new PackedCollection(shape(1));
+		bias.setMem(0, 0.1);
+
+		PackedCollection out = new PackedCollection(shape(1));
+
+		CollectionProducer mul = multiply(
+				traverseEach(p(weights)), traverseEach(p(in)));
+		Producer<PackedCollection> isolated =
+				new CollectionProducerComputation.IsolatedProcess(mul);
+		CollectionProducer dense = add(
+				sum(traverse(0, isolated)), p(bias));
+
+		Runnable assign = a("standalone isolated", p(out), dense).get();
+		log("standaloneIsolatedSourceAssignment runnable=" + assign.getClass().getSimpleName());
+
+		in.setMem(0, 2.0, 3.0);
+		assign.run();
+		log("standaloneIsolatedSourceAssignment pass=1 result=" + out.toDouble(0) + " expected=0.35");
+
+		in.setMem(0, 4.0, 6.0);
+		assign.run();
+		log("standaloneIsolatedSourceAssignment pass=2 result=" + out.toDouble(0) + " expected=0.6");
+
+		in.setMem(0, 8.0, 12.0);
+		assign.run();
+		log("standaloneIsolatedSourceAssignment pass=3 result=" + out.toDouble(0) + " expected=1.1");
+	}
+
+	/**
+	 * Bisection layer: the same two-member structure the model composite has —
+	 * an input-record assignment followed by a dense assignment reading the
+	 * recorded buffer — but built directly and passed through the same
+	 * {@code flatten().optimize()} the model composite uses. A one-pass lag here
+	 * localizes the defect to the OperationList optimization cascade; correct
+	 * values localize it to the model/cell wiring.
+	 */
+	@Test(timeout = 120000)
+	public void optimizedListRecordThenDense() {
+		PackedCollection external = new PackedCollection(shape(2));
+		PackedCollection recorded = new PackedCollection(shape(2));
+
+		PackedCollection weights = new PackedCollection(shape(2));
+		weights.setMem(0, 0.5, -0.25);
+
+		PackedCollection bias = new PackedCollection(shape(1));
+		bias.setMem(0, 0.1);
+
+		PackedCollection out = new PackedCollection(shape(1));
+
+		CollectionProducer mul = multiply(
+				traverseEach(p(weights)), traverseEach(p(recorded)));
+		CollectionProducer dense = add(sum(traverse(0, mul)), p(bias));
+
+		OperationList list = new OperationList("optimizedListRecordThenDense");
+		list.add(a("record", traverseEach(p(recorded)), traverseEach(p(external))));
+		list.add(a("dense", p(out), dense));
+
+		Runnable run = ((ParallelProcess<?, Runnable>) list.flatten().optimize()).get();
+
+		double[][] inputs = { { 2.0, 3.0 }, { 4.0, 6.0 }, { 8.0, 12.0 } };
+		double[] expected = { 0.35, 0.6, 1.1 };
+
+		for (int i = 0; i < inputs.length; i++) {
+			external.setMem(0, inputs[i][0], inputs[i][1]);
+			run.run();
+			log("optimizedListRecordThenDense pass=" + (i + 1) +
+					" result=" + out.toDouble(0) + " expected=" + expected[i]);
+		}
+	}
+
+	/**
+	 * Bisection variant A: the record-then-dense optimized list, with the dense
+	 * member using the real dense-layer operator tree
+	 * ({@code matmul(weights, input).add(bias)}) instead of the hand-built
+	 * multiply/sum. Isolates whether the matmul tree shape is the trigger.
+	 */
+	@Test(timeout = 120000)
+	public void optimizedListRecordThenMatmul() {
+		PackedCollection external = new PackedCollection(shape(2));
+		PackedCollection recorded = new PackedCollection(shape(2));
+
+		PackedCollection weights = new PackedCollection(shape(1, 2));
+		weights.setMem(0, 0.5, -0.25);
+
+		PackedCollection bias = new PackedCollection(shape(1));
+		bias.setMem(0, 0.1);
+
+		PackedCollection out = new PackedCollection(shape(1));
+
+		CollectionProducer dense = matmul(p(weights),
+				reshape(shape(1, 2).traverse(1), p(recorded)))
+				.add(traverse(1, p(bias)))
+				.reshape(shape(1));
+
+		OperationList list = new OperationList("optimizedListRecordThenMatmul");
+		list.add(a("record", traverseEach(p(recorded)), traverseEach(p(external))));
+		list.add(a("dense", p(out), dense));
+
+		Runnable run = ((ParallelProcess<?, Runnable>) list.flatten().optimize()).get();
+
+		double[][] inputs = { { 2.0, 3.0 }, { 4.0, 6.0 }, { 8.0, 12.0 } };
+		double[] expected = { 0.35, 0.6, 1.1 };
+
+		for (int i = 0; i < inputs.length; i++) {
+			external.setMem(0, inputs[i][0], inputs[i][1]);
+			run.run();
+			log("optimizedListRecordThenMatmul pass=" + (i + 1) +
+					" result=" + out.toDouble(0) + " expected=" + expected[i]);
+		}
+	}
+
+	/**
+	 * Bisection variant B: the record-then-dense optimized list, with the record
+	 * member's source supplied by a {@link DynamicCollectionProducer} (as the
+	 * model's InputManager supplies it) instead of a provider. Isolates whether
+	 * the dynamic input source is the trigger.
+	 */
+	@Test(timeout = 120000)
+	public void optimizedListDynamicRecordThenDense() {
+		PackedCollection[] external = new PackedCollection[1];
+		PackedCollection recorded = new PackedCollection(shape(2));
+
+		PackedCollection weights = new PackedCollection(shape(2));
+		weights.setMem(0, 0.5, -0.25);
+
+		PackedCollection bias = new PackedCollection(shape(1));
+		bias.setMem(0, 0.1);
+
+		PackedCollection out = new PackedCollection(shape(1));
+
+		DynamicCollectionProducer dynamicInput =
+				new DynamicCollectionProducer(shape(2), args -> external[0]);
+
+		CollectionProducer mul = multiply(
+				traverseEach(p(weights)), traverseEach(p(recorded)));
+		CollectionProducer dense = add(sum(traverse(0, mul)), p(bias));
+
+		OperationList list = new OperationList("optimizedListDynamicRecordThenDense");
+		list.add(a("record", traverseEach(p(recorded)), traverseEach(dynamicInput)));
+		list.add(a("dense", p(out), dense));
+
+		Runnable run = ((ParallelProcess<?, Runnable>) list.flatten().optimize()).get();
+
+		double[][] inputs = { { 2.0, 3.0 }, { 4.0, 6.0 }, { 8.0, 12.0 } };
+		double[] expected = { 0.35, 0.6, 1.1 };
+
+		for (int i = 0; i < inputs.length; i++) {
+			external[0] = new PackedCollection(shape(2));
+			external[0].setMem(0, inputs[i][0], inputs[i][1]);
+			run.run();
+			log("optimizedListDynamicRecordThenDense pass=" + (i + 1) +
+					" result=" + out.toDouble(0) + " expected=" + expected[i]);
+		}
+	}
+
+	/**
+	 * Bisection variant C: replicates the layer cell wiring — nested operation
+	 * lists with {@code into(...)} members exactly as {@link DefaultCellularLayer}
+	 * builds them (dynamic-source input record, matmul output record, model
+	 * output capture) — without any Model or Cell machinery. A one-pass lag here
+	 * gives a minimal reproduction of the model composite defect.
+	 */
+	@Test(timeout = 120000)
+	public void optimizedNestedIntoComposite() {
+		PackedCollection[] external = new PackedCollection[1];
+		PackedCollection recorded = new PackedCollection(shape(2));
+
+		PackedCollection weights = new PackedCollection(shape(1, 2));
+		weights.setMem(0, 0.5, -0.25);
+
+		PackedCollection bias = new PackedCollection(shape(1));
+		bias.setMem(0, 0.1);
+
+		PackedCollection layerOut = new PackedCollection(shape(1));
+		PackedCollection modelOut = new PackedCollection(shape(1));
+
+		DynamicCollectionProducer dynamicInput =
+				new DynamicCollectionProducer(shape(2), args -> external[0]);
+
+		CollectionProducer dense = matmul(p(weights),
+				reshape(shape(1, 2).traverse(1), p(recorded)))
+				.add(traverse(1, p(bias)))
+				.reshape(shape(1));
+
+		OperationList entry = new OperationList("entry");
+		entry.add(into("record", dynamicInput, p(recorded), false));
+		entry.add(into("dense out", dense, p(layerOut), false));
+
+		OperationList forward = new OperationList("forward");
+		forward.add(entry);
+		forward.add(a("model out", p(modelOut), p(layerOut)));
+
+		Runnable run = ((ParallelProcess<?, Runnable>) forward.flatten().optimize()).get();
+
+		double[][] inputs = { { 2.0, 3.0 }, { 4.0, 6.0 }, { 8.0, 12.0 } };
+		double[] expected = { 0.35, 0.6, 1.1 };
+
+		for (int i = 0; i < inputs.length; i++) {
+			external[0] = new PackedCollection(shape(2));
+			external[0].setMem(0, inputs[i][0], inputs[i][1]);
+			run.run();
+			log("optimizedNestedIntoComposite pass=" + (i + 1) +
+					" result=" + modelOut.toDouble(0) + " expected=" + expected[i]);
+		}
+	}
+
+	/**
+	 * Runs the minimal composite reproduction with selectable ingredients and
+	 * logs per-pass results, so single-ingredient variants can be compared.
+	 *
+	 * @param label       log label for this variant
+	 * @param useInto     build the record/dense members with {@code into(...)} (true) or {@code a(...)} (false)
+	 * @param nested      place the record/dense members in a nested entry list (true) or directly in the forward list (false)
+	 * @param dynamic     supply the record source from a {@link DynamicCollectionProducer} (true) or a provider (false)
+	 * @param thirdMember append the model-output capture assignment (true) or omit it (false)
+	 */
+	private void runCompositeVariant(String label, boolean useInto, boolean nested,
+									 boolean dynamic, boolean thirdMember) {
+		PackedCollection[] external = new PackedCollection[1];
+		PackedCollection providerExternal = new PackedCollection(shape(2));
+		PackedCollection recorded = new PackedCollection(shape(2));
+
+		PackedCollection weights = new PackedCollection(shape(1, 2));
+		weights.setMem(0, 0.5, -0.25);
+
+		PackedCollection bias = new PackedCollection(shape(1));
+		bias.setMem(0, 0.1);
+
+		PackedCollection layerOut = new PackedCollection(shape(1));
+		PackedCollection modelOut = new PackedCollection(shape(1));
+
+		Producer<PackedCollection> source = dynamic ?
+				new DynamicCollectionProducer(shape(2), args -> external[0]) :
+				traverseEach(p(providerExternal));
+
+		CollectionProducer dense = matmul(p(weights),
+				reshape(shape(1, 2).traverse(1), p(recorded)))
+				.add(traverse(1, p(bias)))
+				.reshape(shape(1));
+
+		OperationList members = new OperationList("members");
+		if (useInto) {
+			members.add(into("record", source, p(recorded), false));
+			members.add(into("dense out", dense, p(layerOut), false));
+		} else {
+			members.add(a("record", traverseEach(p(recorded)), source));
+			members.add(a("dense out", p(layerOut), dense));
+		}
+
+		OperationList forward = new OperationList("forward");
+		if (nested) {
+			forward.add(members);
+		} else {
+			forward.add(members.get(0));
+			forward.add(members.get(1));
+		}
+
+		if (thirdMember) {
+			forward.add(a("model out", p(modelOut), p(layerOut)));
+		}
+
+		Runnable run = ((ParallelProcess<?, Runnable>) forward.flatten().optimize()).get();
+
+		if (run instanceof OperationListRunner) {
+			List<Runnable> ops = ((OperationListRunner) run).getOperations();
+			for (int i = 0; i < ops.size(); i++) {
+				log(label + " member=" + i + " type=" + ops.get(i).getClass().getSimpleName() +
+						" display=" + OperationInfo.display(ops.get(i)));
+			}
+		} else {
+			log(label + " runner=" + run.getClass().getSimpleName());
+		}
+
+		PackedCollection result = thirdMember ? modelOut : layerOut;
+		double[][] inputs = { { 2.0, 3.0 }, { 4.0, 6.0 }, { 8.0, 12.0 } };
+		double[] expected = { 0.35, 0.6, 1.1 };
+
+		for (int i = 0; i < inputs.length; i++) {
+			if (dynamic) {
+				external[0] = new PackedCollection(shape(2));
+				external[0].setMem(0, inputs[i][0], inputs[i][1]);
+			} else {
+				providerExternal.setMem(0, inputs[i][0], inputs[i][1]);
+			}
+
+			run.run();
+			log(label + " pass=" + (i + 1) +
+					" result=" + result.toDouble(0) + " expected=" + expected[i] +
+					" recorded=" + recorded.toDouble(0) + "," + recorded.toDouble(1));
+		}
+	}
+
+	/**
+	 * Single-ingredient variants of the minimal composite reproduction. The
+	 * failing configuration is (into, nested, dynamic, third); each variant
+	 * removes exactly one ingredient to identify which is load-bearing.
+	 */
+	@Test(timeout = 240000)
+	public void compositeVariants() {
+		runCompositeVariant("variantAll(into,nested,dynamic,third)", true, true, true, true);
+		runCompositeVariant("variantNoInto(a,nested,dynamic,third)", false, true, true, true);
+		runCompositeVariant("variantFlat(into,flat,dynamic,third)", true, false, true, true);
+		runCompositeVariant("variantProvider(into,nested,provider,third)", true, true, false, true);
+		runCompositeVariant("variantNoThird(into,nested,dynamic)", true, true, true, false);
+	}
+
+	/**
+	 * The variant the earlier passing configurations never exercised: a record
+	 * member that writes the input buffer, followed by a dense member whose
+	 * multiply is explicitly isolated — with a plain provider source, so any
+	 * failure is attributable purely to the isolated child's evaluation being
+	 * mis-ordered against the preceding member's write.
+	 */
+	@Test(timeout = 120000)
+	public void optimizedListRecordThenIsolatedDense() {
+		PackedCollection external = new PackedCollection(shape(2));
+		PackedCollection recorded = new PackedCollection(shape(2));
+
+		PackedCollection weights = new PackedCollection(shape(2));
+		weights.setMem(0, 0.5, -0.25);
+
+		PackedCollection bias = new PackedCollection(shape(1));
+		bias.setMem(0, 0.1);
+
+		PackedCollection out = new PackedCollection(shape(1));
+
+		CollectionProducer mul = multiply(
+				traverseEach(p(weights)), traverseEach(p(recorded)));
+		Producer<PackedCollection> isolated =
+				new CollectionProducerComputation.IsolatedProcess(mul);
+		CollectionProducer dense = add(sum(traverse(0, isolated)), p(bias));
+
+		OperationList list = new OperationList("optimizedListRecordThenIsolatedDense");
+		list.add(a("record", traverseEach(p(recorded)), traverseEach(p(external))));
+		list.add(a("dense", p(out), dense));
+
+		Runnable run = ((ParallelProcess<?, Runnable>) list.flatten().optimize()).get();
+
+		double[][] inputs = { { 2.0, 3.0 }, { 4.0, 6.0 }, { 8.0, 12.0 } };
+		double[] expected = { 0.35, 0.6, 1.1 };
+
+		for (int i = 0; i < inputs.length; i++) {
+			external.setMem(0, inputs[i][0], inputs[i][1]);
+			run.run();
+			log("optimizedListRecordThenIsolatedDense pass=" + (i + 1) +
+					" result=" + out.toDouble(0) + " expected=" + expected[i]);
+		}
+	}
+
+	/**
+	 * Control for the standalone reproduction: the same computation with no
+	 * explicit isolation.
+	 */
+	@Test(timeout = 120000)
+	public void standaloneInlineSourceAssignment() {
+		PackedCollection weights = new PackedCollection(shape(2));
+		weights.setMem(0, 0.5, -0.25);
+
+		PackedCollection in = new PackedCollection(shape(2));
+		PackedCollection bias = new PackedCollection(shape(1));
+		bias.setMem(0, 0.1);
+
+		PackedCollection out = new PackedCollection(shape(1));
+
+		CollectionProducer mul = multiply(
+				traverseEach(p(weights)), traverseEach(p(in)));
+		CollectionProducer dense = add(sum(traverse(0, mul)), p(bias));
+
+		Runnable assign = a("standalone inline", p(out), dense).get();
+		log("standaloneInlineSourceAssignment runnable=" + assign.getClass().getSimpleName());
+
+		in.setMem(0, 2.0, 3.0);
+		assign.run();
+		log("standaloneInlineSourceAssignment pass=1 result=" + out.toDouble(0) + " expected=0.35");
+
+		in.setMem(0, 4.0, 6.0);
+		assign.run();
+		log("standaloneInlineSourceAssignment pass=2 result=" + out.toDouble(0) + " expected=0.6");
+	}
+
+	/**
+	 * Reproduces the CI failure signature for the norm model (NormTests.normModel)
+	 * under default copy-based recording: the norm layer's shapes route both of
+	 * its recording copies through the assignment branch of {@code into(...)},
+	 * so after the CompiledModel output-capture migration every forward member is
+	 * a computation and the composite fuses. With identical input on every pass,
+	 * a fused composite suffering the isolated-argument lag produces a wrong
+	 * first pass and stable later passes; a correct composite produces identical
+	 * output on every pass.
+	 */
+	@Test(timeout = 120000)
+	public void normModelRepeatedForward() {
+		int c = 12;
+		int v = 10;
+		int groups = 4;
+
+		PackedCollection weights = new PackedCollection(shape(c * v)).randnFill();
+		PackedCollection biases = new PackedCollection(shape(c * v)).randnFill();
+		PackedCollection in = new PackedCollection(shape(c, v)).randnFill();
+
+		Model model = new Model(shape(c, v));
+		model.add(norm(groups, weights, biases));
+
+		CompiledModel compiled = model.compile(true, null);
+
+		double[] first = new double[3];
+		for (int i = 0; i < 3; i++) {
+			PackedCollection out = compiled.forward(in.reshape(compiled.getInputShape()));
+			first[i] = out.toDouble(0);
+			log("normModelRepeatedForward pass=" + (i + 1) + " out0=" + first[i]);
+		}
+
+		log("normModelRepeatedForward lagSignature=" +
+				(first[0] != first[1] && first[1] == first[2]));
+		compiled.destroy();
+	}
+
+	/**
+	 * Control: copy-based recording with default settings, which is expected
+	 * to produce the correct value.
+	 */
+	@Test(timeout = 120000)
+	public void copyRecordingControl() {
+		boolean original = DefaultCellularLayer.enableMemoryDataCopy;
+		DefaultCellularLayer.enableMemoryDataCopy = true;
+
+		try {
+			double result = forwardDense();
+			log("copyRecordingControl result=" + result + " expected=" + EXPECTED);
+		} finally {
+			DefaultCellularLayer.enableMemoryDataCopy = original;
+		}
+	}
+
+	/**
+	 * Runs the forward pass with assignment-based recording enabled, restoring
+	 * the recording mode afterward.
+	 *
+	 * @return the forward output value
+	 */
+	private double forwardWithAssignmentRecording() {
+		boolean original = DefaultCellularLayer.enableMemoryDataCopy;
+		DefaultCellularLayer.enableMemoryDataCopy = false;
+
+		try {
+			return forwardDense();
+		} finally {
+			DefaultCellularLayer.enableMemoryDataCopy = original;
+		}
+	}
+
+	/**
+	 * Builds the fixed {@code dense(2, 1)} model and runs one forward pass.
+	 *
+	 * @return the forward output value
+	 */
+	private double forwardDense() {
+		return forwardDense(1)[0];
+	}
+
+	/**
+	 * Builds the fixed {@code dense(2, 1)} model and runs the requested number of
+	 * forward passes with identical input, returning the output of each pass.
+	 *
+	 * @param passes the number of forward passes to run
+	 * @return the forward output value of each pass, in order
+	 */
+	private double[] forwardDense(int passes) {
+		double[][] inputs = new double[passes][];
+		for (int i = 0; i < passes; i++) {
+			inputs[i] = new double[] { 2.0, 3.0 };
+		}
+
+		return forwardDense(inputs);
+	}
+
+	/**
+	 * Builds the fixed {@code dense(2, 1)} model and runs one forward pass per
+	 * supplied input, returning the output of each pass.
+	 *
+	 * @param inputs the input values for each pass (each of length 2)
+	 * @return the forward output value of each pass, in order
+	 */
+	private double[] forwardDense(double[][] inputs) {
+		PackedCollection weights = new PackedCollection(shape(1, 2));
+		weights.setMem(0, 0.5, -0.25);
+
+		PackedCollection biases = new PackedCollection(shape(1));
+		biases.setMem(0, 0.1);
+
+		CellularLayer layer = dense(weights, biases).apply(shape(2));
+
+		SequentialBlock block = new SequentialBlock(shape(2));
+		block.add(layer);
+
+		Model model = new Model(shape(2), 0.1);
+		model.add(block);
+
+		CompiledModel compiled = model.compile(true,
+				new OperationProfile("assignmentIsolationDiag"));
+
+		PackedCollection input = new PackedCollection(shape(2));
+
+		double[] results = new double[inputs.length];
+		for (int i = 0; i < inputs.length; i++) {
+			input.setMem(0, inputs[i][0], inputs[i][1]);
+			PackedCollection out = compiled.forward(input);
+			results[i] = out.toDouble(0);
+		}
+
+		compiled.destroy();
+		return results;
+	}
+}

--- a/engine/utils/src/test/java/org/almostrealism/hardware/test/ArgumentPreparationChainTest.java
+++ b/engine/utils/src/test/java/org/almostrealism/hardware/test/ArgumentPreparationChainTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2026 Michael Murray
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.almostrealism.hardware.test;
+
+import io.almostrealism.compute.ComputeRequirement;
+import io.almostrealism.relation.Evaluable;
+import io.almostrealism.relation.Producer;
+import org.almostrealism.collect.CollectionProducer;
+import org.almostrealism.collect.CollectionProducerComputation;
+import org.almostrealism.collect.PackedCollection;
+import org.almostrealism.hardware.Hardware;
+import org.almostrealism.hardware.MemoryData;
+import org.almostrealism.hardware.OperationList;
+import org.almostrealism.hardware.OperationListRunner;
+import org.almostrealism.hardware.computations.Assignment;
+import org.almostrealism.hardware.metal.MetalComputeContext;
+import org.almostrealism.util.TestFeatures;
+import org.almostrealism.util.TestSuiteBase;
+import org.junit.Test;
+
+import java.util.List;
+
+/**
+ * Verifies that argument preparation for an {@link org.almostrealism.hardware.AcceleratedOperation}
+ * respects the {@link io.almostrealism.concurrent.Semaphore} chain: an argument evaluation that is
+ * itself a dispatch reading memory written by a prior member of the same composite must be ordered
+ * after that member's completion.
+ *
+ * <p>The composite executes through the {@link OperationListRunner} with chained submission (a
+ * trailing plain {@link Runnable} prevents fusion into a single kernel without introducing any
+ * wait between the members). Member one is a Metal-pinned kernel writing a buffer; member two is
+ * a CPU-pinned kernel whose source contains an explicitly isolated subtree reading that buffer,
+ * so the subtree is evaluated as a nested dispatch during member two's argument preparation. The
+ * cross-context read must not observe the buffer from before member one's command buffer
+ * committed.</p>
+ */
+public class ArgumentPreparationChainTest extends TestSuiteBase implements TestFeatures {
+
+	/**
+	 * Runs the two-member cross-context composite several times with fresh values
+	 * each pass and requires member two's isolated argument to observe member one's
+	 * write on every pass.
+	 */
+	@Test(timeout = 120000)
+	public void crossContextArgumentObservesPriorMemberWrite() {
+		if (Hardware.getLocalHardware()
+				.getComputeContexts(false, true, ComputeRequirement.MTL).stream()
+				.noneMatch(MetalComputeContext.class::isInstance)) {
+			log("skipping, no MetalComputeContext available");
+			return;
+		}
+
+		int n = 8;
+
+		PackedCollection source = new PackedCollection(shape(n));
+		PackedCollection written = new PackedCollection(shape(n));
+		PackedCollection weights = new PackedCollection(shape(n));
+		PackedCollection out = new PackedCollection(shape(1));
+
+		weights.fill(pos -> 1.0);
+
+		// Member 1 (Metal): written = source
+		Assignment<MemoryData> write = new Assignment<>(n,
+				() -> (Evaluable<MemoryData>) args -> written,
+				() -> (Evaluable<MemoryData>) args -> source,
+				List.of(ComputeRequirement.MTL));
+
+		// Member 2 (CPU): out = sum(isolated multiply reading the Metal-written buffer).
+		// The isolation forces the multiply to be evaluated as a nested dispatch during
+		// member 2's argument preparation rather than inlined into its kernel.
+		CollectionProducer mul = multiply(
+				traverseEach(p(weights)), traverseEach(p(written)));
+		Producer<PackedCollection> isolated =
+				new CollectionProducerComputation.IsolatedProcess(mul);
+		CollectionProducer reduce = sum(traverse(0, isolated));
+
+		Assignment<MemoryData> gather = new Assignment<>(1,
+				() -> (Evaluable<MemoryData>) args -> out,
+				(Producer) reduce,
+				List.of(ComputeRequirement.CPU));
+
+		OperationList list = new OperationList("crossContextArgumentObservesPriorMemberWrite");
+		list.add(write);
+		list.add(gather);
+		list.add(() -> () -> { });
+
+		Runnable run = list.get();
+		log("crossContextArgumentObservesPriorMemberWrite runnable=" + run.getClass().getSimpleName());
+
+		if (run instanceof OperationListRunner) {
+			List<Runnable> ops = ((OperationListRunner) run).getOperations();
+			for (int i = 0; i < ops.size(); i++) {
+				log("crossContextArgumentObservesPriorMemberWrite member=" + i +
+						" type=" + ops.get(i).getClass().getSimpleName());
+			}
+		}
+
+		for (int pass = 1; pass <= 3; pass++) {
+			double base = pass * 10.0;
+			double expected = 0.0;
+
+			for (int i = 0; i < n; i++) {
+				source.setMem(i, base + i);
+				expected += base + i;
+			}
+
+			run.run();
+			double result = out.toDouble(0);
+			log("crossContextArgumentObservesPriorMemberWrite pass=" + pass +
+					" result=" + result + " expected=" + expected);
+			assertEquals(expected, result);
+		}
+	}
+}

--- a/engine/utils/src/test/java/org/almostrealism/hardware/test/ArgumentPreparationChainTest.java
+++ b/engine/utils/src/test/java/org/almostrealism/hardware/test/ArgumentPreparationChainTest.java
@@ -27,6 +27,7 @@ import org.almostrealism.hardware.MemoryData;
 import org.almostrealism.hardware.OperationList;
 import org.almostrealism.hardware.OperationListRunner;
 import org.almostrealism.hardware.computations.Assignment;
+import org.almostrealism.hardware.metal.MetalCommandRunner;
 import org.almostrealism.hardware.metal.MetalComputeContext;
 import org.almostrealism.util.TestFeatures;
 import org.almostrealism.util.TestSuiteBase;
@@ -47,24 +48,47 @@ import java.util.List;
  * so the subtree is evaluated as a nested dispatch during member two's argument preparation. The
  * cross-context read must not observe the buffer from before member one's command buffer
  * committed.</p>
+ *
+ * <p>The composite runs at two sizes: small enough for any synchronous fast path to hide the
+ * ordering question entirely, and large enough that the Metal dispatch is certainly a genuine
+ * asynchronous encode. Commit counts from the {@link MetalCommandRunner} are logged around each
+ * pass so a run records <em>when</em> the writing dispatch's buffer was committed relative to the
+ * reading member.</p>
  */
 public class ArgumentPreparationChainTest extends TestSuiteBase implements TestFeatures {
+
+	/**
+	 * Runs the composite, requiring member two's isolated argument to observe
+	 * member one's write on every pass. The commit counts logged with each pass
+	 * confirm the Metal write is a genuine asynchronous encode (committed only
+	 * by a chained wait), so the ordering under test is real.
+	 */
+	@Test(timeout = 120000)
+	public void crossContextArgumentObservesPriorMemberWrite() {
+		runCrossContextComposite(8, "crossContext");
+	}
 
 	/**
 	 * Runs the two-member cross-context composite several times with fresh values
 	 * each pass and requires member two's isolated argument to observe member one's
 	 * write on every pass.
+	 *
+	 * @param n     element count for the written buffer
+	 * @param label log label for this variant
 	 */
-	@Test(timeout = 120000)
-	public void crossContextArgumentObservesPriorMemberWrite() {
-		if (Hardware.getLocalHardware()
+	private void runCrossContextComposite(int n, String label) {
+		MetalComputeContext metal = Hardware.getLocalHardware()
 				.getComputeContexts(false, true, ComputeRequirement.MTL).stream()
-				.noneMatch(MetalComputeContext.class::isInstance)) {
-			log("skipping, no MetalComputeContext available");
+				.filter(MetalComputeContext.class::isInstance)
+				.map(MetalComputeContext.class::cast)
+				.findFirst().orElse(null);
+
+		if (metal == null) {
+			log(label + " skipping, no MetalComputeContext available");
 			return;
 		}
 
-		int n = 8;
+		MetalCommandRunner runner = metal.getCommandRunner();
 
 		PackedCollection source = new PackedCollection(shape(n));
 		PackedCollection written = new PackedCollection(shape(n));
@@ -93,19 +117,20 @@ public class ArgumentPreparationChainTest extends TestSuiteBase implements TestF
 				(Producer) reduce,
 				List.of(ComputeRequirement.CPU));
 
+		// Compile each member under its own pushed requirements: constructor
+		// requirements apply at dispatch, but context selection happens at
+		// compile time, so an unpushed compile would target the default context.
 		OperationList list = new OperationList("crossContextArgumentObservesPriorMemberWrite");
-		list.add(write);
-		list.add(gather);
-		list.add(() -> () -> { });
+		list.add(() -> compiled(write, ComputeRequirement.MTL));
+		list.add(() -> compiled(gather, ComputeRequirement.CPU));
 
 		Runnable run = list.get();
-		log("crossContextArgumentObservesPriorMemberWrite runnable=" + run.getClass().getSimpleName());
+		log(label + " runnable=" + run.getClass().getSimpleName());
 
 		if (run instanceof OperationListRunner) {
 			List<Runnable> ops = ((OperationListRunner) run).getOperations();
 			for (int i = 0; i < ops.size(); i++) {
-				log("crossContextArgumentObservesPriorMemberWrite member=" + i +
-						" type=" + ops.get(i).getClass().getSimpleName());
+				log(label + " member=" + i + " type=" + ops.get(i).getClass().getSimpleName());
 			}
 		}
 
@@ -113,16 +138,42 @@ public class ArgumentPreparationChainTest extends TestSuiteBase implements TestF
 			double base = pass * 10.0;
 			double expected = 0.0;
 
+			double[] values = new double[n];
 			for (int i = 0; i < n; i++) {
-				source.setMem(i, base + i);
-				expected += base + i;
+				values[i] = base + (i % 100);
+				expected += values[i];
 			}
+			source.setMem(0, values, 0, n);
+
+			long commits = runner.getCommitCount();
+			long hostCommits = runner.getHostCompleteCommitCount();
 
 			run.run();
 			double result = out.toDouble(0);
-			log("crossContextArgumentObservesPriorMemberWrite pass=" + pass +
-					" result=" + result + " expected=" + expected);
+
+			log(label + " pass=" + pass + " result=" + result + " expected=" + expected +
+					" commits=" + (runner.getCommitCount() - commits) +
+					" hostCompleteCommits=" + (runner.getHostCompleteCommitCount() - hostCommits));
 			assertEquals(expected, result);
+		}
+	}
+
+	/**
+	 * Compiles the given assignment for the specified backend by pushing the
+	 * requirement around compilation, mirroring how framework code selects a
+	 * compute context at compile time.
+	 *
+	 * @param assignment  the assignment to compile
+	 * @param requirement backend the assignment must compile for
+	 * @return the compiled runnable
+	 */
+	private static Runnable compiled(Assignment<MemoryData> assignment, ComputeRequirement requirement) {
+		Hardware.getLocalHardware().getComputer().pushRequirements(List.of(requirement));
+
+		try {
+			return assignment.get();
+		} finally {
+			Hardware.getLocalHardware().getComputer().popRequirements();
 		}
 	}
 }


### PR DESCRIPTION
When an AcceleratedOperation is dispatched with a dependsOn completion, only the kernel dispatch was ordered after it (argument-delivery completions and dependsOn merged via Semaphore.all); the argument evaluations themselves were launched unchained from ProcessDetailsFactory.construct() at submit time. An argument whose evaluation is itself a dispatch could therefore be issued without the dependency the surrounding operation was given.

DependentStreamingEvaluable (io.almostrealism.concurrent) is the streaming counterpart of Submittable.submit(Semaphore): request(args, dependsOn) orders the computation's dispatch after the given completion by chaining it through the provider, without blocking the requesting thread. DestinationEvaluable, AcceleratedComputationEvaluable, and HardwareEvaluable implement it by passing dependsOn into their nested apply; ProcessDetailsFactory.construct(Semaphore) delivers the dependency to capable argument evaluables, and apply threads its dependsOn through getProcessDetails.

Plain host argument evaluables are deliberately left unordered: they are handle-producers (they return MemoryData handles; the kernel reads contents on-device, ordered by its own chained dispatch), and blocking them would violate the submission contract verified by SemaphoreChainBatchingTest - a submit with a same-runner dependency must remain commit-free, and a submit with an outstanding foreign dependency must return. A host function that reads memory contents rather than returning a handle remains responsible for its own ordering; the design notes in
docs/plans/ARGUMENT_PREPARATION_SEMAPHORE.md record this contract and the follow-on work it supports.

Verified with SemaphoreChainBatchingTest (zero-commit same-runner chaining and the non-blocking foreign bridge), AssignmentSemaphoreChainTest, SemaphoreCompositionTest, AsyncResultDeliveryTest, StreamingEvaluableTests, and the new ArgumentPreparationChainTest (a Metal-writer/CPU-reader composite exercising cross-context argument preparation): 15 tests, 0 failures. No currently constructible case changes behavior; the change aligns argument preparation with the Semaphore pattern the rest of the execution chain follows and is groundwork for hazard-aware composite subdivision.