### PR TITLE
Make argument preparation exception-safe in ProcessDetailsFactory

### DIFF
--- a/base/hardware/src/main/java/org/almostrealism/hardware/AcceleratedOperation.java
+++ b/base/hardware/src/main/java/org/almostrealism/hardware/AcceleratedOperation.java
@@ -496,7 +496,7 @@ public abstract class AcceleratedOperation<T extends MemoryData> extends Operati
 	 * @return Process details ready for execution
 	 */
 	protected AcceleratedProcessDetails getProcessDetails(MemoryBank output, Object[] args, Semaphore dependsOn) {
-		return getDetailsFactory().init(output, args).construct(dependsOn);
+		return getDetailsFactory().construct(output, args, dependsOn);
 	}
 
 	/**

--- a/base/hardware/src/main/java/org/almostrealism/hardware/ProcessDetailsFactory.java
+++ b/base/hardware/src/main/java/org/almostrealism/hardware/ProcessDetailsFactory.java
@@ -182,14 +182,9 @@ import java.util.stream.Stream;
  * public class MyAcceleratedOperation extends AcceleratedOperation {
  *     @Override
  *     protected AcceleratedProcessDetails apply(MemoryBank output, Object[] args) {
- *         // Get factory (created in createDetailsFactory())
- *         ProcessDetailsFactory factory = getDetailsFactory();
- *
- *         // Initialize with output and args
- *         factory.init(output, args);
- *
- *         // Construct process details (evaluates arguments async)
- *         return factory.construct();
+ *         // Get factory (created in createDetailsFactory()), prepare the
+ *         // arguments, and construct process details (evaluates arguments async)
+ *         return getDetailsFactory().construct(output, args, null);
  *     }
  * }
  * }</pre>
@@ -258,23 +253,16 @@ public class ProcessDetailsFactory<T> implements Factory<AcceleratedProcessDetai
 	/** Supplier of the memory replacement manager, used to redirect memory from one provider to another. */
 	private Supplier<MemoryReplacementManager> replacements;
 
-	/** The output {@link MemoryBank} passed to the last {@link #init} call. */
-	private MemoryBank output;
-	/** The positional arguments passed to the last {@link #init} call. */
-	private Object args[];
-	/** True if all positional arguments passed to {@link #init} are {@link io.almostrealism.code.MemoryData} instances. */
-	private boolean allMemoryData;
-
-	/** Resolved kernel size (number of parallel work items) for the current invocation. */
-	private long kernelSize;
-	/** Pre-resolved {@link MemoryData} instances for each kernel argument slot. */
-	private MemoryData kernelArgs[];
-	/** {@link Evaluable} instances for kernel arguments that could not be statically resolved. */
-	private Evaluable kernelArgEvaluables[];
-	/** {@link StreamingEvaluable} instances for asynchronous kernel arguments. */
-	private StreamingEvaluable asyncEvaluables[];
-	/** The most recently built {@link AcceleratedProcessDetails} instance. */
-	private AcceleratedProcessDetails currentDetails;
+	/**
+	 * The most recently prepared argument snapshot, reused when {@link #init}
+	 * is called again with the same output and argument identities.
+	 *
+	 * <p>Only ever assigned a fully constructed {@link PreparedArguments}
+	 * instance, as the last step of preparation. A preparation that fails
+	 * partway through leaves the previous (complete) snapshot in place, so
+	 * no caller can observe argument state that is only partially resolved.</p>
+	 */
+	private PreparedArguments prepared;
 
 	/** Executor used to dispatch asynchronous kernel execution when {@link Hardware#isAsync()} is true. */
 	private Executor executor;
@@ -335,16 +323,39 @@ public class ProcessDetailsFactory<T> implements Factory<AcceleratedProcessDetai
 	 * @return This factory instance for chaining
 	 */
 	public ProcessDetailsFactory init(MemoryBank output, Object args[]) {
-		if (kernelArgEvaluables != null && output == this.output &&
-				Arrays.equals(args, this.args, (a, b) -> a == b ? 0 : 1)) {
-			// The configuration is already valid as does not need to be repeated
-			return this;
+		prepare(output, args);
+		return this;
+	}
+
+	/**
+	 * Prepares (or reuses) the argument snapshot for the given output and arguments.
+	 *
+	 * <p>The snapshot is built entirely in local state and only published to
+	 * {@link #prepared} once every argument slot has been resolved. A failure
+	 * during preparation (for example, a kernel compilation error raised while
+	 * obtaining an argument's {@link Evaluable}) therefore leaves the previous
+	 * snapshot untouched, and a reentrant invocation triggered by evaluating a
+	 * constant argument can never observe a partially populated snapshot.</p>
+	 *
+	 * @param output Output {@link MemoryBank} to write results into; may be null for operations without output
+	 * @param args Positional arguments passed at evaluation time
+	 * @return The fully prepared argument snapshot for this combination of output and arguments
+	 */
+	protected PreparedArguments prepare(MemoryBank output, Object args[]) {
+		PreparedArguments existing = prepared;
+		if (existing != null && existing.matches(output, args)) {
+			// The prepared snapshot is already valid and does not need to be rebuilt
+			return existing;
 		}
 
-		this.output = output;
-		this.args = args;
+		if (outputArgIndex < 0 && output != null) {
+			// There is no output for this process
+			throw new UnsupportedOperationException();
+		}
 
-		allMemoryData = args.length <= 0 || Stream.of(args).filter(a -> !(a instanceof MemoryData)).findAny().isEmpty();
+		boolean allMemoryData = args.length <= 0 || Stream.of(args).filter(a -> !(a instanceof MemoryData)).findAny().isEmpty();
+
+		long kernelSize;
 
 		if (isFixedCount()) {
 			kernelSize = getCount();
@@ -377,14 +388,8 @@ public class ProcessDetailsFactory<T> implements Factory<AcceleratedProcessDetai
 			kernelSize = -1;
 		}
 
-		kernelArgs = new MemoryData[arguments.size()];
-		kernelArgEvaluables = new Evaluable[arguments.size()];
-		asyncEvaluables = new StreamingEvaluable[arguments.size()];
-
-		if (outputArgIndex < 0 && output != null) {
-			// There is no output for this process
-			throw new UnsupportedOperationException();
-		}
+		MemoryData kernelArgs[] = new MemoryData[arguments.size()];
+		Evaluable kernelArgEvaluables[] = new Evaluable[arguments.size()];
 
 		/*
 		 * In the first pass, kernel size is inferred from Producer arguments that
@@ -427,17 +432,27 @@ public class ProcessDetailsFactory<T> implements Factory<AcceleratedProcessDetai
 			}
 		}
 
-		return this;
+		/*
+		 * If the kernel size is still not known, the kernel size will be the count.
+		 */
+		if (kernelSize < 0) {
+			if (enableKernelSizeWarnings)
+				warn("Could not infer kernel size, it will be set to " + getCount());
+			kernelSize = getCount();
+		}
+
+		PreparedArguments result = new PreparedArguments(output, args, kernelSize, kernelArgs, kernelArgEvaluables);
+		prepared = result;
+		return result;
 	}
-	
+
 	/**
-	 * Clears cached evaluables so the next {@link #init} call fully re-evaluates all arguments.
+	 * Clears the prepared argument snapshot so the next {@link #init} call fully re-evaluates all arguments.
 	 *
 	 * <p>Call this when argument producers may have changed since the last {@link #init} call.</p>
 	 */
 	public void reset() {
-		this.kernelArgEvaluables = null;
-		this.asyncEvaluables = null;
+		this.prepared = null;
 	}
 
 	/**
@@ -449,12 +464,51 @@ public class ProcessDetailsFactory<T> implements Factory<AcceleratedProcessDetai
 	 */
 	@Override
 	public AcceleratedProcessDetails construct() {
-		return construct(null);
+		return construct((Semaphore) null);
 	}
 
 	/**
-	 * Constructs an {@link AcceleratedProcessDetails} whose dispatch-backed argument
-	 * evaluations are ordered after the given completion.
+	 * Constructs an {@link AcceleratedProcessDetails} from the most recently
+	 * prepared arguments, ordering dispatch-backed argument evaluations after
+	 * the given completion.
+	 *
+	 * @param dependsOn completion that dispatch-backed argument evaluations must chain
+	 *                  on, or {@code null} when there is no dependency
+	 * @return the fully configured process details ready for execution
+	 * @throws IllegalStateException if no arguments have been prepared via {@link #init}
+	 */
+	public AcceleratedProcessDetails construct(Semaphore dependsOn) {
+		PreparedArguments current = prepared;
+
+		if (current == null) {
+			throw new IllegalStateException("No arguments have been prepared");
+		}
+
+		return construct(current, dependsOn);
+	}
+
+	/**
+	 * Prepares the given output and arguments, then constructs an
+	 * {@link AcceleratedProcessDetails} from the resulting snapshot.
+	 *
+	 * <p>This is the preferred entry point for a complete invocation: the
+	 * snapshot produced by preparation is carried directly into construction,
+	 * so an invocation that (through argument evaluation) reaches this same
+	 * factory again cannot substitute its own arguments into this one.</p>
+	 *
+	 * @param output Output {@link MemoryBank} to write results into; may be null for operations without output
+	 * @param args Positional arguments passed at evaluation time
+	 * @param dependsOn completion that dispatch-backed argument evaluations must chain
+	 *                  on, or {@code null} when there is no dependency
+	 * @return the fully configured process details ready for execution
+	 */
+	public AcceleratedProcessDetails construct(MemoryBank output, Object args[], Semaphore dependsOn) {
+		return construct(prepare(output, args), dependsOn);
+	}
+
+	/**
+	 * Constructs an {@link AcceleratedProcessDetails} from the given argument snapshot,
+	 * ordering dispatch-backed argument evaluations after the given completion.
 	 *
 	 * <p>Each argument's {@link StreamingEvaluable} is requested with {@code dependsOn}.
 	 * An argument whose evaluation is itself a hardware dispatch chains the dependency
@@ -468,25 +522,32 @@ public class ProcessDetailsFactory<T> implements Factory<AcceleratedProcessDetai
 	 * host function that reads memory <em>contents</em> rather than returning a handle
 	 * is responsible for its own ordering.</p>
 	 *
+	 * <p>All working state lives in locals of this method, so overlapping
+	 * constructions (whether from another thread or from an argument evaluation
+	 * that reenters this factory) each operate on their own state and deliver
+	 * results to their own {@link AcceleratedProcessDetails}.</p>
+	 *
+	 * @param prepared the argument snapshot to construct from
 	 * @param dependsOn completion that dispatch-backed argument evaluations must chain
 	 *                  on, or {@code null} when there is no dependency
 	 * @return the fully configured process details ready for execution
 	 */
-	public AcceleratedProcessDetails construct(Semaphore dependsOn) {
+	protected AcceleratedProcessDetails construct(PreparedArguments prepared, Semaphore dependsOn) {
+		Evaluable kernelArgEvaluables[] = prepared.kernelArgEvaluables;
 		MemoryData kernelArgs[] = new MemoryData[arguments.size()];
 
 		for (int i = 0; i < kernelArgs.length; i++) {
-			if (this.kernelArgs[i] != null) kernelArgs[i] = this.kernelArgs[i];
+			if (prepared.kernelArgs[i] != null) kernelArgs[i] = prepared.kernelArgs[i];
 		}
 
 		/*
-		 * Reset asyncEvaluables for each construct() call.
-		 * This ensures fresh StreamingEvaluable instances are created with
-		 * new downstream consumers that point to the new AcceleratedProcessDetails.
-		 * Without this reset, reused asyncEvaluables would throw UnsupportedOperationException
-		 * when trying to set a different downstream consumer.
+		 * Fresh StreamingEvaluable instances are created for each construction,
+		 * so that each has a downstream consumer pointing at the specific
+		 * AcceleratedProcessDetails produced here. A reused StreamingEvaluable
+		 * would throw UnsupportedOperationException when trying to set a
+		 * different downstream consumer.
 		 */
-		asyncEvaluables = new StreamingEvaluable[arguments.size()];
+		StreamingEvaluable asyncEvaluables[] = new StreamingEvaluable[arguments.size()];
 
 		/*
 		 * First pass: determine which arguments need async evaluation and create
@@ -528,16 +589,7 @@ public class ProcessDetailsFactory<T> implements Factory<AcceleratedProcessDetai
 			}
 		}
 
-		/*
-		 * If the kernel size is still not known, the kernel size will be the count.
-		 */
-		if (kernelSize < 0) {
-			if (enableKernelSizeWarnings)
-				warn("Could not infer kernel size, it will be set to " + getCount());
-			kernelSize = getCount();
-		}
-
-		int size = Math.toIntExact(kernelSize);
+		int size = Math.toIntExact(prepared.kernelSize);
 
 		/*
 		 * Second pass: create async evaluables for kernel arguments that need
@@ -555,34 +607,30 @@ public class ProcessDetailsFactory<T> implements Factory<AcceleratedProcessDetai
 		/*
 		 * Create AcceleratedProcessDetails BEFORE setting downstream on async evaluables.
 		 * This ensures that the downstream lambdas capture the specific details instance
-		 * rather than accessing the mutable currentDetails field at execution time.
+		 * produced by this construction.
 		 */
-		currentDetails = new AcceleratedProcessDetails(kernelArgs, size,
+		AcceleratedProcessDetails details = new AcceleratedProcessDetails(kernelArgs, size,
 											replacements.get(), executor);
 
-		/*
-		 * Set downstream on all async evaluables, passing the specific details instance.
-		 * FIX: Previously, result(i) created a lambda that accessed 'this.currentDetails'
-		 * at execution time. Now we pass the specific instance to avoid the mutable field.
-		 */
+		/* Set downstream on all async evaluables, passing the specific details instance */
 		for (int i = 0; i < asyncEvaluables.length; i++) {
 			if (asyncEvaluables[i] == null || kernelArgs[i] != null) continue;
-			asyncEvaluables[i].setDownstream(result(i, currentDetails));
+			asyncEvaluables[i].setDownstream(result(i, details));
 		}
 
 		/*
 		 * Now that every StreamingEvaluable is configured to deliver
-		 * results to the current AcceleratedProcessDetails, their work
+		 * results to the new AcceleratedProcessDetails, their work
 		 * can be initiated via StreamingEvaluable#request
 		 */
 		for (int i = 0; i < asyncEvaluables.length; i++) {
 			if (asyncEvaluables[i] == null || kernelArgs[i] != null) continue;
 
-			asyncEvaluables[i].request(args, dependsOn);
+			asyncEvaluables[i].request(prepared.args, dependsOn);
 		}
 
 		/* The details are ready */
-		return currentDetails;
+		return details;
 	}
 
 	/**
@@ -622,6 +670,63 @@ public class ProcessDetailsFactory<T> implements Factory<AcceleratedProcessDetai
 			executor.execute(r);
 		} else {
 			r.run();
+		}
+	}
+
+	/**
+	 * Immutable snapshot of the argument state prepared for one combination of
+	 * output and positional arguments.
+	 *
+	 * <p>An instance is only created once every argument slot has been fully
+	 * resolved, so any consumer can rely on the invariant that each slot holds
+	 * either a pre-resolved {@link MemoryData} in {@link #kernelArgs} or an
+	 * {@link Evaluable} in {@link #kernelArgEvaluables} (slots whose argument
+	 * variable is absent hold the pre-resolved null). Because the snapshot is
+	 * immutable, a construction that overlaps with the preparation of different
+	 * arguments — from another thread, or from an argument evaluation that
+	 * reenters the same operation — always observes consistent state.</p>
+	 */
+	protected static class PreparedArguments {
+		/** The output {@link MemoryBank} this snapshot was prepared for. */
+		private final MemoryBank output;
+		/** The positional arguments this snapshot was prepared for. */
+		private final Object args[];
+		/** Resolved kernel size (number of parallel work items). */
+		private final long kernelSize;
+		/** Pre-resolved {@link MemoryData} instances for each kernel argument slot. */
+		private final MemoryData kernelArgs[];
+		/** {@link Evaluable} instances for kernel arguments that could not be statically resolved. */
+		private final Evaluable kernelArgEvaluables[];
+
+		/**
+		 * Captures a fully resolved argument snapshot.
+		 *
+		 * @param output Output {@link MemoryBank} the snapshot was prepared for; may be null
+		 * @param args Positional arguments the snapshot was prepared for
+		 * @param kernelSize Resolved kernel size for the invocation
+		 * @param kernelArgs Pre-resolved {@link MemoryData} for each argument slot
+		 * @param kernelArgEvaluables {@link Evaluable} for each argument slot not covered by kernelArgs
+		 */
+		private PreparedArguments(MemoryBank output, Object args[], long kernelSize,
+								  MemoryData kernelArgs[], Evaluable kernelArgEvaluables[]) {
+			this.output = output;
+			this.args = args;
+			this.kernelSize = kernelSize;
+			this.kernelArgs = kernelArgs;
+			this.kernelArgEvaluables = kernelArgEvaluables;
+		}
+
+		/**
+		 * Returns true if this snapshot was prepared for exactly the given output
+		 * and argument identities.
+		 *
+		 * @param output Output {@link MemoryBank} for the invocation being prepared
+		 * @param args Positional arguments for the invocation being prepared
+		 * @return True if this snapshot can be reused for the invocation
+		 */
+		protected boolean matches(MemoryBank output, Object args[]) {
+			return output == this.output &&
+					Arrays.equals(args, this.args, (a, b) -> a == b ? 0 : 1);
 		}
 	}
 

--- a/docs/plans/ARGUMENT_PREPARATION_NPE.md
+++ b/docs/plans/ARGUMENT_PREPARATION_NPE.md
@@ -1,6 +1,32 @@
 # Handoff — NPE in ProcessDetailsFactory after the argument-preparation chaining arc
 
-> **Status: open defect on `master`, 2026-07-09.** Found while verifying the PDSL ring
+> **Status: RESOLVED on `defect/process-details-init`, 2026-07-10.** Root cause was not
+> the suspected `init`/`construct` thread race (all factory access is under the
+> operation monitor — `AcceleratedOperation.apply` is `synchronized`, and the only
+> call site into the factory is `getProcessDetails`). It was **exception-unsafety in
+> `init`**: a Metal kernel compile failure (`'buffer' attribute parameter is out of
+> bounds: must be between 0 and 30` — the aggregate kernel exceeds Metal's 31-buffer
+> limit when `aggregationThresholdSweep` runs at low thresholds) threw out of `init`'s
+> second pass, *after* `this.output`/`this.args` were published and the arrays
+> recreated. Every later call with the same output/args identity took `init`'s fast
+> path over the half-populated `kernelArgEvaluables` and NPE'd in `construct` —
+> permanently poisoning the shared compiled operation (observed: threshold=2 fails
+> with the real `HardwareException`, thresholds 4→1024 and then `hotPathBreakdown`
+> all fail with the NPE). Fix: per-invocation state is now an immutable
+> `PreparedArguments` snapshot, built entirely in locals and published only once
+> complete; `construct` works entirely on locals (also removing the reentrancy hazard
+> where a nested invocation clobbered `asyncEvaluables`/`currentDetails`). Regression
+> guard: `ProcessDetailsFactoryRecoveryTest` (engine/utils, ungated) reproduces the
+> exact production NPE on the unfixed code and passes with the fix. After the fix,
+> `PdslHotPathBreakdownTest` passes; the sweep's threshold≤32 entries fail cleanly
+> with the genuine `HardwareException` every time. That buffer-limit overflow only
+> occurs when the sweep drives `MemoryDataArgumentMap.maxAggregateLength` below its
+> default of 1024 (lowering it excludes buffers from aggregation, so more raw
+> arguments reach the kernel signature); default configuration is unaffected. It
+> still matters to the sweep work itself: the low-threshold data points will read as
+> failures until the kernel compiler respects the device argument limit.
+
+> **Original report (2026-07-09):** Found while verifying the PDSL ring
 > fixes; **provenance verified against a pristine tree** (stash round-trip: the identical
 > failure occurs with and without the ring-fix changes), so it belongs to the
 > operation-list subdivision / argument-preparation work merged 2026-07-08 (PR #340),

--- a/engine/utils/src/test/java/org/almostrealism/hardware/test/ProcessDetailsFactoryRecoveryTest.java
+++ b/engine/utils/src/test/java/org/almostrealism/hardware/test/ProcessDetailsFactoryRecoveryTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2026 Michael Murray
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.almostrealism.hardware.test;
+
+import io.almostrealism.relation.Evaluable;
+import io.almostrealism.scope.ArrayVariable;
+import io.almostrealism.uml.Multiple;
+import org.almostrealism.collect.CollectionProducer;
+import org.almostrealism.collect.PackedCollection;
+import org.almostrealism.hardware.AcceleratedComputationEvaluable;
+import org.almostrealism.hardware.HardwareException;
+import org.almostrealism.hardware.ProcessDetailsFactory;
+import org.almostrealism.hardware.arguments.ProcessArgumentEvaluator;
+import org.almostrealism.hardware.computations.HardwareEvaluable;
+import org.almostrealism.util.TestFeatures;
+import org.almostrealism.util.TestSuiteBase;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Verifies that a failure during argument preparation does not permanently
+ * poison the {@link ProcessDetailsFactory} of a compiled operation.
+ *
+ * <p>Argument preparation can fail for reasons that are specific to a single
+ * invocation — most notably a backend kernel compilation error raised while
+ * obtaining an argument's {@link Evaluable} (for example, Metal rejecting a
+ * kernel with more than 31 buffer arguments). Compiled operations are shared,
+ * so the factory must remain usable after such a failure: the next invocation
+ * has to rebuild the argument state from scratch rather than reuse a snapshot
+ * that was only partially populated when the failure occurred. A factory that
+ * retains partially populated state produces a {@link NullPointerException}
+ * from an argument slot with neither a resolved {@link
+ * org.almostrealism.hardware.MemoryData} nor an {@link Evaluable} on every
+ * subsequent invocation.</p>
+ */
+public class ProcessDetailsFactoryRecoveryTest extends TestSuiteBase implements TestFeatures {
+	/**
+	 * Evaluates a compiled operation, then makes its argument evaluator fail
+	 * exactly once and confirms the operation recovers on the following
+	 * invocation instead of failing with a {@link NullPointerException} from
+	 * partially prepared argument state.
+	 */
+	@Test(timeout = 120000)
+	public void recoversAfterFailedArgumentPreparation() {
+		PackedCollection a = new PackedCollection(shape(8));
+		PackedCollection b = new PackedCollection(shape(8));
+		a.fill(pos -> 2.0);
+		b.fill(pos -> 3.0);
+
+		CollectionProducer sum = add(traverseEach(p(a)), traverseEach(p(b)));
+		Evaluable<PackedCollection> ev = sum.get();
+
+		// Prime the operation so it is compiled and its details factory exists
+		PackedCollection primed = ev.evaluate();
+		for (int i = 0; i < 8; i++) {
+			assertEquals(5.0, primed.toDouble(i));
+		}
+
+		AcceleratedComputationEvaluable<?> kernel = kernel(ev);
+		ProcessDetailsFactory<?> factory = kernel.getDetailsFactory();
+		ProcessArgumentEvaluator original = factory.getEvaluator();
+
+		AtomicBoolean failPreparation = new AtomicBoolean(true);
+
+		try {
+			factory.setEvaluator(new ProcessArgumentEvaluator() {
+				@Override
+				public <V> Evaluable<? extends Multiple<V>> getEvaluable(ArrayVariable<V> argument) {
+					if (failPreparation.get()) {
+						throw new HardwareException("Simulated argument preparation failure");
+					}
+
+					return original.getEvaluable(argument);
+				}
+			});
+
+			// Force the next invocation to prepare arguments again,
+			// encountering the simulated failure partway through
+			factory.reset();
+
+			try {
+				ev.evaluate();
+				Assert.fail("Argument preparation was expected to fail");
+			} catch (HardwareException e) {
+				log("Argument preparation failed as intended: " + e.getMessage());
+			}
+
+			// The failure is gone; the operation must recover rather than
+			// reuse argument state left behind by the failed preparation
+			failPreparation.set(false);
+
+			PackedCollection recovered = ev.evaluate();
+			for (int i = 0; i < 8; i++) {
+				assertEquals(5.0, recovered.toDouble(i));
+			}
+		} finally {
+			factory.setEvaluator(original);
+		}
+	}
+
+	/**
+	 * Unwraps any {@link HardwareEvaluable} layers to reach the compiled
+	 * {@link AcceleratedComputationEvaluable} whose details factory manages
+	 * argument preparation.
+	 *
+	 * @param ev The evaluable produced for a compiled operation
+	 * @return The underlying compiled evaluable
+	 */
+	private AcceleratedComputationEvaluable<?> kernel(Evaluable<?> ev) {
+		Evaluable<?> inner = ev;
+
+		while (inner instanceof HardwareEvaluable) {
+			inner = ((HardwareEvaluable<?>) inner).getKernel().getValue();
+		}
+
+		return (AcceleratedComputationEvaluable<?>) inner;
+	}
+}


### PR DESCRIPTION
A failure during argument preparation could permanently poison a shared compiled operation. ProcessDetailsFactory.init published the output/args identity used by its fast path and recreated the kernel argument arrays before populating them, so an exception thrown partway through the population passes (for example, a Metal kernel compile error when an aggregate kernel exceeds the device's 31-buffer argument limit) left the factory with half-populated state that the fast path later mistook for valid. Every subsequent invocation with the same output and argument identities then failed in construct with an NPE
("this.kernelArgEvaluables[i] is null"). Observed in PdslHotPathBreakdownTest: one genuine compile failure at aggregation threshold 2 caused every later sweep entry, and then hotPathBreakdown itself, to fail with the NPE. (The suspected init/construct thread race was ruled out: the factory is only reached through the synchronized AcceleratedOperation.apply.)

Restructure the factory around an immutable per-invocation snapshot:

- Replace the mutable per-invocation fields (output, args, kernelSize, kernelArgs, kernelArgEvaluables, asyncEvaluables, currentDetails) with a PreparedArguments snapshot holding output/args identity, kernel size, resolved kernel arguments, and argument evaluables.
- prepare(output, args) builds the snapshot entirely in local state and publishes it only once every argument slot is resolved, so a failed preparation leaves the previous complete snapshot in place and the next invocation prepares again from scratch.
- construct works entirely on locals (including the StreamingEvaluable array and the AcceleratedProcessDetails it delivers results to), so a reentrant invocation of the same shared operation can no longer clobber in-progress construction state.
- AcceleratedOperation.getProcessDetails uses the new construct(output, args, dependsOn) entry point, which carries the snapshot from preparation directly into construction; init, reset, and the existing construct signatures remain as thin wrappers.
- Add ProcessDetailsFactoryRecoveryTest, an ungated regression test that makes a compiled operation's argument evaluator fail exactly once and verifies the operation recovers on the following invocation. It reproduces the exact production NPE against the previous implementation.

Verified: full-reactor mvn install -DskipTests succeeds; build-validator (checkstyle, code_policy, test_timeouts, duplicate_code) reports no violations; PdslHotPathBreakdownTest passes end to end (previously died within ~40s), with the aggregation sweep's threshold<=32 entries now failing cleanly with the genuine Metal buffer-limit HardwareException on every attempt (the default maxAggregateLength of 1024 is unaffected); ArgumentPreparationChainTest, AsyncResultDeliveryTest, AssignmentIsolationDiagTest, and ProducerEvalCachesKernelTest pass.