### PR TITLE
Add Quality Assurance workflow for documentation staleness review

### DIFF
--- a/.github/workflows/quality-assurance.yaml
+++ b/.github/workflows/quality-assurance.yaml
@@ -1,0 +1,154 @@
+name: "Quality Assurance"
+
+# Runs after merges to master. Submits a FlowTree coding-agent job that reviews
+# the documentation for staleness against the changes merged over the last week
+# and opens a PR with any fixes.
+#
+# Rate limit: at most one submission per UTC calendar day. Every merge triggers
+# the workflow, but a GitHub Actions cache marker keyed on the day short-circuits
+# any run after the first submission that day. workflow_dispatch with force=true
+# bypasses the cap.
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+    inputs:
+      force:
+        description: "Submit a documentation QA job even if one already ran today"
+        required: false
+        default: "false"
+
+# Serialize runs so the once-per-day marker is race-free: two merges close
+# together run one after another, and the second sees the marker the first saved.
+concurrency:
+  group: quality-assurance
+  cancel-in-progress: false
+
+jobs:
+  doc-qa:
+    runs-on: [self-hosted, macos, ar-ci]
+    permissions:
+      contents: write
+      pull-requests: write
+
+    env:
+      # The window of recent history the agent reviews for documentation drift.
+      # Passed to the prompt as a git --since expression.
+      REVIEW_SINCE: "1 week ago"
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          ref: master
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute daily rate-limit key
+        id: ratelimit
+        run: |
+          TODAY=$(date -u +%Y%m%d)
+          echo "day=$TODAY" >> "$GITHUB_OUTPUT"
+          echo "::notice::Documentation QA rate-limit day (UTC): $TODAY"
+
+      - name: Check today's submission marker
+        id: marker
+        uses: actions/cache/restore@v4
+        with:
+          path: .qa-submitted-marker
+          key: qa-submitted-${{ steps.ratelimit.outputs.day }}
+
+      - name: Decide whether to submit
+        id: decide
+        run: |
+          if [ "${{ steps.marker.outputs.cache-hit }}" = "true" ] && [ "${{ github.event.inputs.force }}" != "true" ]; then
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::A documentation QA job already ran today (${{ steps.ratelimit.outputs.day }}) — skipping. Re-run via workflow_dispatch with force=true to override."
+          else
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            if [ "${{ github.event.inputs.force }}" = "true" ]; then
+              echo "::notice::Force mode — submitting a documentation QA job regardless of the daily cap"
+            else
+              echo "::notice::No submission yet today — submitting a documentation QA job"
+            fi
+          fi
+
+      # A fresh branch for the agent to work on. It is pushed before submission
+      # so the agent's targetBranch exists; AUTO_CREATE_PR opens the PR once the
+      # agent commits its fixes. On a day when the docs are already current the
+      # agent makes no changes and no PR is opened, leaving an empty branch at
+      # master's HEAD (harmless; a future refinement could prune these).
+      - name: Create QA branch
+        if: steps.decide.outputs.run == 'true'
+        id: qa_branch
+        run: |
+          TIMESTAMP=$(date -u +%Y%m%d-%H%M%S)
+          BRANCH_NAME="qa/docs-${TIMESTAMP}"
+          git checkout -b "$BRANCH_NAME"
+          git push -u origin "$BRANCH_NAME"
+          echo "branch=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
+          echo "::notice::Created branch $BRANCH_NAME"
+
+      - name: Register workstream
+        if: steps.decide.outputs.run == 'true'
+        env:
+          CONTROLLER_HOST: ${{ secrets.FLOWTREE_CONTROLLER_HOST || 'mac-studio' }}
+          CONTROLLER_PORT: ${{ secrets.FLOWTREE_CONTROLLER_PORT || '7780' }}
+          BRANCH: ${{ steps.qa_branch.outputs.branch }}
+          BASE_BRANCH: master
+          REPO_URL: git@github.com:${{ github.repository }}.git
+        run: |
+          chmod +x ./tools/ci/register-workstream.sh
+          ./tools/ci/register-workstream.sh
+
+      - name: Build documentation QA prompt
+        if: steps.decide.outputs.run == 'true'
+        env:
+          BRANCH: ${{ steps.qa_branch.outputs.branch }}
+          BASE_BRANCH: master
+          REVIEW_SINCE: ${{ env.REVIEW_SINCE }}
+        run: |
+          ./tools/ci/prompts/build-doc-qa-prompt.sh "${{ runner.temp }}/agent-prompt.txt"
+
+      - name: Submit documentation QA agent job
+        if: steps.decide.outputs.run == 'true'
+        env:
+          CONTROLLER_HOST: ${{ secrets.FLOWTREE_CONTROLLER_HOST || 'mac-studio' }}
+          CONTROLLER_PORT: ${{ secrets.FLOWTREE_CONTROLLER_PORT || '7780' }}
+          BRANCH: ${{ steps.qa_branch.outputs.branch }}
+          BASE_BRANCH: master
+          DESCRIPTION: "Review documentation for staleness"
+          AUTO_CREATE_PR: "true"
+        run: |
+          ./tools/ci/submit-agent-job.sh "${{ runner.temp }}/agent-prompt.txt"
+
+      # Consume today's slot only after a successful submission (a failed submit
+      # exits non-zero and fails the job before this runs, leaving the day open
+      # for a later merge to retry). Skipped when the marker already existed.
+      - name: Record today's submission
+        if: steps.decide.outputs.run == 'true' && steps.marker.outputs.cache-hit != 'true'
+        run: date -u +%s > .qa-submitted-marker
+
+      - name: Save daily submission marker
+        if: steps.decide.outputs.run == 'true' && steps.marker.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: .qa-submitted-marker
+          key: qa-submitted-${{ steps.ratelimit.outputs.day }}
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "## Quality Assurance — Documentation" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Rate-limit day (UTC):** ${{ steps.ratelimit.outputs.day }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Review window:** ${{ env.REVIEW_SINCE }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          if [ "${{ steps.decide.outputs.run }}" = "true" ]; then
+            echo "Created branch \`${{ steps.qa_branch.outputs.branch }}\` and submitted a FlowTree" >> "$GITHUB_STEP_SUMMARY"
+            echo "coding agent job to review documentation for staleness and open a PR with any fixes." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "A documentation QA job already ran today — skipped to honor the once-per-day cap." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/quality-assurance.yaml
+++ b/.github/workflows/quality-assurance.yaml
@@ -120,6 +120,7 @@ jobs:
           BRANCH: ${{ steps.qa_branch.outputs.branch }}
           BASE_BRANCH: master
           DESCRIPTION: "Review documentation for staleness"
+          PROTECT_TEST_FILES: "true"
           AUTO_CREATE_PR: "true"
         run: |
           ./tools/ci/submit-agent-job.sh "${{ runner.temp }}/agent-prompt.txt"

--- a/flowtree/runtime/src/main/java/io/flowtree/jobs/McpConfigBuilder.java
+++ b/flowtree/runtime/src/main/java/io/flowtree/jobs/McpConfigBuilder.java
@@ -112,6 +112,8 @@ public class McpConfigBuilder implements ConsoleFeatures {
             "github_request_copilot_review",
             "github_read_file",
             "github_pr_check_status",
+            "github_list_workflow_runs",
+            "github_workflow_run_status",
             "project_read_plan",
             "tracker_get_task",
             "tracker_list_tasks",

--- a/flowtree/runtime/src/test/java/io/flowtree/jobs/McpToolDiscoveryTest.java
+++ b/flowtree/runtime/src/test/java/io/flowtree/jobs/McpToolDiscoveryTest.java
@@ -334,6 +334,8 @@ public class McpToolDiscoveryTest extends TestSuiteBase {
 			"github_request_copilot_review",
 			"github_read_file",
 			"github_pr_check_status",
+			"github_list_workflow_runs",
+			"github_workflow_run_status",
 			"tracker_list_projects",
 			"tracker_create_project",
 			"tracker_update_project",
@@ -615,6 +617,20 @@ public class McpToolDiscoveryTest extends TestSuiteBase {
 			prCheckParams.contains("workstream_id"));
 		assertTrue("github_pr_check_status must declare branch in signature",
 			prCheckParams.contains("branch"));
+
+		List<String> listRunsParams =
+			McpToolDiscovery.discoverToolParameters(serverFile, "github_list_workflow_runs");
+		assertTrue("github_list_workflow_runs must declare workflow in signature",
+			listRunsParams.contains("workflow"));
+		assertTrue("github_list_workflow_runs must declare status in signature",
+			listRunsParams.contains("status"));
+		assertTrue("github_list_workflow_runs must declare limit in signature",
+			listRunsParams.contains("limit"));
+
+		List<String> runStatusParams =
+			McpToolDiscovery.discoverToolParameters(serverFile, "github_workflow_run_status");
+		assertTrue("github_workflow_run_status must declare run_id in signature",
+			runStatusParams.contains("run_id"));
 
 		List<String> trackerCreateParams =
 			McpToolDiscovery.discoverToolParameters(serverFile, "tracker_create_task");

--- a/tools/ci/prompts/build-doc-qa-prompt.sh
+++ b/tools/ci/prompts/build-doc-qa-prompt.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# ─── Build the documentation-QA prompt for the FlowTree agent ─────────
+#
+# Reads the documentation-QA prompt template and substitutes environment
+# variables to produce a concrete prompt for the coding agent.
+#
+# Usage:
+#   build-doc-qa-prompt.sh <output-file>
+#
+# Required environment variables:
+#   BRANCH          - branch name for the QA work
+#   BASE_BRANCH     - base branch (master)
+#   REVIEW_SINCE    - git --since expression bounding the review window
+#                     (e.g. "1 week ago")
+#
+# Exit codes:
+#   0 - prompt written successfully
+#   1 - invalid arguments or missing env vars
+
+set -euo pipefail
+
+OUTPUT_FILE="${1:-}"
+
+if [ -z "$OUTPUT_FILE" ]; then
+    echo "Usage: $0 <output-file>" >&2
+    exit 1
+fi
+
+for var in BRANCH BASE_BRANCH REVIEW_SINCE; do
+    if [ -z "${!var:-}" ]; then
+        echo "ERROR: ${var} is not set." >&2
+        exit 1
+    fi
+done
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TEMPLATE="${SCRIPT_DIR}/doc-qa.txt"
+
+if [ ! -f "$TEMPLATE" ]; then
+    echo "ERROR: Template not found at ${TEMPLATE}" >&2
+    exit 1
+fi
+
+# Substitute environment variables in the template.
+sed -e "s|\${BRANCH}|${BRANCH}|g" \
+    -e "s|\${BASE_BRANCH}|${BASE_BRANCH}|g" \
+    -e "s|\${REVIEW_SINCE}|${REVIEW_SINCE}|g" \
+    "$TEMPLATE" > "$OUTPUT_FILE"

--- a/tools/ci/prompts/doc-qa.txt
+++ b/tools/ci/prompts/doc-qa.txt
@@ -1,0 +1,89 @@
+You are the Documentation Quality Assurance reviewer for the Almost Realism platform — an
+evolving ecosystem for high-performance scientific computing, generative art, machine
+learning, and multimedia generation with pluggable native acceleration.
+
+Your job is to find documentation that has fallen out of date with the code and fix it. You
+are working on branch "${BRANCH}" (created from ${BASE_BRANCH}). You are a coding agent, not a
+reviewer — make the corrections yourself; do not merely list them.
+
+## Why this matters
+
+Good documentation is the foundation of everything here — for new contributors, for AI
+assistants, and for the models we hope to eventually train on this codebase. Documentation
+that silently disagrees with the code is worse than no documentation: it teaches the wrong
+model of the system. Recent changes are where drift is most likely, so that is where you look.
+
+## The review window
+
+Focus on documentation drift caused by changes merged over the recent past — specifically the
+last "${REVIEW_SINCE}". This is deliberately NOT limited to a single merge: you are assessing
+the accumulated effect of recent work, not one commit.
+
+Establish what changed:
+
+- `git log --since="${REVIEW_SINCE}" --oneline origin/${BASE_BRANCH}` — the recent commits.
+- To see the code that actually moved, resolve the commit as of the start of the window and
+  diff from there (this uses commit dates, not reflog, so it is reliable on a fresh checkout):
+  `SINCE_REF=$(git rev-list -1 --before="${REVIEW_SINCE}" origin/${BASE_BRANCH})`
+  then `git diff "$SINCE_REF" origin/${BASE_BRANCH} -- '*.java' '**/pom.xml'`
+  (add `--stat` first for a high-level view of which production code, APIs, and module
+  structure changed).
+
+From that set of changes, work outward to the documentation that describes the changed code.
+
+## What to check and fix
+
+For each meaningful recent change, find the documentation that is supposed to describe it and
+confirm it still matches reality. Documentation in this project lives in several places:
+
+- Module `README.md` files (e.g. `base/collect/README.md`, `engine/ml/README.md`).
+- The `docs/` portal — `docs/internals/`, `docs/modules/`, tutorials, `docs/QUICK_REFERENCE.md`.
+- `CLAUDE.md` files (root and module-level) and `.github/CLAUDE.md` (the CI/dependency graph).
+- Javadoc on public classes and methods in the changed `.java` files.
+- The `llms.txt` documentation index.
+
+Look specifically for:
+
+- Descriptions of behavior, APIs, method signatures, or class names that no longer match the
+  code after a recent change.
+- Module maps, dependency graphs, or layer descriptions that no longer reflect the current
+  `pom.xml` dependencies or directory structure.
+- References to classes, methods, files, or modules that were renamed, moved, or deleted.
+- Newly added public classes/methods from the review window that lack Javadoc or are missing
+  from the relevant README/portal page.
+- Code examples in docs that would no longer compile or that use a retired API.
+- Version numbers or hard-coded specifics that contradict the "never reference version
+  numbers" rule (refer to pom.xml as the source of truth instead).
+
+## How to verify — evidence, not speculation
+
+- **Use `ar-consultant`.** Query the documentation corpus for the components touched by recent
+  changes and compare what it returns against the current source. The consultant knows things
+  about this codebase that are not obvious from a first read.
+- Confirm every claimed discrepancy against the actual code before changing a doc. Do not
+  "correct" documentation to match an assumption — read the code that the documentation
+  describes and make the doc reflect what the code now does.
+- When you fix a dependency/module-structure claim, verify it against the relevant `pom.xml`
+  files in both directions (what the module depends on, and what depends on it).
+
+## Scope and guardrails
+
+- This is a staleness pass, not a documentation rewrite. Fix what recent changes made wrong or
+  incomplete; do not restructure healthy docs or churn wording for its own sake.
+- Edit documentation and Javadoc only. Do NOT change production logic, and do NOT modify test
+  files or CI workflow files — a documentation QA pass never needs to. (Automated enforcement
+  blocks agent changes to base-branch test and CI files.)
+- Follow the project's documentation conventions: no version numbers, accurate module
+  placement, and Javadoc for public API.
+
+## Deliverable
+
+1. Make the documentation corrections directly by editing the files.
+2. If you changed Javadoc in any `.java` file, run `mvn install -DskipTests` to confirm the
+   build still succeeds.
+3. Your committed changes will be opened as a pull request automatically. Send a summary
+   organized by the recent change that motivated each fix: for each, the doc file path and a
+   one-line explanation of the drift you corrected.
+4. If, after a genuine investigation, the documentation is accurate and up to date with the
+   recent changes, make no changes and say so explicitly — explain what you checked and why you
+   are confident the docs are current. "No drift found" is a valid and valuable outcome.

--- a/tools/ci/prompts/doc-qa.txt
+++ b/tools/ci/prompts/doc-qa.txt
@@ -25,7 +25,7 @@ Establish what changed:
 - To see the code that actually moved, resolve the commit as of the start of the window and
   diff from there (this uses commit dates, not reflog, so it is reliable on a fresh checkout):
   `SINCE_REF=$(git rev-list -1 --before="${REVIEW_SINCE}" origin/${BASE_BRANCH})`
-  then `git diff "$SINCE_REF" origin/${BASE_BRANCH} -- '*.java' '**/pom.xml'`
+  then `git diff "$SINCE_REF" origin/${BASE_BRANCH} -- '**/*.java' '**/pom.xml'`
   (add `--stat` first for a high-level view of which production code, APIs, and module
   structure changed).
 

--- a/tools/mcp/manager/README.md
+++ b/tools/mcp/manager/README.md
@@ -73,6 +73,8 @@ resolved issues). Requires `security_events: write` permission on the PAT.
 | `github_pr_conversation` | github | Get the issue-style conversation comments on a PR |
 | `github_pr_reply` | github | Reply to a PR review thread |
 | `github_pr_check_status` | github | Get CI/check status for a PR head commit |
+| `github_list_workflow_runs` | github | Search GitHub Actions workflow runs (by workflow/branch/event/status) |
+| `github_workflow_run_status` | github | Get a workflow run's jobs and failed steps by run id |
 | `github_list_open_prs` | github | List open PRs for a repo |
 | `github_create_pr` | github | Create a pull request |
 | `github_request_copilot_review` | github | Request a Copilot automated review on a PR |

--- a/tools/mcp/manager/github_api.py
+++ b/tools/mcp/manager/github_api.py
@@ -321,3 +321,178 @@ def _resolve_github_repo(workstream_id: str = "", branch: str = "",
 
     return "", "", branch, {"ok": False,
                             "error": f"Workstream '{effective_ws}' not found and no local git repo detected"}
+
+
+# ---------------------------------------------------------------------------
+# GitHub Actions — workflow run search and status
+# ---------------------------------------------------------------------------
+
+
+def _shape_workflow_run(run: dict) -> dict:
+    """Reduce a raw GitHub workflow-run object to the fields callers need.
+
+    Args:
+        run: A raw workflow-run object from the GitHub Actions API.
+
+    Returns:
+        A flat dict with the run's identity, trigger, and outcome fields.
+    """
+    return {
+        "run_id": run.get("id"),
+        "name": run.get("name", ""),
+        "display_title": run.get("display_title", ""),
+        "workflow_id": run.get("workflow_id"),
+        "event": run.get("event", ""),
+        "status": run.get("status", ""),
+        "conclusion": run.get("conclusion"),
+        "head_branch": run.get("head_branch", ""),
+        "head_sha": run.get("head_sha", ""),
+        "run_number": run.get("run_number"),
+        "run_attempt": run.get("run_attempt"),
+        "created_at": run.get("created_at", ""),
+        "updated_at": run.get("updated_at", ""),
+        "html_url": run.get("html_url", ""),
+    }
+
+
+def _shape_job(job: dict) -> dict:
+    """Reduce a raw GitHub Actions job object to a diagnostic summary.
+
+    Only the steps that failed are retained, since those are what a caller
+    diagnosing a CI failure needs to see.
+
+    Args:
+        job: A raw job object from the GitHub Actions API.
+
+    Returns:
+        A flat dict describing the job and its failed steps.
+    """
+    failed_steps = [
+        {
+            "name": step.get("name", ""),
+            "number": step.get("number"),
+            "conclusion": step.get("conclusion"),
+        }
+        for step in (job.get("steps") or [])
+        if step.get("conclusion") == "failure"
+    ]
+    return {
+        "job_id": job.get("id"),
+        "name": job.get("name", ""),
+        "status": job.get("status", ""),
+        "conclusion": job.get("conclusion"),
+        "started_at": job.get("started_at"),
+        "completed_at": job.get("completed_at"),
+        "html_url": job.get("html_url", ""),
+        "failed_steps": failed_steps,
+    }
+
+
+def list_workflow_runs(owner: str, repo: str, workflow: str = "",
+                       branch: str = "", event: str = "", status: str = "",
+                       actor: str = "", limit: int = 20) -> dict:
+    """List GitHub Actions workflow runs for a repository.
+
+    When ``workflow`` is given the workflow-scoped endpoint is used
+    (runs of that single workflow); otherwise runs across all workflows
+    are returned. All filters map directly onto the GitHub Actions API's
+    query parameters.
+
+    Args:
+        owner: Repository owner (org or user).
+        repo: Repository name.
+        workflow: Workflow file name (e.g. ``analysis.yaml``) or numeric
+            workflow id. Empty means all workflows.
+        branch: Filter by head branch. Empty means any branch.
+        event: Filter by triggering event (``push``, ``pull_request``,
+            ``workflow_dispatch``, ``schedule``, ...). Empty means any.
+        status: Filter by status or conclusion (``queued``,
+            ``in_progress``, ``completed``, ``success``, ``failure``,
+            ``cancelled``, ``timed_out``, ...). Empty means any.
+        actor: Filter by the login that triggered the run. Empty means any.
+        limit: Maximum number of runs to return (1-100).
+
+    Returns:
+        dict with ok=True, total_count (GitHub's count of all matches),
+        returned (number in this response), and a workflow_runs list; or
+        an ok=False error dict.
+    """
+    per_page = max(1, min(int(limit or 20), 100))
+    params = [f"per_page={per_page}"]
+    if branch:
+        params.append(f"branch={quote(branch, safe='')}")
+    if event:
+        params.append(f"event={quote(event, safe='')}")
+    if status:
+        params.append(f"status={quote(status, safe='')}")
+    if actor:
+        params.append(f"actor={quote(actor, safe='')}")
+    query = "&".join(params)
+
+    if workflow:
+        path = (f"/repos/{owner}/{repo}/actions/workflows/"
+                f"{quote(str(workflow), safe='')}/runs?{query}")
+    else:
+        path = f"/repos/{owner}/{repo}/actions/runs?{query}"
+
+    result = _github_request("GET", path)
+    if isinstance(result, dict) and result.get("ok") is False:
+        return result
+    if not isinstance(result, dict):
+        return {"ok": False, "error": "Unexpected response listing workflow runs"}
+
+    runs = [_shape_workflow_run(run) for run in result.get("workflow_runs", [])]
+    return {
+        "ok": True,
+        "total_count": result.get("total_count", len(runs)),
+        "returned": len(runs),
+        "workflow_runs": runs,
+    }
+
+
+def get_workflow_run_status(owner: str, repo: str, run_id: int) -> dict:
+    """Fetch a single workflow run together with its jobs and failed steps.
+
+    Args:
+        owner: Repository owner (org or user).
+        repo: Repository name.
+        run_id: The numeric workflow run id.
+
+    Returns:
+        dict with ok=True, a shaped ``run``, a ``jobs`` list (each with its
+        failed_steps), and a ``summary`` (total/failed job counts and the
+        run's status/conclusion); or an ok=False error dict.
+    """
+    run_result = _github_request(
+        "GET", f"/repos/{owner}/{repo}/actions/runs/{run_id}")
+    if isinstance(run_result, dict) and run_result.get("ok") is False:
+        return run_result
+    if not isinstance(run_result, dict):
+        return {"ok": False, "error": "Unexpected response fetching workflow run"}
+
+    jobs_result = _github_request(
+        "GET", f"/repos/{owner}/{repo}/actions/runs/{run_id}/jobs?per_page=100")
+
+    jobs = []
+    failed_jobs = 0
+    if isinstance(jobs_result, dict) and jobs_result.get("ok") is not False:
+        for job in jobs_result.get("jobs", []):
+            shaped = _shape_job(job)
+            if shaped["conclusion"] == "failure":
+                failed_jobs += 1
+            jobs.append(shaped)
+
+    run = _shape_workflow_run(run_result)
+    run["run_started_at"] = run_result.get("run_started_at", "")
+
+    return {
+        "ok": True,
+        "run": run,
+        "jobs": jobs,
+        "summary": {
+            "total_jobs": len(jobs),
+            "failed_jobs": failed_jobs,
+            "status": run_result.get("status", ""),
+            "conclusion": run_result.get("conclusion"),
+        },
+    }

--- a/tools/mcp/manager/server.py
+++ b/tools/mcp/manager/server.py
@@ -4758,6 +4758,114 @@ def github_pr_check_status(
     }
 
 
+@mcp.tool()
+def github_list_workflow_runs(
+    workflow: str = "",
+    branch: str = "",
+    event: str = "",
+    status: str = "",
+    actor: str = "",
+    limit: int = 20,
+    workstream_id: str = "",
+    org: str = "",
+    repo: str = "",
+) -> dict:
+    """Search GitHub Actions workflow runs for a repository.
+
+    Unlike ``github_pr_check_status`` (which is scoped to one PR's HEAD
+    commit), this lists arbitrary workflow runs so a failure that only
+    reproduces in CI can be found and inspected — e.g. every ``failure``
+    run of ``analysis.yaml`` on ``master``, or the most recent
+    ``workflow_dispatch`` runs of a given workflow. Pair it with
+    ``github_workflow_run_status`` to drill into a specific run's jobs.
+
+    Args:
+        workflow: Workflow file name (e.g. ``analysis.yaml``) or numeric
+            workflow id to restrict to a single workflow. Empty (default)
+            lists runs across all workflows.
+        branch: Filter by head branch. Empty (default) means any branch.
+        event: Filter by triggering event (``push``, ``pull_request``,
+            ``workflow_dispatch``, ``schedule``, ...). Empty means any.
+        status: Filter by run status or conclusion (``queued``,
+            ``in_progress``, ``completed``, ``success``, ``failure``,
+            ``cancelled``, ``timed_out``, ...). Empty means any.
+        actor: Filter by the GitHub login that triggered the run. Empty
+            means any.
+        limit: Maximum number of runs to return (1-100). Defaults to 20.
+        workstream_id: Workstream to resolve the repo from. Defaults to
+            the token context.
+        org: GitHub org (owner) to address directly. Must be passed
+            together with ``repo``; bypasses workstream resolution and is
+            checked against the workspace scope gate.
+        repo: GitHub repository name. Must be passed together with ``org``.
+
+    Returns:
+        dict with ok=True, total_count, returned, and a workflow_runs
+        list; or ok=False with error details.
+    """
+    _require_scope("github")
+    if org and repo:
+        _require_org_in_scope(org)
+    owner, repo, _, err = _resolve_github_repo(
+        workstream_id=workstream_id, branch=branch, owner=org, repo=repo,
+    )
+    if err:
+        return err
+
+    _audit("github_list_workflow_runs", workflow=workflow, branch=branch,
+           event=event, status=status, workstream_id=workstream_id)
+
+    return github_api.list_workflow_runs(
+        owner, repo, workflow=workflow, branch=branch, event=event,
+        status=status, actor=actor, limit=limit,
+    )
+
+
+@mcp.tool()
+def github_workflow_run_status(
+    run_id: int,
+    workstream_id: str = "",
+    org: str = "",
+    repo: str = "",
+) -> dict:
+    """Get the status, jobs, and failed steps of a single workflow run.
+
+    Given a run id (from ``github_list_workflow_runs`` or a run URL),
+    fetches the run's outcome and the per-job breakdown, including which
+    steps failed and their log URLs — the detail needed to diagnose a CI
+    failure without a PR context.
+
+    Args:
+        run_id: The numeric workflow run id.
+        workstream_id: Workstream to resolve the repo from. Defaults to
+            the token context.
+        org: GitHub org (owner) to address directly. Must be passed
+            together with ``repo``; bypasses workstream resolution and is
+            checked against the workspace scope gate.
+        repo: GitHub repository name. Must be passed together with ``org``.
+
+    Returns:
+        dict with ok=True, a shaped run, a jobs list (each with its
+        failed_steps and html_url), and a summary (total/failed job counts
+        and the run's status/conclusion); or ok=False with error details.
+    """
+    _require_scope("github")
+    if org and repo:
+        _require_org_in_scope(org)
+    if not run_id:
+        return {"ok": False, "error": "run_id is required"}
+    owner, repo, _, err = _resolve_github_repo(
+        workstream_id=workstream_id, owner=org, repo=repo,
+    )
+    if err:
+        return err
+
+    _audit("github_workflow_run_status", run_id=run_id,
+           workstream_id=workstream_id)
+
+    return github_api.get_workflow_run_status(owner, repo, run_id)
+
+
 # Tracker HTTP helpers are in tracker_client.py (imported above).
 
 # -- Tracker tools -----------------------------------------------------------

--- a/tools/mcp/manager/test_server.py
+++ b/tools/mcp/manager/test_server.py
@@ -4164,6 +4164,102 @@ class TestGithubPrCheckStatus(unittest.TestCase):
 
 
 # -----------------------------------------------------------------------
+# github_list_workflow_runs / github_workflow_run_status
+# -----------------------------------------------------------------------
+
+
+class TestGithubWorkflowRuns(unittest.TestCase):
+    """Tests for the arbitrary workflow-run search and status tools."""
+
+    def setUp(self):
+        _grant_all_scopes()
+
+    @patch.object(server, "_resolve_github_repo",
+                  return_value=("owner", "repo", "master", None))
+    @patch.object(server.github_api, "_github_request")
+    def test_list_runs_shapes_and_applies_filters(self, mock_gh, mock_repo):
+        mock_gh.return_value = {
+            "total_count": 7,
+            "workflow_runs": [
+                {"id": 101, "name": "Build and Test", "event": "push",
+                 "status": "completed", "conclusion": "failure",
+                 "head_branch": "master", "head_sha": "deadbeef",
+                 "run_number": 12, "run_attempt": 2,
+                 "html_url": "https://github.com/owner/repo/actions/runs/101"},
+            ],
+        }
+        result = server.github_list_workflow_runs(
+            branch="master", status="failure", event="push", limit=5)
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["total_count"], 7)
+        self.assertEqual(result["returned"], 1)
+        run = result["workflow_runs"][0]
+        self.assertEqual(run["run_id"], 101)
+        self.assertEqual(run["conclusion"], "failure")
+        self.assertEqual(run["run_attempt"], 2)
+        # Filters and the repo-wide endpoint must reach the API path.
+        path = mock_gh.call_args[0][1]
+        self.assertIn("/repos/owner/repo/actions/runs?", path)
+        self.assertIn("branch=master", path)
+        self.assertIn("status=failure", path)
+        self.assertIn("event=push", path)
+        self.assertIn("per_page=5", path)
+
+    @patch.object(server, "_resolve_github_repo",
+                  return_value=("owner", "repo", "master", None))
+    @patch.object(server.github_api, "_github_request")
+    def test_list_runs_workflow_scoped_endpoint(self, mock_gh, mock_repo):
+        mock_gh.return_value = {"total_count": 0, "workflow_runs": []}
+        result = server.github_list_workflow_runs(workflow="analysis.yaml")
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["returned"], 0)
+        path = mock_gh.call_args[0][1]
+        self.assertIn(
+            "/repos/owner/repo/actions/workflows/analysis.yaml/runs?", path)
+
+    @patch.object(server, "_resolve_github_repo",
+                  return_value=("owner", "repo", "master", None))
+    @patch.object(server.github_api, "_github_request")
+    def test_run_status_reports_jobs_and_failed_steps(self, mock_gh, mock_repo):
+        mock_gh.side_effect = [
+            {"id": 101, "name": "Build and Test", "status": "completed",
+             "conclusion": "failure", "head_branch": "master",
+             "run_started_at": "2026-07-18T00:00:00Z",
+             "html_url": "https://github.com/owner/repo/actions/runs/101"},
+            {"jobs": [
+                {"id": 1, "name": "build", "status": "completed",
+                 "conclusion": "success", "steps": []},
+                {"id": 2, "name": "test (0)", "status": "completed",
+                 "conclusion": "failure", "steps": [
+                     {"name": "Checkout", "number": 1, "conclusion": "success"},
+                     {"name": "Run Tests", "number": 2, "conclusion": "failure"},
+                 ]},
+            ]},
+        ]
+        result = server.github_workflow_run_status(run_id=101)
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["summary"]["total_jobs"], 2)
+        self.assertEqual(result["summary"]["failed_jobs"], 1)
+        self.assertEqual(result["run"]["run_started_at"], "2026-07-18T00:00:00Z")
+        failed = [j for j in result["jobs"] if j["conclusion"] == "failure"]
+        self.assertEqual(len(failed), 1)
+        self.assertEqual(failed[0]["failed_steps"][0]["name"], "Run Tests")
+
+    def test_run_status_requires_run_id(self):
+        result = server.github_workflow_run_status(run_id=0)
+        self.assertFalse(result["ok"])
+        self.assertIn("run_id", result["error"])
+
+    @patch.object(server, "_resolve_github_repo",
+                  return_value=("owner", "repo", "master", None))
+    @patch.object(server.github_api, "_github_request")
+    def test_list_runs_propagates_api_error(self, mock_gh, mock_repo):
+        mock_gh.return_value = {"ok": False, "error": "GitHub returned HTTP 404"}
+        result = server.github_list_workflow_runs()
+        self.assertFalse(result["ok"])
+
+
+# -----------------------------------------------------------------------
 # Tool registration (no duplicate names)
 # -----------------------------------------------------------------------
 
@@ -4217,6 +4313,8 @@ class TestToolRegistration(unittest.TestCase):
             "github_request_copilot_review",
             "github_read_file",
             "github_pr_check_status",
+            "github_list_workflow_runs",
+            "github_workflow_run_status",
             "tracker_list_projects",
             "tracker_create_project",
             "tracker_update_project",


### PR DESCRIPTION
Introduce a "Quality Assurance" CI workflow that submits a FlowTree coding-agent job to review documentation for drift against recent changes and open a PR with any fixes. This extends the existing dev-lifecycle automation (Project Manager, auto-resolve) into a documentation-quality pass.

New files:
- .github/workflows/quality-assurance.yaml
- tools/ci/prompts/build-doc-qa-prompt.sh
- tools/ci/prompts/doc-qa.txt

Behavior:
- Triggers on push to master (every merge) and workflow_dispatch, with a force input to bypass the daily cap. Modeled on project-manager.yaml, reusing register-workstream.sh and submit-agent-job.sh.
- Rate-limited to at most one submission per UTC calendar day via a GitHub Actions cache marker keyed qa-submitted-<YYYYMMDD>: a cache hit skips the run, a miss submits and then saves the marker. A top-level concurrency group serializes runs so the guard is race-free. The marker is saved only after a successful submission, so a failed submit leaves the day open for a later merge to retry.
- On a run that proceeds, creates a qa/docs-<timestamp> branch, registers a workstream, builds the prompt, and submits the agent with AUTO_CREATE_PR=true so fixes land as a pull request.

The prompt directs the agent to review documentation drift across the last week of changes (not a single merge), work outward from changed code to the docs that describe it (module READMEs, docs/ portal, CLAUDE.md files, Javadoc, llms.txt), verify every discrepancy against the actual code, and use ar-consultant. It is scoped to a staleness pass over documentation and Javadoc only, never touching test or CI files, and treats "no drift found" as a valid outcome. The review window is resolved with git rev-list -1 --before so it is reliable on a fresh CI checkout.

ENFORCE_CHANGES is intentionally left unset so a clean-docs run can conclude without forcing a change; such runs open no PR.