### PR TITLE
Skip late bridge signals to released events instead of racing them

### DIFF
--- a/base/hardware/src/main/java/org/almostrealism/hardware/metal/MTLEvent.java
+++ b/base/hardware/src/main/java/org/almostrealism/hardware/metal/MTLEvent.java
@@ -40,16 +40,41 @@ public class MTLEvent extends MTLObject {
 	 * for values up to and including it. The signaled value must never decrease.
 	 *
 	 * @param value Value to signal
+	 * @throws IllegalStateException if the event has been released
 	 */
 	public void setSignaledValue(long value) {
 		MTL.setSignaledValue(getNativePointer(), value);
 	}
 
 	/**
-	 * Releases the native shared event.
+	 * Signals this event to the given value if it has not been released, mutually
+	 * excluded with {@link #release()} so the native object cannot be freed while
+	 * the signal call is in flight.
+	 *
+	 * <p>This is the safe form for a host signal that is delivered asynchronously
+	 * (a completion callback): the event may legitimately be gone by the time the
+	 * callback runs — its sole waiting command buffer already finished by another
+	 * path (an error or teardown completion) and released it — in which case the
+	 * signal has no observer and is skipped rather than throwing or touching freed
+	 * native memory.</p>
+	 *
+	 * @param value Value to signal
+	 * @return true if the event was signaled, false if it was already released
+	 */
+	public synchronized boolean signal(long value) {
+		if (isReleased()) return false;
+		MTL.setSignaledValue(getNativePointer(), value);
+		return true;
+	}
+
+	/**
+	 * Releases the native shared event. Mutually excluded with {@link #signal(long)},
+	 * so a late asynchronous signal observes either a live event or the released
+	 * state — never a freed native pointer mid-call.
 	 */
 	@Override
-	public void release() {
+	public synchronized void release() {
+		if (isReleased()) return;
 		MTL.releaseSharedEvent(getNativePointer());
 		super.release();
 	}

--- a/base/hardware/src/main/java/org/almostrealism/hardware/metal/MetalCommandRunner.java
+++ b/base/hardware/src/main/java/org/almostrealism/hardware/metal/MetalCommandRunner.java
@@ -132,6 +132,13 @@ public class MetalCommandRunner {
 	private volatile long destroyCommits;
 	/** Commits forced so a bridged dispatch starts a fresh buffer. Executor-thread written. */
 	private volatile long bridgeCommits;
+
+	/**
+	 * Foreign-completion signals that arrived after their bridge event was already
+	 * released (the bridged buffer finished by an error or teardown path first).
+	 * Written from completion-callback threads.
+	 */
+	private final AtomicLong lateBridgeSignals = new AtomicLong();
 	/** Number of dispatches encoded into the open buffer. Executor-thread only. */
 	private int openCount;
 	/** Released-memory callbacks for dispatches in the open buffer. Executor-thread only. */
@@ -181,6 +188,16 @@ public class MetalCommandRunner {
 	 * bridge has, moved onto the GPU. With bridges disabled, the foreign dependency is waited
 	 * before the dispatch is encoded.</p>
 	 *
+	 * <p><b>Bridge event lifecycle:</b> the per-bridge event is released with its buffer's
+	 * completion callbacks. On the success path the buffer's encoded wait guarantees the host
+	 * signal already ran before the buffer could complete. A buffer that finishes by another
+	 * path — a GPU error or watchdog kill, or a teardown completion — releases the event while
+	 * the foreign completion callback is still pending, so the callback signals through
+	 * {@link MTLEvent#signal(long)}, which skips a released event instead of touching freed
+	 * native state; such skipped signals are counted by {@link #getLateBridgeSignalCount()}.
+	 * A skipped signal has no observer to lose: the event's only encoded wait was in the
+	 * buffer whose completion released it.</p>
+	 *
 	 * @param requester  metadata of the operation the dispatch belongs to, or {@code null}; carried by
 	 *                   the returned semaphore so a later commit-forcing wait can be attributed to it
 	 * @param command   encodes the kernel into the supplied command buffer
@@ -227,14 +244,17 @@ public class MetalCommandRunner {
 			}
 
 			if (foreign != null) {
-				// Each bridge uses its own event because a host signal releases every encoded
-				// wait at or below the signaled value; sharing an event across bridges would let
-				// an out-of-order foreign completion release another bridge's wait. The event is
-				// released with the buffer, which cannot complete before the wait is satisfied.
+				// Each bridge uses its own event; sharing one would let an out-of-order
+				// foreign completion release another bridge's wait (see the bridging
+				// lifecycle in this method's javadoc).
 				MTLEvent bridge = queue.getDevice().newSharedEvent();
 				openBuffer.encodeWaitForEvent(bridge, 1);
 				openOnComplete.add(bridge::release);
-				foreign.onComplete(() -> bridge.setSignaledValue(1));
+				foreign.onComplete(() -> {
+					if (!bridge.signal(1)) {
+						lateBridgeSignals.incrementAndGet();
+					}
+				});
 			}
 
 			command.encode(openBuffer);
@@ -358,6 +378,17 @@ public class MetalCommandRunner {
 	 * @return the number of commits caused by foreign-dependency bridges
 	 */
 	public long getBridgeCommitCount() { return bridgeCommits; }
+
+	/**
+	 * Returns the number of foreign-completion signals that arrived after their bridge
+	 * event had already been released — the bridged buffer finished by an error or
+	 * teardown path before the foreign work completed. Each is skipped safely by
+	 * {@link MTLEvent#signal(long)}; a persistently non-zero count indicates bridged
+	 * dispatches whose gated work never ran.
+	 *
+	 * @return the number of skipped late bridge signals
+	 */
+	public long getLateBridgeSignalCount() { return lateBridgeSignals.get(); }
 
 	/**
 	 * Commits the open buffer (if any) and moves it to the committed list. Does not wait for

--- a/engine/utils/src/test/java/org/almostrealism/hardware/test/MTLEventLifecycleTest.java
+++ b/engine/utils/src/test/java/org/almostrealism/hardware/test/MTLEventLifecycleTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026 Michael Murray
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.almostrealism.hardware.test;
+
+import org.almostrealism.hardware.metal.MTLEvent;
+import org.almostrealism.hardware.metal.MetalComputeContext;
+import org.almostrealism.util.TestSuiteBase;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Pins the {@link MTLEvent} signal/release lifecycle contract that
+ * {@code MetalCommandRunner}'s foreign-dependency bridging relies on.
+ *
+ * <p>A bridge signals its event from a completion callback that runs whenever the
+ * foreign work finishes, while the event is released with its command buffer's
+ * completion. On the success path the buffer's encoded wait orders the signal
+ * before the release, but a buffer that finishes by an error or teardown path
+ * releases the event first — previously the late callback then threw
+ * {@code IllegalStateException} from {@code setSignaledValue} (observed
+ * intermittently as {@code Exception in thread "Semaphore onComplete"}), and
+ * because release and signal were unsynchronized, the same window could reach
+ * freed native state. {@link MTLEvent#signal(long)} closes both: it skips a
+ * released event and is mutually excluded with {@link MTLEvent#release()}.</p>
+ */
+public class MTLEventLifecycleTest extends TestSuiteBase {
+
+	/**
+	 * Returns a fresh shared event, or null when no Metal device is available.
+	 */
+	private MTLEvent newEvent() {
+		MetalComputeContext metal = SemaphoreChainBatchingTest.metalContext();
+		if (metal == null) return null;
+		return metal.getMtlDevice().newSharedEvent();
+	}
+
+	/**
+	 * The normal bridge order: signal from the completion callback, then release
+	 * with the buffer. Release is idempotent, matching the destroy paths that can
+	 * run completion callbacks for a buffer more than one teardown route reaches.
+	 */
+	@Test(timeout = 60000)
+	public void signalThenReleaseSucceeds() {
+		MTLEvent event = newEvent();
+		if (event == null) {
+			log("Skipping signalThenReleaseSucceeds - no Metal device");
+			return;
+		}
+
+		Assert.assertTrue("A live event must accept the signal", event.signal(1));
+		event.release();
+		Assert.assertTrue(event.isReleased());
+		event.release();
+		Assert.assertTrue(event.isReleased());
+	}
+
+	/**
+	 * The race order this contract exists for: the buffer finished by another path
+	 * and released the event before the foreign completion callback ran. The late
+	 * signal must report false without throwing.
+	 */
+	@Test(timeout = 60000)
+	public void lateSignalAfterReleaseIsSkipped() {
+		MTLEvent event = newEvent();
+		if (event == null) {
+			log("Skipping lateSignalAfterReleaseIsSkipped - no Metal device");
+			return;
+		}
+
+		event.release();
+		Assert.assertFalse("A released event must skip the signal", event.signal(1));
+	}
+
+	/**
+	 * The legacy unguarded form keeps its documented contract: signaling a
+	 * released event through {@link MTLEvent#setSignaledValue(long)} throws.
+	 */
+	@Test(timeout = 60000)
+	public void setSignaledValueAfterReleaseStillThrows() {
+		MTLEvent event = newEvent();
+		if (event == null) {
+			log("Skipping setSignaledValueAfterReleaseStillThrows - no Metal device");
+			return;
+		}
+
+		event.release();
+
+		try {
+			event.setSignaledValue(1);
+			Assert.fail("setSignaledValue on a released event must throw");
+		} catch (IllegalStateException e) {
+			log("setSignaledValue correctly threw after release");
+		}
+	}
+}


### PR DESCRIPTION
The foreign-dependency bridge in MetalCommandRunner.submit encodes a GPU wait on a fresh per-bridge MTLSharedEvent, releases the event with its command buffer's completion callbacks, and signals it from the host via Semaphore.onComplete when the foreign work finishes. The release ordering relied on the buffer's encoded wait: a buffer cannot complete before the signal, so release always follows it. That invariant only holds on the success path — neither completion path (completeOnExecutor, destroy) checks the buffer's status after waitUntilCompleted, so a buffer that finishes by another route (a GPU error or watchdog kill, or a teardown completion) releases the event while the foreign completion callback is still pending. The late callback then threw IllegalStateException from setSignaledValue, observed intermittently as "Exception in thread Semaphore onComplete" in five of the fifty stored test runs, spanning multiple sessions and unmodified baselines. Worse, release and signal were entirely unsynchronized over a plain boolean, so the same window could free the native shared event while setSignaledValue was mid-call — the observed exception was the benign interleaving of a potential native use-after-free.

MTLEvent gains signal(value): synchronized with release() on the event's monitor, it skips a released event and reports whether it signaled. Skipping is correct rather than masking — each bridge event's only encoded wait lives in the one buffer whose completion released it, so a late signal has no observer to lose. release() is now idempotent, and the bridge callback counts skipped signals (getLateBridgeSignalCount): a persistently non-zero count means bridged dispatches whose gated work never ran, which is the trail for the remaining follow-up — the completion paths still treat an errored or killed buffer like a successful one when running its released-memory callbacks, and surfacing buffer status there is a separate change. The bridge event lifecycle is now documented on submit().

MTLEventLifecycleTest pins the contract: signal-then-release, the late-signal skip (the regression case), release idempotence, and the unchanged throwing behavior of the legacy setSignaledValue form. It and the bridge-sensitive suites (SemaphoreChainBatchingTest, ArgumentPreparationChainTest, SemaphoreCompositionTest, AssignmentSemaphoreChainTest, CommitCauseMeasurementTest, DestinationReuseTest) all pass; checkstyle is clean.