### PR TITLE
Fix genome-activation latch left permanently set by a failed activation

### DIFF
--- a/studio/compose/src/main/java/org/almostrealism/studio/optimize/AudioScenePopulation.java
+++ b/studio/compose/src/main/java/org/almostrealism/studio/optimize/AudioScenePopulation.java
@@ -189,16 +189,26 @@ public class AudioScenePopulation implements Population<PackedCollection, Tempor
 	 * Enables the given genome as the active genome for the current evaluation,
 	 * verifying that no other genome is already active.
 	 *
+	 * <p>The active-genome latch is recorded only after the scene has accepted
+	 * the genome. A failed assignment (an incompatible genome, or a failure
+	 * inside the scene's parameter refresh) therefore leaves this population
+	 * ready for the next genome — previously the latch was set first, so one
+	 * failed genome caused every later {@code enableGenome} in an optimizer
+	 * batch to throw the already-active {@link IllegalStateException},
+	 * flooding the log with latch errors that hid the one real failure.</p>
+	 *
 	 * @param newGenome the genome to activate
 	 * @throws IllegalStateException if a genome is already active
 	 */
 	private void enableGenome(Genome newGenome) {
 		if (currentGenome != null) {
-			throw new IllegalStateException();
+			throw new IllegalStateException(
+					"A genome is already active; disableGenome must run before" +
+					" another genome can be enabled");
 		}
 
+		scene.assignGenome((ProjectedGenome) newGenome);
 		currentGenome = newGenome;
-		scene.assignGenome((ProjectedGenome) currentGenome);
 	}
 
 	@Override

--- a/studio/compose/src/test/java/org/almostrealism/studio/optimize/test/AudioScenePopulationLatchTest.java
+++ b/studio/compose/src/test/java/org/almostrealism/studio/optimize/test/AudioScenePopulationLatchTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 Michael Murray
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.almostrealism.studio.optimize.test;
+
+import org.almostrealism.audio.line.OutputLine;
+import org.almostrealism.audio.tone.DefaultKeyboardTuning;
+import org.almostrealism.collect.PackedCollection;
+import org.almostrealism.heredity.Genome;
+import org.almostrealism.heredity.ProjectedGenome;
+import org.almostrealism.studio.AudioScene;
+import org.almostrealism.studio.health.StableDurationHealthComputation;
+import org.almostrealism.studio.optimize.AudioScenePopulation;
+import org.almostrealism.util.TestSuiteBase;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Verifies that a genome whose activation fails does not leave
+ * {@link AudioScenePopulation} with its active-genome latch stuck.
+ *
+ * <p>The latch was previously recorded before the scene accepted the genome, so
+ * one incompatible genome (or any failure inside the scene's parameter refresh)
+ * caused every later {@code enableGenome} in an optimizer batch to throw the
+ * already-active {@link IllegalStateException} — an entire "Run N Cycle(s)"
+ * batch producing nothing but latch errors after a single real failure. The
+ * latch must only be set once activation succeeds, so each genome's failure
+ * surfaces its own cause and the next genome gets a clean attempt.</p>
+ */
+public class AudioScenePopulationLatchTest extends TestSuiteBase {
+
+	/**
+	 * Activates an incompatible genome (whose parameter assignment fails), then
+	 * confirms the population still accepts a compatible genome afterwards.
+	 */
+	@Test(timeout = 120000)
+	public void failedGenomeDoesNotStickTheLatch() {
+		AudioScene<?> scene = new AudioScene<>(120.0, 2,
+				AudioScene.DEFAULT_DELAY_LAYERS, OutputLine.sampleRate);
+		scene.setTuning(new DefaultKeyboardTuning());
+
+		Genome<PackedCollection> compatible = scene.getGenome();
+		Genome<PackedCollection> incompatible =
+				new ProjectedGenome(new PackedCollection(1));
+
+		List<Genome<PackedCollection>> genomes = new ArrayList<>();
+		genomes.add(compatible);
+
+		AudioScenePopulation pop = new AudioScenePopulation(scene, genomes);
+		StableDurationHealthComputation health =
+				new StableDurationHealthComputation(2, true);
+
+		try {
+			try {
+				pop.init(incompatible, health.getOutput(), null, health.getBatchSize());
+				Assert.fail("Initializing with an incompatible genome must fail");
+			} catch (IllegalArgumentException e) {
+				log("Incompatible genome rejected as expected");
+			}
+
+			Assert.assertTrue(
+					"A compatible genome must be accepted after a failed activation",
+					pop.validateGenome(compatible));
+
+			try {
+				pop.init(incompatible, health.getOutput(), null, health.getBatchSize());
+				Assert.fail("A repeated incompatible genome must fail the same way");
+			} catch (IllegalArgumentException e) {
+				log("Incompatible genome rejected again, not masked by a stuck latch");
+			}
+
+			Assert.assertTrue(
+					"Validation must keep succeeding after repeated failures",
+					pop.validateGenome(compatible));
+		} finally {
+			pop.destroy();
+			health.destroy();
+			scene.destroy();
+		}
+	}
+}


### PR DESCRIPTION
Triage of the Rings 0.40 heapless run identified four distinct failure axes, recorded in ringsdesktop's docs/plans/DESKTOP_ISSUES.md (F1 library-tree NPE and F4 device-wiring/zero-frame writes in ringsdesktop, F2 enableGenome latch and F3 "Already allocated" tracking collisions in common). None is Memory Max Reached — the memory fix held, and the longer runs it enables are why these surfaced. This commit fixes F2; F1 is fixed by a companion ringsdesktop commit (which also adds the triage document); F3 and F4 are documented with next steps but not yet addressed.

F2: AudioScenePopulation.enableGenome recorded currentGenome before scene.assignGenome(...) ran, so any activation failure (in the failing run, the F1 NPE reaching refreshParameters) left the latch permanently set. Every subsequent enableGenome in the optimizer batch then threw a bare IllegalStateException — the log's endless identical stacks, which buried the single real failure. The latch is now set only after assignment succeeds, so each genome's failure surfaces its own cause and the next genome gets a clean attempt. The guard exception also carries a message now instead of being bare.

The new AudioScenePopulationLatchTest activates an incompatible genome (ProjectedGenome over a 1-element collection), expects the IllegalArgumentException, and then requires validateGenome(compatible) to still succeed — twice, to show repeated failures do not accumulate state. The test was A/B validated: with the fix stashed it fails at exactly the stuck-latch assertion; with the fix applied it passes. Both runs were against freshly rebuilt master artifacts.

This latch ordering predates the memory/Heap work on the other branches; the fix applies directly to master and is independent of them.