### PR TITLE
Bound orchestrator wake-up bursts with debounce and dormancy gate

### DIFF
--- a/flowtree/runtime/src/main/java/io/flowtree/api/FlowTreeApiEndpoint.java
+++ b/flowtree/runtime/src/main/java/io/flowtree/api/FlowTreeApiEndpoint.java
@@ -180,7 +180,6 @@ public class FlowTreeApiEndpoint extends NanoHTTPD implements ConsoleFeatures {
      * harness cannot crash the controller.
      */
     private CompletionListenerFanout completionListenerFanout;
-
     /** Base URL of the ar-memory HTTP server (e.g., "http://localhost:8020"). */
     private String memoryServerUrl;
     /** Base URL of the ar-manager HTTP server (e.g., "http://ar-manager:8010"). */
@@ -1162,14 +1161,22 @@ public class FlowTreeApiEndpoint extends NanoHTTPD implements ConsoleFeatures {
             targetNotifier.onJobStarted(workstreamId, event);
         } else {
             targetNotifier.onJobCompleted(workstreamId, event);
-            // Fan the terminal completion out to every completion
-            // listener of the source workstream. This is the single
-            // entry point the listener-graph uses to spawn wake-up
-            // jobs; it never throws, so a misbehaving listener cannot
-            // poison the source job's completion recording. The
-            // fanout is a no-op when the workstream has no listeners,
-            // so the inert default (the v0 behavior) is preserved
-            // automatically.
+            // Wake-up completion: clear the listener's debounce so
+            // a fast-completing wake-up does not artificially
+            // extend the debounce window (over-debouncing would
+            // defeat the "genuinely new event still wakes the
+            // orchestrator" correctness property). The fan-out
+            // inspects the description and only acts on wake-up
+            // completions.
+            if (completionListenerFanout != null) {
+                completionListenerFanout.notifyListenerWakeUpCompleted(
+                        workstreamId, event.getDescription());
+            }
+            // Fan the terminal completion out to every listener of
+            // the source workstream; never throws, so a
+            // misbehaving listener cannot poison the source job's
+            // completion recording. No-op when the workstream has
+            // no listeners, so the inert default is preserved.
             if (completionListenerFanout != null) {
                 try {
                     completionListenerFanout.fanout(workstreamId, event);
@@ -1179,7 +1186,6 @@ public class FlowTreeApiEndpoint extends NanoHTTPD implements ConsoleFeatures {
                 }
             }
         }
-
         return newFixedLengthResponse(Response.Status.OK,
                 "application/json", "{\"ok\":true}");
     }
@@ -1207,374 +1213,7 @@ public class FlowTreeApiEndpoint extends NanoHTTPD implements ConsoleFeatures {
         }
     }
 
-    /**
-     * Applies {@code value} to {@code setter} and converts any
-     * {@link IllegalArgumentException} thrown by the setter into a 400
-     * response built by {@code errorBuilder} so request handlers can
-     * short-circuit with a single {@code return}.  Returns {@code null}
-     * (no error) when the value is empty or successfully applied.
-     *
-     * @param value        the candidate value, or {@code null}/empty for a no-op
-     * @param setter       the setter to invoke on the candidate value
-     * @param errorBuilder factory that wraps a message into a 400 response
-     * @return an error response, or {@code null} on success
-     */
-    static Response applyValidated(String value, Consumer<String> setter,
-                                   Function<String, Response> errorBuilder) {
-        if (value == null || value.isEmpty()) return null;
-        try {
-            setter.accept(value);
-            return null;
-        } catch (IllegalArgumentException e) {
-            return errorBuilder.apply(e.getMessage());
-        }
-    }
-
-    /**
-     * Convenience overload of {@link #applyValidated(String, Consumer, Function)}
-     * that uses this endpoint's own 400-response factory.
-     *
-     * @param value  the candidate value
-     * @param setter the setter to invoke on the candidate value
-     * @return an error response, or {@code null} on success
-     */
-    private Response applyValidated(String value, Consumer<String> setter) {
-        return applyValidated(value, setter, this::errorResponse);
-    }
-
-    /**
-     * Creates an error response with the specified message.
-     */
-    private Response errorResponse(String message) {
-        String json = "{\"ok\":false,\"error\":\"" + JsonFieldExtractor.escapeJson(message) + "\"}";
-        return newFixedLengthResponse(Response.Status.BAD_REQUEST,
-                "application/json", json);
-    }
-
-    /**
-     * Delegates to {@link io.flowtree.JsonFieldExtractor#hasField(String, String)}.
-     */
-    static boolean extractJsonHasField(String json, String field) {
-        return JsonFieldExtractor.hasField(json, field);
-    }
-
-    /**
-     * Delegates to {@link io.flowtree.JsonFieldExtractor#extractString(String, String)}.
-     */
-    public static String extractJsonField(String json, String field) {
-        return JsonFieldExtractor.extractString(json, field);
-    }
-
-    /**
-     * Delegates to {@link io.flowtree.JsonFieldExtractor#extractBoolean(String, String)}.
-     */
-    static boolean extractJsonBooleanField(String json, String field) {
-        return JsonFieldExtractor.extractBoolean(json, field);
-    }
-
-    /**
-     * Delegates to {@link io.flowtree.JsonFieldExtractor#extractInt(String, String)}.
-     */
-    static int extractJsonIntField(String json, String field) {
-        return JsonFieldExtractor.extractInt(json, field);
-    }
-
-    /**
-     * Delegates to {@link io.flowtree.JsonFieldExtractor#extractLong(String, String)}.
-     */
-    static long extractJsonLongField(String json, String field) {
-        return JsonFieldExtractor.extractLong(json, field);
-    }
-
-    /**
-     * Delegates to {@link io.flowtree.JsonFieldExtractor#extractDouble(String, String)}.
-     */
-    static double extractJsonDoubleField(String json, String field) {
-        return JsonFieldExtractor.extractDouble(json, field);
-    }
-
-    /**
-     * Delegates to {@link io.flowtree.JsonFieldExtractor#extractStringArray(String, String)}.
-     */
-    static List<String> extractJsonArrayField(String json, String field) {
-        return JsonFieldExtractor.extractStringArray(json, field);
-    }
-
-    /**
-     * Delegates to {@link io.flowtree.JsonFieldExtractor#extractStringObject(String, String)}.
-     */
-    static Map<String, String> extractJsonObjectFields(String json, String field) {
-        return JsonFieldExtractor.extractStringObject(json, field);
-    }
-
-    /**
-     * Computes the effective agent environment for a submission: the workstream's static
-     * {@code agentEnv} with any per-submission {@code agentEnv} from the request body merged on top
-     * (submission wins on key collisions). This is what lets a caller inject dynamic, per-job
-     * environment — e.g. a short-lived bearer token minted per job — that cannot live in static
-     * workstream config. Either input may be {@code null}/absent.
-     *
-     * @param workstreamEnv the workstream's configured agentEnv, or {@code null}
-     * @param body          the raw submission JSON body (may contain an {@code agentEnv} object)
-     * @return a new merged map (never {@code null})
-     */
-    static Map<String, String> mergeAgentEnv(Map<String, String> workstreamEnv, String body) {
-        Map<String, String> effective = new HashMap<>();
-        if (workstreamEnv != null) {
-            effective.putAll(workstreamEnv);
-        }
-        Map<String, String> submissionAgentEnv = extractJsonObjectFields(body, "agentEnv");
-        if (submissionAgentEnv != null) {
-            effective.putAll(submissionAgentEnv);
-        }
-        return effective;
-    }
-
-    /**
-     * Builds the {@code 500} response returned when an operation mutated
-     * workstream config in memory but the YAML write failed. Centralised so
-     * endpoints can report a non-durable write identically — never as success —
-     * honouring the rule that an operation should not confirm completion
-     * before the workstreams file is written.
-     *
-     * @param operation a short label for the attempted operation (e.g. {@code "Archive"})
-     * @return an {@code ok:false} 500 response describing the failed persist
-     */
-    static Response persistFailureResponse(String operation) {
-        return newFixedLengthResponse(Response.Status.INTERNAL_ERROR,
-                "application/json",
-                "{\"ok\":false,\"error\":" + escapeJsonValue(operation
-                    + " applied in memory but the workstreams config could not be written to"
-                    + " disk; the change is not durable and would be lost on restart. Retry.")
-                + "}");
-    }
-
-    /**
-     * Escapes a string as a JSON string value (with surrounding quotes).
-     * Shared by every handler in this package so the JSON shape produced by
-     * one endpoint is identical to the next.
-     *
-     * @param s the string to escape
-     * @return the JSON-escaped quoted string
-     */
-    static String escapeJsonValue(String s) {
-        StringBuilder sb = new StringBuilder(s.length() + 16);
-        sb.append('"');
-        for (int i = 0; i < s.length(); i++) {
-            char c = s.charAt(i);
-            switch (c) {
-                case '"': sb.append("\\\""); break;
-                case '\\': sb.append("\\\\"); break;
-                case '\n': sb.append("\\n"); break;
-                case '\r': sb.append("\\r"); break;
-                case '\t': sb.append("\\t"); break;
-                default:
-                    if (c < 0x20) {
-                        sb.append(String.format("\\u%04x", (int) c));
-                    } else {
-                        sb.append(c);
-                    }
-            }
-        }
-        sb.append('"');
-        return sb.toString();
-    }
-
-    /**
-     * Serialises a {@link JobCompletionEvent} to a JSON object string.
-     *
-     * @param event the event to serialise
-     * @return JSON object string
-     */
-    private String jobEventToJson(JobCompletionEvent event) {
-        return jobEventToJson(event, null);
-    }
-
-    /**
-     * Serialises a {@link JobCompletionEvent} to a JSON object string,
-     * optionally including the owning workstream identifier.
-     *
-     * @param event         the event to serialise
-     * @param workstreamId  the workstream that owns this job, or {@code null}
-     * @return JSON object string
-     */
-    private String jobEventToJson(JobCompletionEvent event, String workstreamId) {
-        StringBuilder j = new StringBuilder();
-        j.append("{");
-        j.append("\"jobId\":\"").append(JsonFieldExtractor.escapeJson(event.getJobId())).append("\"");
-        j.append(",\"status\":\"").append(event.getStatus().name()).append("\"");
-        j.append(",\"description\":\"").append(JsonFieldExtractor.escapeJson(event.getDescription())).append("\"");
-        j.append(",\"timestamp\":\"").append(event.getTimestamp().toString()).append("\"");
-        if (workstreamId != null) {
-            j.append(",\"workstreamId\":\"").append(JsonFieldExtractor.escapeJson(workstreamId)).append("\"");
-        }
-        if (event.getTargetBranch() != null) {
-            j.append(",\"targetBranch\":\"").append(JsonFieldExtractor.escapeJson(event.getTargetBranch())).append("\"");
-        }
-        if (event.getCommitHash() != null) {
-            j.append(",\"commitHash\":\"").append(JsonFieldExtractor.escapeJson(event.getCommitHash())).append("\"");
-        }
-        if (event.getPullRequestUrl() != null) {
-            j.append(",\"pullRequestUrl\":\"").append(JsonFieldExtractor.escapeJson(event.getPullRequestUrl())).append("\"");
-        }
-        if (event.getErrorMessage() != null) {
-            j.append(",\"errorMessage\":\"").append(JsonFieldExtractor.escapeJson(event.getErrorMessage())).append("\"");
-        }
-        double totalCost = event.getTotalCostUsd();
-        boolean costIncomplete = event.isCostIncomplete();
-        // Always emit costIncomplete as a stable boolean, matching
-        // JobCompletionEvent.toJson() and the documented wire shape so consumers
-        // never have to treat its absence as false.
-        j.append(",\"costIncomplete\":").append(costIncomplete);
-        // Emit the cost block when there is a positive total OR when the cost is
-        // incomplete: an inactivity-killed session can leave totalCost at 0 even
-        // though real (uncosted) work happened, and the total/breakdowns should
-        // still be surfaced as a lower bound.
-        if (totalCost > 0 || costIncomplete) {
-            j.append(String.format(",\"totalCostUsd\":%.2f", totalCost));
-            Map<String, Double> costByRunner = event.getCostByRunner();
-            if (costByRunner != null && !costByRunner.isEmpty()) {
-                j.append(",\"costByRunner\":{");
-                boolean first = true;
-                for (Map.Entry<String, Double> e : costByRunner.entrySet()) {
-                    if (!first) j.append(",");
-                    first = false;
-                    j.append("\"").append(JsonFieldExtractor.escapeJson(e.getKey())).append("\":")
-                        .append(String.format("%.2f", e.getValue() != null ? e.getValue() : 0.0));
-                }
-                j.append("}");
-            }
-            Map<String, Double> costByModel = event.getCostByModel();
-            if (costByModel != null && !costByModel.isEmpty()) {
-                j.append(",\"costByModel\":{");
-                boolean first = true;
-                for (Map.Entry<String, Double> e : costByModel.entrySet()) {
-                    if (!first) j.append(",");
-                    first = false;
-                    j.append("\"").append(JsonFieldExtractor.escapeJson(e.getKey())).append("\":")
-                        .append(String.format("%.2f", e.getValue() != null ? e.getValue() : 0.0));
-                }
-                j.append("}");
-            }
-        }
-        j.append("}");
-        return j.toString();
-    }
-
-    /**
-     * Handles {@code GET /api/workstreams/{id}/jobs?limit=N}.
-     * Returns the most recent jobs for the workstream, newest first.
-     *
-     * @param workstreamId the workstream identifier
-     * @param limit        maximum number of jobs to return
-     * @return JSON array of job events
-     */
-    private Response handleListJobs(String workstreamId, int limit) {
-        SlackNotifier n = notifiers.notifierFor(workstreamId);
-        List<JobCompletionEvent> page = n != null
-                ? n.getRecentJobs(workstreamId, limit) : new ArrayList<>();
-
-        StringBuilder json = new StringBuilder("[");
-        boolean first = true;
-        for (JobCompletionEvent event : page) {
-            if (!first) json.append(",");
-            first = false;
-            json.append(jobEventToJson(event));
-        }
-        json.append("]");
-
-        return newFixedLengthResponse(Response.Status.OK, "application/json", json.toString());
-    }
-
-    /**
-     * Handles {@code GET /api/jobs/{jobId}}.
-     * Returns the most recent event for the specified job.
-     *
-     * @param jobId the job identifier
-     * @return JSON object for the job event, or 404 if not found
-     */
-    private Response handleGetJob(String jobId) {
-        JobCompletionEvent event = notifiers.findJob(jobId);
-        if (event == null) {
-            return newFixedLengthResponse(Response.Status.NOT_FOUND,
-                    "application/json", "{\"ok\":false,\"error\":\"Job not found\"}");
-        }
-        String workstreamId = notifiers.findWorkstreamIdForJob(jobId);
-        return newFixedLengthResponse(Response.Status.OK,
-                "application/json", jobEventToJson(event, workstreamId));
-    }
-
-    /**
-     * Handles {@code GET /api/workstreams}. Returns a JSON array of all
-     * registered workstreams with their configuration and capabilities.
-     *
-     * <p>By default, workstreams flagged as archived are omitted. Pass
-     * {@code ?includeArchived=true} to include them; archived entries
-     * carry an {@code "archived": true} field in the response.</p>
-     *
-     * @param includeArchived when {@code false} archived workstreams are skipped
-     * @return an HTTP 200 response containing a JSON array of workstream objects
-     */
-    private Response handleListWorkstreams(boolean includeArchived) {
-        Map<String, Workstream> workstreams = notifiers.allWorkstreams();
-        StringBuilder json = new StringBuilder("[");
-        boolean first = true;
-        for (Workstream ws : workstreams.values()) {
-            if (!includeArchived && ws.isArchived()) continue;
-            if (!first) json.append(",");
-            first = false;
-            json.append(ws.toSummaryJson());
-        }
-        json.append("]");
-        return newFixedLengthResponse(Response.Status.OK,
-                "application/json", json.toString());
-    }
-
-    /**
-     * Builds the archive/unarchive/delete handler bound to this endpoint's
-     * notifiers and listener. See {@link WorkstreamLifecycleHandler}.
-     */
-    private WorkstreamLifecycleHandler lifecycleHandler() {
-        return new WorkstreamLifecycleHandler(notifiers, listener, this::readBody,
-                this::errorResponse, this::log);
-    }
-
-    /** Builds the {@code /api/workspaces/{id}/config} handler bound to this endpoint. */
-    private WorkspaceConfigHandler workspaceConfigHandler() {
-        return new WorkspaceConfigHandler(workspaceLookup, workspaceRenameHook,
-                listener, this::readBody, this::errorResponse, this::log);
-    }
-
-    /**
-     * Builds the workstream-message endpoint handler bound to this endpoint.
-     * See {@link MessageEndpointHandler}.
-     *
-     * @return a fresh handler reflecting the current memory-server URL and
-     *         notifier registry
-     */
-    private MessageEndpointHandler messageEndpointHandler() {
-        return new MessageEndpointHandler(notifiers, memoryServerUrl,
-                this::readBody, this::errorResponse, this::log, this::warn);
-    }
-
-    /**
-     * Builds the workstream registration/update endpoint handler bound to this endpoint.
-     * See {@link WorkstreamRegistrationHandler}.
-     *
-     * @return a fresh handler reflecting the current notifier registry,
-     *         org-to-workspace map, and listener
-     */
-    private WorkstreamRegistrationHandler workstreamRegistrationHandler() {
-        return new WorkstreamRegistrationHandler(notifiers, orgToWorkspaceId,
-                listener, this::readBody, this::errorResponse, this::log);
-    }
-
-    /**
-     * Handles {@code GET /api/stats}. Delegates to {@link StatsQueryHandler}.
-     *
-     * @param session the HTTP session supplying query parameters
-     * @return an HTTP response containing weekly stats JSON
-     */
+    // TODO(review): deleted helper methods still referenced below (build-breaking); see review-followup memory.
     private Response handleStatsQuery(IHTTPSession session) {
         StatsQueryHandler handler = statsQueryHandler != null
             ? statsQueryHandler : new StatsQueryHandler(null);

--- a/flowtree/runtime/src/main/java/io/flowtree/api/FlowTreeApiEndpoint.java
+++ b/flowtree/runtime/src/main/java/io/flowtree/api/FlowTreeApiEndpoint.java
@@ -1161,22 +1161,19 @@ public class FlowTreeApiEndpoint extends NanoHTTPD implements ConsoleFeatures {
             targetNotifier.onJobStarted(workstreamId, event);
         } else {
             targetNotifier.onJobCompleted(workstreamId, event);
-            // Wake-up completion: clear the listener's debounce so
-            // a fast-completing wake-up does not artificially
-            // extend the debounce window (over-debouncing would
-            // defeat the "genuinely new event still wakes the
-            // orchestrator" correctness property). The fan-out
-            // inspects the description and only acts on wake-up
-            // completions.
+            // Wake-up completion: clear the listener's debounce so a
+            // fast-completing wake-up does not artificially extend the
+            // window (over-debouncing would defeat the "genuinely new
+            // event still wakes the orchestrator" property). The fan-out
+            // inspects the description and only acts on wake-up completions.
             if (completionListenerFanout != null) {
                 completionListenerFanout.notifyListenerWakeUpCompleted(
                         workstreamId, event.getDescription());
             }
-            // Fan the terminal completion out to every listener of
-            // the source workstream; never throws, so a
-            // misbehaving listener cannot poison the source job's
-            // completion recording. No-op when the workstream has
-            // no listeners, so the inert default is preserved.
+            // Fan the terminal completion out to every listener of the
+            // source workstream; never throws, so a misbehaving listener
+            // cannot poison the source job's completion recording. No-op
+            // when the workstream has no listeners (the inert default).
             if (completionListenerFanout != null) {
                 try {
                     completionListenerFanout.fanout(workstreamId, event);
@@ -1213,7 +1210,374 @@ public class FlowTreeApiEndpoint extends NanoHTTPD implements ConsoleFeatures {
         }
     }
 
-    // TODO(review): deleted helper methods still referenced below (build-breaking); see review-followup memory.
+    /**
+     * Applies {@code value} to {@code setter} and converts any
+     * {@link IllegalArgumentException} thrown by the setter into a 400
+     * response built by {@code errorBuilder} so request handlers can
+     * short-circuit with a single {@code return}.  Returns {@code null}
+     * (no error) when the value is empty or successfully applied.
+     *
+     * @param value        the candidate value, or {@code null}/empty for a no-op
+     * @param setter       the setter to invoke on the candidate value
+     * @param errorBuilder factory that wraps a message into a 400 response
+     * @return an error response, or {@code null} on success
+     */
+    static Response applyValidated(String value, Consumer<String> setter,
+                                   Function<String, Response> errorBuilder) {
+        if (value == null || value.isEmpty()) return null;
+        try {
+            setter.accept(value);
+            return null;
+        } catch (IllegalArgumentException e) {
+            return errorBuilder.apply(e.getMessage());
+        }
+    }
+
+    /**
+     * Convenience overload of {@link #applyValidated(String, Consumer, Function)}
+     * that uses this endpoint's own 400-response factory.
+     *
+     * @param value  the candidate value
+     * @param setter the setter to invoke on the candidate value
+     * @return an error response, or {@code null} on success
+     */
+    private Response applyValidated(String value, Consumer<String> setter) {
+        return applyValidated(value, setter, this::errorResponse);
+    }
+
+    /**
+     * Creates an error response with the specified message.
+     */
+    private Response errorResponse(String message) {
+        String json = "{\"ok\":false,\"error\":\"" + JsonFieldExtractor.escapeJson(message) + "\"}";
+        return newFixedLengthResponse(Response.Status.BAD_REQUEST,
+                "application/json", json);
+    }
+
+    /**
+     * Delegates to {@link io.flowtree.JsonFieldExtractor#hasField(String, String)}.
+     */
+    static boolean extractJsonHasField(String json, String field) {
+        return JsonFieldExtractor.hasField(json, field);
+    }
+
+    /**
+     * Delegates to {@link io.flowtree.JsonFieldExtractor#extractString(String, String)}.
+     */
+    public static String extractJsonField(String json, String field) {
+        return JsonFieldExtractor.extractString(json, field);
+    }
+
+    /**
+     * Delegates to {@link io.flowtree.JsonFieldExtractor#extractBoolean(String, String)}.
+     */
+    static boolean extractJsonBooleanField(String json, String field) {
+        return JsonFieldExtractor.extractBoolean(json, field);
+    }
+
+    /**
+     * Delegates to {@link io.flowtree.JsonFieldExtractor#extractInt(String, String)}.
+     */
+    static int extractJsonIntField(String json, String field) {
+        return JsonFieldExtractor.extractInt(json, field);
+    }
+
+    /**
+     * Delegates to {@link io.flowtree.JsonFieldExtractor#extractLong(String, String)}.
+     */
+    static long extractJsonLongField(String json, String field) {
+        return JsonFieldExtractor.extractLong(json, field);
+    }
+
+    /**
+     * Delegates to {@link io.flowtree.JsonFieldExtractor#extractDouble(String, String)}.
+     */
+    static double extractJsonDoubleField(String json, String field) {
+        return JsonFieldExtractor.extractDouble(json, field);
+    }
+
+    /**
+     * Delegates to {@link io.flowtree.JsonFieldExtractor#extractStringArray(String, String)}.
+     */
+    static List<String> extractJsonArrayField(String json, String field) {
+        return JsonFieldExtractor.extractStringArray(json, field);
+    }
+
+    /**
+     * Delegates to {@link io.flowtree.JsonFieldExtractor#extractStringObject(String, String)}.
+     */
+    static Map<String, String> extractJsonObjectFields(String json, String field) {
+        return JsonFieldExtractor.extractStringObject(json, field);
+    }
+
+    /**
+     * Computes the effective agent environment for a submission: the workstream's static
+     * {@code agentEnv} with any per-submission {@code agentEnv} from the request body merged on top
+     * (submission wins on key collisions). This is what lets a caller inject dynamic, per-job
+     * environment — e.g. a short-lived bearer token minted per job — that cannot live in static
+     * workstream config. Either input may be {@code null}/absent.
+     *
+     * @param workstreamEnv the workstream's configured agentEnv, or {@code null}
+     * @param body          the raw submission JSON body (may contain an {@code agentEnv} object)
+     * @return a new merged map (never {@code null})
+     */
+    static Map<String, String> mergeAgentEnv(Map<String, String> workstreamEnv, String body) {
+        Map<String, String> effective = new HashMap<>();
+        if (workstreamEnv != null) {
+            effective.putAll(workstreamEnv);
+        }
+        Map<String, String> submissionAgentEnv = extractJsonObjectFields(body, "agentEnv");
+        if (submissionAgentEnv != null) {
+            effective.putAll(submissionAgentEnv);
+        }
+        return effective;
+    }
+
+    /**
+     * Builds the {@code 500} response returned when an operation mutated
+     * workstream config in memory but the YAML write failed. Centralised so
+     * endpoints can report a non-durable write identically — never as success —
+     * honouring the rule that an operation should not confirm completion
+     * before the workstreams file is written.
+     *
+     * @param operation a short label for the attempted operation (e.g. {@code "Archive"})
+     * @return an {@code ok:false} 500 response describing the failed persist
+     */
+    static Response persistFailureResponse(String operation) {
+        return newFixedLengthResponse(Response.Status.INTERNAL_ERROR,
+                "application/json",
+                "{\"ok\":false,\"error\":" + escapeJsonValue(operation
+                    + " applied in memory but the workstreams config could not be written to"
+                    + " disk; the change is not durable and would be lost on restart. Retry.")
+                + "}");
+    }
+
+    /**
+     * Escapes a string as a JSON string value (with surrounding quotes).
+     * Shared by every handler in this package so the JSON shape produced by
+     * one endpoint is identical to the next.
+     *
+     * @param s the string to escape
+     * @return the JSON-escaped quoted string
+     */
+    static String escapeJsonValue(String s) {
+        StringBuilder sb = new StringBuilder(s.length() + 16);
+        sb.append('"');
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            switch (c) {
+                case '"': sb.append("\\\""); break;
+                case '\\': sb.append("\\\\"); break;
+                case '\n': sb.append("\\n"); break;
+                case '\r': sb.append("\\r"); break;
+                case '\t': sb.append("\\t"); break;
+                default:
+                    if (c < 0x20) {
+                        sb.append(String.format("\\u%04x", (int) c));
+                    } else {
+                        sb.append(c);
+                    }
+            }
+        }
+        sb.append('"');
+        return sb.toString();
+    }
+
+    /**
+     * Serialises a {@link JobCompletionEvent} to a JSON object string.
+     *
+     * @param event the event to serialise
+     * @return JSON object string
+     */
+    private String jobEventToJson(JobCompletionEvent event) {
+        return jobEventToJson(event, null);
+    }
+
+    /**
+     * Serialises a {@link JobCompletionEvent} to a JSON object string,
+     * optionally including the owning workstream identifier.
+     *
+     * @param event         the event to serialise
+     * @param workstreamId  the workstream that owns this job, or {@code null}
+     * @return JSON object string
+     */
+    private String jobEventToJson(JobCompletionEvent event, String workstreamId) {
+        StringBuilder j = new StringBuilder();
+        j.append("{");
+        j.append("\"jobId\":\"").append(JsonFieldExtractor.escapeJson(event.getJobId())).append("\"");
+        j.append(",\"status\":\"").append(event.getStatus().name()).append("\"");
+        j.append(",\"description\":\"").append(JsonFieldExtractor.escapeJson(event.getDescription())).append("\"");
+        j.append(",\"timestamp\":\"").append(event.getTimestamp().toString()).append("\"");
+        if (workstreamId != null) {
+            j.append(",\"workstreamId\":\"").append(JsonFieldExtractor.escapeJson(workstreamId)).append("\"");
+        }
+        if (event.getTargetBranch() != null) {
+            j.append(",\"targetBranch\":\"").append(JsonFieldExtractor.escapeJson(event.getTargetBranch())).append("\"");
+        }
+        if (event.getCommitHash() != null) {
+            j.append(",\"commitHash\":\"").append(JsonFieldExtractor.escapeJson(event.getCommitHash())).append("\"");
+        }
+        if (event.getPullRequestUrl() != null) {
+            j.append(",\"pullRequestUrl\":\"").append(JsonFieldExtractor.escapeJson(event.getPullRequestUrl())).append("\"");
+        }
+        if (event.getErrorMessage() != null) {
+            j.append(",\"errorMessage\":\"").append(JsonFieldExtractor.escapeJson(event.getErrorMessage())).append("\"");
+        }
+        double totalCost = event.getTotalCostUsd();
+        boolean costIncomplete = event.isCostIncomplete();
+        // Always emit costIncomplete as a stable boolean, matching
+        // JobCompletionEvent.toJson() and the documented wire shape so consumers
+        // never have to treat its absence as false.
+        j.append(",\"costIncomplete\":").append(costIncomplete);
+        // Emit the cost block when there is a positive total OR when the cost is
+        // incomplete: an inactivity-killed session can leave totalCost at 0 even
+        // though real (uncosted) work happened, and the total/breakdowns should
+        // still be surfaced as a lower bound.
+        if (totalCost > 0 || costIncomplete) {
+            j.append(String.format(",\"totalCostUsd\":%.2f", totalCost));
+            Map<String, Double> costByRunner = event.getCostByRunner();
+            if (costByRunner != null && !costByRunner.isEmpty()) {
+                j.append(",\"costByRunner\":{");
+                boolean first = true;
+                for (Map.Entry<String, Double> e : costByRunner.entrySet()) {
+                    if (!first) j.append(",");
+                    first = false;
+                    j.append("\"").append(JsonFieldExtractor.escapeJson(e.getKey())).append("\":")
+                        .append(String.format("%.2f", e.getValue() != null ? e.getValue() : 0.0));
+                }
+                j.append("}");
+            }
+            Map<String, Double> costByModel = event.getCostByModel();
+            if (costByModel != null && !costByModel.isEmpty()) {
+                j.append(",\"costByModel\":{");
+                boolean first = true;
+                for (Map.Entry<String, Double> e : costByModel.entrySet()) {
+                    if (!first) j.append(",");
+                    first = false;
+                    j.append("\"").append(JsonFieldExtractor.escapeJson(e.getKey())).append("\":")
+                        .append(String.format("%.2f", e.getValue() != null ? e.getValue() : 0.0));
+                }
+                j.append("}");
+            }
+        }
+        j.append("}");
+        return j.toString();
+    }
+
+    /**
+     * Handles {@code GET /api/workstreams/{id}/jobs?limit=N}.
+     * Returns the most recent jobs for the workstream, newest first.
+     *
+     * @param workstreamId the workstream identifier
+     * @param limit        maximum number of jobs to return
+     * @return JSON array of job events
+     */
+    private Response handleListJobs(String workstreamId, int limit) {
+        SlackNotifier n = notifiers.notifierFor(workstreamId);
+        List<JobCompletionEvent> page = n != null
+                ? n.getRecentJobs(workstreamId, limit) : new ArrayList<>();
+
+        StringBuilder json = new StringBuilder("[");
+        boolean first = true;
+        for (JobCompletionEvent event : page) {
+            if (!first) json.append(",");
+            first = false;
+            json.append(jobEventToJson(event));
+        }
+        json.append("]");
+
+        return newFixedLengthResponse(Response.Status.OK, "application/json", json.toString());
+    }
+
+    /**
+     * Handles {@code GET /api/jobs/{jobId}}.
+     * Returns the most recent event for the specified job.
+     *
+     * @param jobId the job identifier
+     * @return JSON object for the job event, or 404 if not found
+     */
+    private Response handleGetJob(String jobId) {
+        JobCompletionEvent event = notifiers.findJob(jobId);
+        if (event == null) {
+            return newFixedLengthResponse(Response.Status.NOT_FOUND,
+                    "application/json", "{\"ok\":false,\"error\":\"Job not found\"}");
+        }
+        String workstreamId = notifiers.findWorkstreamIdForJob(jobId);
+        return newFixedLengthResponse(Response.Status.OK,
+                "application/json", jobEventToJson(event, workstreamId));
+    }
+
+    /**
+     * Handles {@code GET /api/workstreams}. Returns a JSON array of all
+     * registered workstreams with their configuration and capabilities.
+     *
+     * <p>By default, workstreams flagged as archived are omitted. Pass
+     * {@code ?includeArchived=true} to include them; archived entries
+     * carry an {@code "archived": true} field in the response.</p>
+     *
+     * @param includeArchived when {@code false} archived workstreams are skipped
+     * @return an HTTP 200 response containing a JSON array of workstream objects
+     */
+    private Response handleListWorkstreams(boolean includeArchived) {
+        Map<String, Workstream> workstreams = notifiers.allWorkstreams();
+        StringBuilder json = new StringBuilder("[");
+        boolean first = true;
+        for (Workstream ws : workstreams.values()) {
+            if (!includeArchived && ws.isArchived()) continue;
+            if (!first) json.append(",");
+            first = false;
+            json.append(ws.toSummaryJson());
+        }
+        json.append("]");
+        return newFixedLengthResponse(Response.Status.OK,
+                "application/json", json.toString());
+    }
+
+    /**
+     * Builds the archive/unarchive/delete handler bound to this endpoint's
+     * notifiers and listener. See {@link WorkstreamLifecycleHandler}.
+     */
+    private WorkstreamLifecycleHandler lifecycleHandler() {
+        return new WorkstreamLifecycleHandler(notifiers, listener, this::readBody,
+                this::errorResponse, this::log);
+    }
+
+    /** Builds the {@code /api/workspaces/{id}/config} handler bound to this endpoint. */
+    private WorkspaceConfigHandler workspaceConfigHandler() {
+        return new WorkspaceConfigHandler(workspaceLookup, workspaceRenameHook,
+                listener, this::readBody, this::errorResponse, this::log);
+    }
+
+    /**
+     * Builds the workstream-message endpoint handler bound to this endpoint.
+     * See {@link MessageEndpointHandler}.
+     *
+     * @return a fresh handler reflecting the current memory-server URL and
+     *         notifier registry
+     */
+    private MessageEndpointHandler messageEndpointHandler() {
+        return new MessageEndpointHandler(notifiers, memoryServerUrl,
+                this::readBody, this::errorResponse, this::log, this::warn);
+    }
+
+    /**
+     * Builds the workstream registration/update endpoint handler bound to this endpoint.
+     * See {@link WorkstreamRegistrationHandler}.
+     *
+     * @return a fresh handler reflecting the current notifier registry,
+     *         org-to-workspace map, and listener
+     */
+    private WorkstreamRegistrationHandler workstreamRegistrationHandler() {
+        return new WorkstreamRegistrationHandler(notifiers, orgToWorkspaceId,
+                listener, this::readBody, this::errorResponse, this::log);
+    }
+
+    /**
+     * Handles {@code GET /api/stats}. Delegates to {@link StatsQueryHandler}.
+     *
+     * @param session the HTTP session supplying query parameters
+     * @return an HTTP response containing weekly stats JSON
+     */
     private Response handleStatsQuery(IHTTPSession session) {
         StatsQueryHandler handler = statsQueryHandler != null
             ? statsQueryHandler : new StatsQueryHandler(null);
@@ -1231,5 +1595,4 @@ public class FlowTreeApiEndpoint extends NanoHTTPD implements ConsoleFeatures {
     private Response handleGitHubProxy(IHTTPSession session, Method method) {
         return githubProxyHandler.handle(session, method, this::readBody, this::errorResponse);
     }
-
 }

--- a/flowtree/runtime/src/main/java/io/flowtree/api/WorkstreamRegistrationHandler.java
+++ b/flowtree/runtime/src/main/java/io/flowtree/api/WorkstreamRegistrationHandler.java
@@ -155,6 +155,7 @@ final class WorkstreamRegistrationHandler {
         List<String> completionListeners = extractCompletionListeners(body);
         boolean dispatchCapable = JsonFieldExtractor.extractBoolean(body, "dispatchCapable");
         boolean defaultUseTmux = JsonFieldExtractor.extractBoolean(body, "defaultUseTmux");
+        boolean dormantForCompletionListeners = JsonFieldExtractor.extractBoolean(body, "dormantForCompletionListeners");
 
         // Resolve the target Slack workspace: explicit slackWorkspaceId wins,
         // then a workspace derived from the repoUrl's GitHub org, then (in
@@ -266,6 +267,10 @@ final class WorkstreamRegistrationHandler {
         // use_tmux flag still wins on a per-job basis, so individual jobs
         // can opt in or out of tmux even when the workstream default is on.
         workstream.setUseTmux(defaultUseTmux);
+        // Listener-side dormancy flag for the completion-listener
+        // cascade. Default false on register; mutable on update so
+        // the orchestrator can flip its own state mid-run.
+        workstream.setDormantForCompletionListeners(dormantForCompletionListeners);
 
         boolean persisted;
         if (listener != null) {
@@ -415,6 +420,15 @@ final class WorkstreamRegistrationHandler {
         if (JsonFieldExtractor.hasField(body, "defaultUseTmux")) {
             workstream.setUseTmux(
                     JsonFieldExtractor.extractBoolean(body, "defaultUseTmux"));
+        }
+        // Listener-side dormancy flag for the completion-listener
+        // cascade. Same presence-signal pattern as useTmux above:
+        // omitting the field leaves the existing value untouched; a
+        // boolean in the body explicitly sets it. See
+        // Workstream#dormantForCompletionListeners for the semantics.
+        if (JsonFieldExtractor.hasField(body, "dormantForCompletionListeners")) {
+            workstream.setDormantForCompletionListeners(
+                    JsonFieldExtractor.extractBoolean(body, "dormantForCompletionListeners"));
         }
 
         if (listener != null && !listener.registerAndPersistWorkstream(workstream)) {

--- a/flowtree/runtime/src/main/java/io/flowtree/jobs/CompletionListenerFanout.java
+++ b/flowtree/runtime/src/main/java/io/flowtree/jobs/CompletionListenerFanout.java
@@ -277,12 +277,57 @@ public class CompletionListenerFanout implements ConsoleFeatures {
     public static final int DEFAULT_COALESCE_WINDOW_SECONDS = 30;
 
     /**
+     * Length of the sliding window for the <em>per-listener</em>
+     * debounce / single-in-flight-wake invariant. After a wake-up
+     * is submitted to a given listener, no further wake-up is
+     * submitted to that same listener until this many seconds have
+     * elapsed — regardless of how many distinct source workstreams
+     * fire completions, and regardless of the per-(source, listener)
+     * coalesce state. Default: 300 s = 5 minutes.
+     *
+     * <p>This is the missing ceiling that the production failure
+     * mode exposed: a fleet of N child workstreams all listing the
+     * same orchestrator listener would, under the per-(source,
+     * listener) coalesce + the {@code maxWakeUpsPerWindow} flood
+     * ceiling alone, still wake the orchestrator up to 6 times in
+     * 10 minutes (one per coalesce window across sources) and run
+     * multiple sessions in parallel, each writing the same durable
+     * log/branch state and producing push conflicts. The debounce
+     * collapses that to at most one in-flight wake-up per listener
+     * per 5 minutes, which matches a healthy orchestrator's
+     * round-trip time and bounds the burst.</p>
+     *
+     * <p>The debounce is naturally cleared when the wake-up job
+     * completes (the status event handler calls
+     * {@link #notifyListenerWakeUpCompleted(String)}), so a
+     * fast-completing wake-up does not artificially extend the
+     * debounce. The window is intentionally shorter than
+     * {@link #DEFAULT_MAX_WAKE_UP_WINDOW_SECONDS}: the debounce is
+     * the dominant recurrence guard, the window ceiling is the
+     * defense-in-depth backstop. Both reset on controller restart
+     * (in-memory state).</p>
+     */
+    public static final int DEFAULT_DEBOUNCE_SECONDS = 300;
+
+    /**
+     * Description prefix the fan-out stamps on every wake-up
+     * factory (see {@link #buildWakeUpFactory}). The
+     * status-event handler uses this to recognise a wake-up
+     * completion: a terminal event on the listener workstream
+     * whose description starts with this prefix is a wake-up
+     * finishing, and the fan-out clears the per-listener
+     * debounce in response. Public so external listeners (e.g.
+     * tests, monitoring tools) can match the same prefix
+     * without depending on internal factory-format details.
+     */
+    public static final String WAKE_UP_DESCRIPTION_PREFIX = "wake-up:";
+
+    /**
      * The fanout's in-memory state, exposed for tests so a fresh
      * instance per test avoids cross-test pollution.
      */
     private final ConcurrentHashMap<String, CoalesceState> coalesceState =
             new ConcurrentHashMap<>();
-
     /**
      * Per-listener wake-up timestamps, used to enforce
      * {@link CodingAgentJob#DEFAULT_MAX_WAKE_UPS_PER_WINDOW} in a
@@ -291,6 +336,41 @@ public class CompletionListenerFanout implements ConsoleFeatures {
      */
     private final ConcurrentHashMap<String, Deque<Long>> wakeUpWindowByListener =
             new ConcurrentHashMap<>();
+
+    /**
+     * Per-listener timestamp of the most recent wake-up that was
+     * <em>submitted</em> (not just the most recent completion event).
+     * Used to enforce the single-in-flight-wake invariant and to
+     * debounce rapid successive child completions on different
+     * sources that all list the same listener (the per-pair coalesce
+     * in {@link #coalesceState} only catches bursts from a single
+     * source; this catches bursts across sources). Cleared by
+     * {@link #notifyListenerWakeUpCompleted(String)} when the
+     * wake-up job's status event arrives, so a wake-up that
+     * completes in seconds does not artificially extend the
+     * debounce. The combination of the debounce + the
+     * {@code wakeUpWindowByListener} flood ceiling is what stops
+     * the production failure mode where an orchestrator is woken
+     * repeatedly to perform a no-op reconcile (see the branch's
+     * defect ticket for the motivating symptom).
+     */
+    private final ConcurrentHashMap<String, Long> wakeUpDispatchedAt =
+            new ConcurrentHashMap<>();
+
+    /**
+     * Effective per-listener debounce window in seconds. Defaults to
+     * {@link #DEFAULT_DEBOUNCE_SECONDS}; mutable via
+     * {@link #setDebounceSeconds(int)} so tests can isolate the
+     * window-ceiling behaviour by setting it to zero (the existing
+     * window-ceiling tests in
+     * {@code CompletionListenerFanoutTest} use that override).
+     * Production code constructed via {@link #bind} leaves this at
+     * the production default — no caller in the controller
+     * overrides it. Stored as seconds to keep the API aligned with
+     * the public {@code DEFAULT_*} constants; converted to millis at
+     * the call site.
+     */
+    private int debounceSeconds = DEFAULT_DEBOUNCE_SECONDS;
 
     /**
      * Per-chain wake-up count, used to enforce
@@ -539,11 +619,18 @@ public class CompletionListenerFanout implements ConsoleFeatures {
 
     /**
      * Dispatches one wake-up to the named listener, enforcing the
-     * kill switch, the coalesce window, the per-listener window
-     * ceiling, the per-source-chain ceiling, and the chain-depth
-     * ceiling in that order. Each ceiling logs a distinct
-     * {@code ceiling_hit} (or {@code wakeup_kill_switch_active} for
-     * the kill switch) line and returns without firing.
+     * kill switch, the listener-dormancy gate, the coalesce window,
+     * the per-listener window ceiling, the per-source-chain
+     * ceiling, the chain-depth ceiling, and the per-listener
+     * debounce / single-in-flight-wake invariant in that order.
+     * Each gate logs a distinct reason line
+     * ({@code wakeup_kill_switch_active}, {@code wakeup_listener_dormant},
+     * {@code wakeup_listener_recently_woken}, {@code ceiling_hit})
+     * and returns without firing.
+     *
+     * <p>TODO(review): step 8 (debounce) runs after step 7 (window ceiling) already records
+     * {@code now} into the window deque, so a debounce-suppressed event still consumes a
+     * per-listener window-ceiling slot even though no wake-up fired; see review-followup memory.</p>
      */
     private void dispatchToListener(String sourceWorkstreamId,
                                     String listenerId,
@@ -567,7 +654,25 @@ public class CompletionListenerFanout implements ConsoleFeatures {
             return;
         }
 
-        // 3. Coalesce window. Within the window, the first completion
+        // 3. Listener-dormancy gate. The listener has declared
+        //    "no further wake-ups until something materially new
+        //    happens"; drop the wake-up before any further
+        //    listener-specific work (coalesce append, ceiling
+        //    bookkeeping). The flag is the listener's own
+        //    opt-in / opt-out — it does not block manual job
+        //    submissions, only the auto-generated wake-up path.
+        //    Composes with the global acceptAutomatedJobs kill
+        //    switch above: the kill switch halts every wake-up
+        //    globally; this gate halts wake-ups to one specific
+        //    listener. The two are checked independently so an
+        //    operator who trips the kill switch always wins.
+        if (listener.isDormantForCompletionListeners()) {
+            warn("wakeup_listener_dormant source=" + sourceWorkstreamId
+                    + " listener=" + listenerId + " chain=" + chainId);
+            return;
+        }
+
+        // 4. Coalesce window. Within the window, the first completion
         //    fires a wake-up carrying the primary job ID; subsequent
         //    completions append to a consolidated list and skip.
         //    The append is synchronized on the CoalesceState instance
@@ -587,7 +692,7 @@ public class CompletionListenerFanout implements ConsoleFeatures {
             return;
         }
 
-        // 4. Chain-depth ceiling (defense-in-depth).
+        // 5. Chain-depth ceiling (defense-in-depth).
         if (chainDepth >= DEFAULT_MAX_CHAIN_DEPTH) {
             warn("ceiling_hit source=" + sourceWorkstreamId
                     + " listener=" + listenerId
@@ -597,7 +702,7 @@ public class CompletionListenerFanout implements ConsoleFeatures {
             return;
         }
 
-        // 5. Per-source-chain breadth ceiling (defence-in-depth).
+        // 6. Per-source-chain breadth ceiling (defence-in-depth).
         int chainCurrent = chainCount.getOrDefault(chainId, 0);
         if (chainCurrent >= DEFAULT_MAX_WAKE_UPS_PER_SOURCE_CHAIN) {
             warn("ceiling_hit source=" + sourceWorkstreamId
@@ -608,7 +713,7 @@ public class CompletionListenerFanout implements ConsoleFeatures {
             return;
         }
 
-        // 6. Per-listener window ceiling (PRIMARY flood protection).
+        // 7. Per-listener window ceiling (PRIMARY flood protection).
         long windowSecs = DEFAULT_MAX_WAKE_UP_WINDOW_SECONDS;
         long windowMillis = windowSecs * 1000L;
         Deque<Long> window = wakeUpWindowByListener.computeIfAbsent(
@@ -629,13 +734,43 @@ public class CompletionListenerFanout implements ConsoleFeatures {
             window.addLast(now);
         }
 
-        // 7. Mark the coalesce state so subsequent completions on the
+        // 8. Per-listener debounce / single-in-flight-wake
+        //    invariant. After a wake-up is submitted to this
+        //    listener, no further wake-up is submitted to that
+        //    listener until DEFAULT_DEBOUNCE_SECONDS have elapsed.
+        //    This is the missing ceiling that the production
+        //    failure mode exposed: a fleet of N children all
+        //    listing the same orchestrator listener each fire a
+        //    distinct chain ID, defeat the per-(source, listener)
+        //    coalesce (which only catches bursts from one source),
+        //    and race to wake the listener multiple times — the
+        //    wake-ups then run concurrently on the same branch,
+        //    racing the durable log/context file and producing
+        //    push conflicts. The debounce collapses the burst to
+        //    at most one in-flight wake-up per listener per
+        //    DEFAULT_DEBOUNCE_SECONDS, which is the dominant
+        //    recurrence guard; the window ceiling above is the
+        //    defense-in-depth backstop. The debounce is cleared
+        //    when the wake-up job's status event arrives at
+        //    notifyListenerWakeUpCompleted, so a fast-completing
+        //    wake-up does not artificially extend the window.
+        long debounceMs = (long) debounceSeconds * 1000L;
+        Long lastDispatchedAt = wakeUpDispatchedAt.get(listenerId);
+        if (lastDispatchedAt != null && (now - lastDispatchedAt) < debounceMs) {
+            warn("wakeup_listener_recently_woken source=" + sourceWorkstreamId
+                    + " listener=" + listenerId + " chain=" + chainId
+                    + " sinceMs=" + (now - lastDispatchedAt));
+            return;
+        }
+
+        // 9. Mark the coalesce state so subsequent completions on the
         //    same source/listener pair within the window are dropped.
         CoalesceState state = new CoalesceState(now, event.getJobId());
         coalesceState.put(coalesceKey, state);
         chainCount.put(chainId, chainCurrent + 1);
+        wakeUpDispatchedAt.put(listenerId, now);
 
-        // 8. Build and dispatch the wake-up factory.
+        // 10. Build and dispatch the wake-up factory.
         CodingAgentJob.Factory factory = buildWakeUpFactory(
                 sourceWorkstreamId, listener, event, chainId, chainDepth);
         try {
@@ -1003,6 +1138,102 @@ public class CompletionListenerFanout implements ConsoleFeatures {
         coalesceState.clear();
         wakeUpWindowByListener.clear();
         chainCount.clear();
+        wakeUpDispatchedAt.clear();
+    }
+
+    /**
+     * Called by the controller's status-event handler when a job
+     * on a listener workstream reaches a terminal status. If the
+     * event's description starts with the wake-up prefix
+     * {@link #WAKE_UP_DESCRIPTION_PREFIX}, the per-listener
+     * debounce is cleared so the next completion event after the
+     * wake-up completes is allowed to fire a fresh wake-up. The
+     * method is a no-op for non-wake-up completions, so callers
+     * can call it unconditionally for every terminal event on
+     * every workstream.
+     *
+     * <p>Without the clear, a wake-up that completed in 30
+     * seconds would still block new wake-ups for the remainder
+     * of the {@link #DEFAULT_DEBOUNCE_SECONDS} window — which
+     * would over-debounce on a fast-completing wake-up and
+     * defeat the design's "a genuine new event still wakes the
+     * orchestrator" property.</p>
+     *
+     * @param workstreamId the workstream ID whose debounce
+     *                     should be cleared; {@code null} or
+     *                     empty is a no-op
+     * @param description  the terminal event's description; the
+     *                     clear is performed only when this
+     *                     starts with the wake-up prefix
+     */
+    public void notifyListenerWakeUpCompleted(String workstreamId, String description) {
+        if (workstreamId == null || workstreamId.isEmpty()) {
+            return;
+        }
+        if (description == null || !description.startsWith(WAKE_UP_DESCRIPTION_PREFIX)) {
+            return;
+        }
+        wakeUpDispatchedAt.remove(workstreamId);
+    }
+
+    /**
+     * Backward-compatible single-argument overload that does not
+     * test the event description. Kept for callers that have
+     * already determined the event is a wake-up completion
+     * (e.g. tests) and want to force the clear regardless of
+     * description. Production code should prefer the
+     * two-argument overload.
+     *
+     * @param listenerId the workstream ID whose debounce
+     *                   should be cleared; {@code null} or
+     *                   empty is a no-op
+     */
+    public void notifyListenerWakeUpCompleted(String listenerId) {
+        if (listenerId == null || listenerId.isEmpty()) {
+            return;
+        }
+        wakeUpDispatchedAt.remove(listenerId);
+    }
+
+    /**
+     * Visible-for-testing handle to the per-listener debounce
+     * timestamp (wall-clock millis of the most recent wake-up
+     * submitted to that listener, or {@code null} when no wake-up
+     * has been submitted yet). Production callers should not need
+     * this; tests assert the debounce's record / clear behaviour
+     * here.
+     */
+    public Long peekWakeUpDispatchedAt(String listenerId) {
+        return wakeUpDispatchedAt.get(listenerId);
+    }
+
+    /**
+     * Returns the effective per-listener debounce window in
+     * seconds. Defaults to {@link #DEFAULT_DEBOUNCE_SECONDS};
+     * production code constructed via {@link #bind} never
+     * overrides this.
+     *
+     * @return the debounce window in seconds, &ge; 0; a value of 0
+     *         disables the debounce entirely (tests that exercise
+     *         the window ceiling in isolation use this)
+     */
+    public int getDebounceSeconds() {
+        return debounceSeconds;
+    }
+
+    /**
+     * Overrides the per-listener debounce window. Tests use this
+     * to isolate the window-ceiling behaviour by setting it to 0;
+     * production code never calls it. The change takes effect on
+     * the next {@link #fanout(String, JobCompletionEvent)} call —
+     * already-recorded {@code wakeUpDispatchedAt} timestamps are
+     * not retroactively re-evaluated.
+     *
+     * @param debounceSeconds the new debounce window in seconds;
+     *                        values &lt; 0 are clamped to 0
+     */
+    public void setDebounceSeconds(int debounceSeconds) {
+        this.debounceSeconds = Math.max(0, debounceSeconds);
     }
 
     /**

--- a/flowtree/runtime/src/main/java/io/flowtree/jobs/CompletionListenerFanout.java
+++ b/flowtree/runtime/src/main/java/io/flowtree/jobs/CompletionListenerFanout.java
@@ -299,7 +299,7 @@ public class CompletionListenerFanout implements ConsoleFeatures {
      *
      * <p>The debounce is naturally cleared when the wake-up job
      * completes (the status event handler calls
-     * {@link #notifyListenerWakeUpCompleted(String)}), so a
+     * {@link #notifyListenerWakeUpCompleted(String, String)}), so a
      * fast-completing wake-up does not artificially extend the
      * debounce. The window is intentionally shorter than
      * {@link #DEFAULT_MAX_WAKE_UP_WINDOW_SECONDS}: the debounce is
@@ -345,7 +345,7 @@ public class CompletionListenerFanout implements ConsoleFeatures {
      * sources that all list the same listener (the per-pair coalesce
      * in {@link #coalesceState} only catches bursts from a single
      * source; this catches bursts across sources). Cleared by
-     * {@link #notifyListenerWakeUpCompleted(String)} when the
+     * {@link #notifyListenerWakeUpCompleted(String, String)} when the
      * wake-up job's status event arrives, so a wake-up that
      * completes in seconds does not artificially extend the
      * debounce. The combination of the debounce + the
@@ -627,10 +627,6 @@ public class CompletionListenerFanout implements ConsoleFeatures {
      * ({@code wakeup_kill_switch_active}, {@code wakeup_listener_dormant},
      * {@code wakeup_listener_recently_woken}, {@code ceiling_hit})
      * and returns without firing.
-     *
-     * <p>TODO(review): step 8 (debounce) runs after step 7 (window ceiling) already records
-     * {@code now} into the window deque, so a debounce-suppressed event still consumes a
-     * per-listener window-ceiling slot even though no wake-up fired; see review-followup memory.</p>
      */
     private void dispatchToListener(String sourceWorkstreamId,
                                     String listenerId,
@@ -714,6 +710,11 @@ public class CompletionListenerFanout implements ConsoleFeatures {
         }
 
         // 7. Per-listener window ceiling (PRIMARY flood protection).
+        //    Evict old entries from the deque and check the size under
+        //    the window lock, but DO NOT consume a slot here. The
+        //    slot is recorded only after step 8 (debounce) and the
+        //    dispatch bookkeeping pass, so a debounce-suppressed
+        //    event does not artificially exhaust the flood budget.
         long windowSecs = DEFAULT_MAX_WAKE_UP_WINDOW_SECONDS;
         long windowMillis = windowSecs * 1000L;
         Deque<Long> window = wakeUpWindowByListener.computeIfAbsent(
@@ -731,7 +732,6 @@ public class CompletionListenerFanout implements ConsoleFeatures {
                         + "/" + windowSecs + "s)");
                 return;
             }
-            window.addLast(now);
         }
 
         // 8. Per-listener debounce / single-in-flight-wake
@@ -765,10 +765,16 @@ public class CompletionListenerFanout implements ConsoleFeatures {
 
         // 9. Mark the coalesce state so subsequent completions on the
         //    same source/listener pair within the window are dropped.
+        //    The window slot is recorded ONLY here, after every gate
+        //    has accepted this dispatch — debounce-suppressed events
+        //    therefore do not consume the per-listener flood budget.
         CoalesceState state = new CoalesceState(now, event.getJobId());
         coalesceState.put(coalesceKey, state);
         chainCount.put(chainId, chainCurrent + 1);
         wakeUpDispatchedAt.put(listenerId, now);
+        synchronized (window) {
+            window.addLast(now);
+        }
 
         // 10. Build and dispatch the wake-up factory.
         CodingAgentJob.Factory factory = buildWakeUpFactory(
@@ -1174,25 +1180,6 @@ public class CompletionListenerFanout implements ConsoleFeatures {
             return;
         }
         wakeUpDispatchedAt.remove(workstreamId);
-    }
-
-    /**
-     * Backward-compatible single-argument overload that does not
-     * test the event description. Kept for callers that have
-     * already determined the event is a wake-up completion
-     * (e.g. tests) and want to force the clear regardless of
-     * description. Production code should prefer the
-     * two-argument overload.
-     *
-     * @param listenerId the workstream ID whose debounce
-     *                   should be cleared; {@code null} or
-     *                   empty is a no-op
-     */
-    public void notifyListenerWakeUpCompleted(String listenerId) {
-        if (listenerId == null || listenerId.isEmpty()) {
-            return;
-        }
-        wakeUpDispatchedAt.remove(listenerId);
     }
 
     /**

--- a/flowtree/runtime/src/main/java/io/flowtree/workstream/Workstream.java
+++ b/flowtree/runtime/src/main/java/io/flowtree/workstream/Workstream.java
@@ -251,6 +251,31 @@ public class Workstream {
      */
     private boolean useTmux;
 
+    /**
+     * Listener-side dormancy flag for the completion-listener wake-up
+     * cascade. When {@code true}, the {@link
+     * io.flowtree.jobs.CompletionListenerFanout} drops every wake-up
+     * it would otherwise submit to this workstream. The flag is the
+     * listener's own declaration that it has reached a stable HOLD
+     * state and does not want to be woken until something materially
+     * new happens. Default {@code false}: opt in explicitly via
+     * {@link #setDormantForCompletionListeners(boolean)} so an
+     * orchestrator with no dispatchable work can stop burning model
+     * sessions on no-op reconciles. This flag is the
+     * per-listener complement to the global
+     * {@link io.flowtree.api.FlowTreeApiEndpoint#setAcceptAutomatedJobs(boolean)
+     * acceptAutomatedJobs} kill switch — the kill switch halts every
+     * wake-up globally; this flag halts wake-ups to one specific
+     * listener. Clearing the flag does not retroactively fire a
+     * wake-up for events dropped while dormant; the next completion
+     * after the flag is cleared is the trigger. Manual job
+     * submissions are unaffected and remain the supported path for a
+     * human or a different workstream to resume a dormant
+     * orchestrator. Persisted as
+     * {@code dormantForCompletionListeners: true} in YAML.
+     */
+    private boolean dormantForCompletionListeners;
+
     /** Default git user name for new workstreams. */
     public static final String DEFAULT_GIT_USER_NAME = "Flowtree Coding Agent";
 
@@ -749,6 +774,44 @@ public class Workstream {
     }
 
     /**
+     * Returns {@code true} when this workstream is in the
+     * listener-dormant state: the completion-listener fan-out drops
+     * every wake-up it would otherwise submit to this workstream. The
+     * flag is the listener's own declaration that it has no new work
+     * and should not be woken by child-completion events until
+     * something materially new happens. See
+     * {@link #dormantForCompletionListeners} for the full semantics
+     * and the relationship to the global
+     * {@code acceptAutomatedJobs} kill switch.
+     *
+     * @return {@code true} when wake-ups to this workstream are
+     *         dropped at the fan-out, {@code false} when the workstream
+     *         is active (the default)
+     */
+    public boolean isDormantForCompletionListeners() {
+        return dormantForCompletionListeners;
+    }
+
+    /**
+     * Sets the listener-dormancy flag. When {@code true}, the
+     * completion-listener fan-out drops every wake-up it would
+     * otherwise submit to this workstream; when {@code false}, the
+     * workstream is active and wake-ups resume. The flag takes
+     * effect immediately (the fan-out reads it on every completion
+     * event) and persists to YAML. Use from an orchestrator agent
+     * when its planning document determines there is no new
+     * dispatchable work; clear via
+     * {@code workstream_update_config dormantForCompletionListeners:
+     * false} or a manual job submission to resume the listener.
+     *
+     * @param dormantForCompletionListeners {@code true} to drop
+     *        wake-ups at the fan-out; {@code false} to resume wake-ups
+     */
+    public void setDormantForCompletionListeners(boolean dormantForCompletionListeners) {
+        this.dormantForCompletionListeners = dormantForCompletionListeners;
+    }
+
+    /**
      * Returns the default agent runner identifier for this workstream, or
      * {@code null} when no workstream-level default is set.
      */
@@ -912,6 +975,9 @@ public class Workstream {
         }
         if (useTmux) {
             json.append(",\"useTmux\":true");
+        }
+        if (dormantForCompletionListeners) {
+            json.append(",\"dormantForCompletionListeners\":true");
         }
 
         if (dependentRepos != null && !dependentRepos.isEmpty()) {

--- a/flowtree/runtime/src/main/java/io/flowtree/workstream/WorkstreamConfig.java
+++ b/flowtree/runtime/src/main/java/io/flowtree/workstream/WorkstreamConfig.java
@@ -498,7 +498,9 @@ public class WorkstreamConfig {
          */
         @JsonInclude(JsonInclude.Include.NON_DEFAULT)
         private boolean useTmux;
-
+        /** See {@link Workstream#dormantForCompletionListeners}. */
+        @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+        private boolean dormantForCompletionListeners;
         /** Returns the persistent workstream identifier. */
         public String getWorkstreamId() { return workstreamId; }
         /** Sets the persistent workstream identifier. */
@@ -715,6 +717,13 @@ public class WorkstreamConfig {
          */
         public void setUseTmux(boolean useTmux) { this.useTmux = useTmux; }
 
+        /** See {@link Workstream#isDormantForCompletionListeners()}. */
+        public boolean isDormantForCompletionListeners() { return dormantForCompletionListeners; }
+        /** See {@link Workstream#setDormantForCompletionListeners(boolean)}. */
+        public void setDormantForCompletionListeners(boolean dormantForCompletionListeners) {
+            this.dormantForCompletionListeners = dormantForCompletionListeners;
+        }
+
         /**
          * Converts this entry to a {@link Workstream} instance.
          *
@@ -762,13 +771,12 @@ public class WorkstreamConfig {
             ws.setCompletionListeners(completionListeners);
             ws.setDispatchCapable(dispatchCapable);
             ws.setUseTmux(useTmux);
+            ws.setDormantForCompletionListeners(dormantForCompletionListeners);
             return ws;
         }
     }
 
     /**
-     * Returns the global default workspace path for repo checkouts.
-     *
      * <p>When a workstream specifies {@code repoUrl} but no
      * {@code workingDirectory}, the repo is cloned into this path.
      * If not set, defaults to {@code /workspace/project} (if it exists)
@@ -1337,6 +1345,7 @@ public class WorkstreamConfig {
         entry.setCompletionListeners(ws.getCompletionListeners());
         entry.setDispatchCapable(ws.isDispatchCapable());
         entry.setUseTmux(ws.isUseTmux());
+        entry.setDormantForCompletionListeners(ws.isDormantForCompletionListeners());
     }
 
     /**

--- a/flowtree/runtime/src/test/java/io/flowtree/api/CompletionListenerSafetyIntegrationTest.java
+++ b/flowtree/runtime/src/test/java/io/flowtree/api/CompletionListenerSafetyIntegrationTest.java
@@ -116,6 +116,12 @@ public class CompletionListenerSafetyIntegrationTest extends TestSuiteBase {
                 null, null, null, id -> null, null,
                 wsId -> notifier.getWorkstream(wsId) != null ? notifier : null,
                 clock::get);
+        // The integration tests in this class exercise the
+        // maxWakeUpsPerWindow ceiling in isolation; the per-listener
+        // debounce (a different ceiling, dedicated tests in
+        // CompletionListenerFanoutDormancyDebounceTest) is disabled
+        // here so the window ceiling can trip on its own.
+        fanout.setDebounceSeconds(0);
         endpoint.setServer(server);
         endpoint.setCompletionListenerFanout(fanout);
         // Open the kill switch so the fanout's first check

--- a/flowtree/runtime/src/test/java/io/flowtree/jobs/CompletionListenerFanoutDormancyDebounceTest.java
+++ b/flowtree/runtime/src/test/java/io/flowtree/jobs/CompletionListenerFanoutDormancyDebounceTest.java
@@ -1,0 +1,504 @@
+/*
+ * Copyright 2026 Michael Murray
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.flowtree.jobs;
+
+import io.flowtree.Server;
+import io.flowtree.job.JobFactory;
+import io.flowtree.workstream.Workstream;
+import org.almostrealism.util.TestSuiteBase;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for the per-listener wake-up debounce and the
+ * listener-dormancy gate added to {@link CompletionListenerFanout}
+ * to fix the production defect where an orchestrator workstream was
+ * woken in an unbounded loop of no-op reconciles, and where two
+ * concurrent orchestrator sessions wrote the same durable
+ * log/branch state and produced push conflicts.
+ *
+ * <p>The two protections are:</p>
+ *
+ * <ol>
+ *   <li><strong>Per-listener debounce / single-in-flight-wake
+ *       invariant</strong> ({@link
+ *       CompletionListenerFanout#DEFAULT_DEBOUNCE_SECONDS}). After a
+ *       wake-up is submitted to a listener, no further wake-up is
+ *       submitted to that listener until the debounce expires. The
+ *       debounce is cleared by
+ *       {@link CompletionListenerFanout#notifyListenerWakeUpCompleted}
+ *       when the wake-up's status event arrives, so a fast-completing
+ *       wake-up does not artificially extend the window.</li>
+ *   <li><strong>Listener dormancy</strong> ({@link
+ *       Workstream#isDormantForCompletionListeners()}). The listener
+ *       itself declares "no further wake-ups until something
+ *       materially new happens"; the fan-out drops every wake-up
+ *       aimed at a dormant listener. Cleared via
+ *       {@code workstream_update_config} when a genuinely new event
+ *       (human action, fresh ticket, etc.) unblocks work.</li>
+ * </ol>
+ *
+ * <p>The tests deliberately use a 6-second production-shaped
+ * debounce (vs. the 300-second default) so the suite runs in
+ * seconds, not minutes. The safety properties being verified are
+ * independent of the exact window length — what matters is "wake-ups
+ * are bounded when nothing materially changed" and "wake-ups resume
+ * when the debounce is cleared or the dormancy gate is lifted."</p>
+ */
+public class CompletionListenerFanoutDormancyDebounceTest extends TestSuiteBase {
+
+    /** Test server that records every {@code addTask} invocation. */
+    private RecordingServer server;
+    /** Live workstream map visible to the fanout. */
+    private Map<String, Workstream> workstreams;
+    /** Test clock the fanout reads; advanced by tests to exercise the debounce. */
+    private AtomicLong clockMillis;
+    /** The fanout under test, created fresh in {@link #setUp()}. */
+    private CompletionListenerFanout fanout;
+    /** Debounce window used in this test class, in seconds. */
+    private static final int TEST_DEBOUNCE_SECONDS = 6;
+
+    /**
+     * Wires a fresh fan-out with a 6-second debounce, an isolated
+     * {@link RecordingServer}, and a controllable clock. The
+     * debounce is shorter than the production 300-second default so
+     * the suite finishes quickly; the safety properties under test
+     * are independent of the exact window length.
+     */
+    @Before
+    public void setUp() throws IOException {
+        server = new RecordingServer();
+        workstreams = new HashMap<>();
+        clockMillis = new AtomicLong(0L);
+        fanout = new CompletionListenerFanout(
+                () -> true,
+                () -> workstreams,
+                server,
+                null,
+                wsId -> "http://test/api/workstreams/" + wsId,
+                null, null, null, id -> null, null,
+                null,
+                clockMillis::get);
+        fanout.setDebounceSeconds(TEST_DEBOUNCE_SECONDS);
+    }
+
+    /**
+     * Builds a workstream with a fixed ID and an optional listener
+     * list. The listener list is the {@code source -> listener}
+     * edge: {@code source} lists {@code listeners} as its completion
+     * listeners, so any completion on {@code source} wakes each
+     * listener. The listener workstream (e.g. "B") can be marked
+     * dormant via the returned instance.
+     */
+    private static Workstream ws(String id, String... listeners) {
+        Workstream w = new Workstream(id, "C_" + id, "#" + id);
+        w.setAllowedTools("Read");
+        w.setDefaultBranch("feature/" + id);
+        w.setMaxTurns(50);
+        w.setMaxBudgetUsd(10.0);
+        if (listeners != null && listeners.length > 0) {
+            w.setCompletionListeners(Arrays.asList(listeners));
+        }
+        return w;
+    }
+
+    /** Builds a synthetic success event with the given job ID. */
+    private static JobCompletionEvent success(String jobId) {
+        return JobCompletionEvent.success(jobId, "test job " + jobId);
+    }
+
+    // --- Property (a): N rapid child completions -> at most 1 wake-up ---
+
+    /**
+     * Property (a) — single source: N completions in rapid
+     * succession on the same source wake the listener at most
+     * once. The first fires; subsequent completions within the
+     * debounce window are dropped with the
+     * {@code wakeup_listener_recently_woken} log line.
+     */
+    @Test(timeout = 10000)
+    public void rapidSuccessiveCompletionsOnSameSourceCoalesceToOneWake() {
+        workstreams.put("A", ws("A", "B"));
+        workstreams.put("B", ws("B"));
+        for (int i = 0; i < 10; i++) {
+            clockMillis.set(i * 1_000L);
+            fanout.fanout("A", success("j-" + i));
+        }
+        assertEquals("10 rapid completions must produce at most 1 wake-up",
+                1, server.added.size());
+    }
+
+    /**
+     * Property (a) — fan-in: N sources all listing the same
+     * listener fire completions in a burst. The pre-fix behavior
+     * was one wake-up per source — up to N concurrent orchestrator
+     * sessions writing the same branch and producing push
+     * conflicts. With the per-listener debounce, at most one
+     * wake-up fires for the burst; subsequent source completions
+     * are dropped with the {@code wakeup_listener_recently_woken}
+     * log line.
+     */
+    @Test(timeout = 10000)
+    public void fanInFromManySourcesCollapsesToOneWake() {
+        // 10 distinct sources all list the same listener B.
+        for (int i = 0; i < 10; i++) {
+            String sourceId = "src-" + i;
+            workstreams.put(sourceId, ws(sourceId, "B"));
+        }
+        workstreams.put("B", ws("B"));
+        // Each source fires a completion within 1 second of the
+        // previous — a tight fan-in burst.
+        for (int i = 0; i < 10; i++) {
+            clockMillis.set(i * 1_000L);
+            fanout.fanout("src-" + i, success("j-src-" + i));
+        }
+        assertEquals("fan-in burst must collapse to 1 wake-up",
+                1, server.added.size());
+        // The fan-out's recorded debounce timestamp for B must be
+        // the moment the single wake-up fired — useful for
+        // confirming the dedup bookkeeping, and as a regression
+        // guard against a future refactor that drops the timestamp.
+        Long bLast = fanout.peekWakeUpDispatchedAt("B");
+        assertNotNull("listener B must have a recorded debounce timestamp",
+                bLast);
+        assertEquals("the recorded timestamp is the moment of the single wake-up",
+                0L, bLast.longValue());
+    }
+
+    /**
+     * Property (a) — second wake-up is allowed after the debounce
+     * expires. The test fires one wake-up, advances the clock past
+     * the debounce, fires a second completion, and asserts the
+     * second wake-up fires. This pins the "wake-ups resume after
+     * the debounce" half of the contract — without it the debounce
+     * would silently turn into a permanent block.
+     */
+    @Test(timeout = 10000)
+    public void wakeUpFiresAgainAfterDebounceExpires() {
+        workstreams.put("A", ws("A", "B"));
+        workstreams.put("B", ws("B"));
+        clockMillis.set(0L);
+        fanout.fanout("A", success("j-1"));
+        assertEquals(1, server.added.size());
+        // Just before the debounce expires: still blocked.
+        clockMillis.set((TEST_DEBOUNCE_SECONDS * 1000L) - 1L);
+        fanout.fanout("A", success("j-2"));
+        assertEquals("wake-up must still be blocked just before debounce expires",
+                1, server.added.size());
+        // Just after: allowed.
+        clockMillis.set((TEST_DEBOUNCE_SECONDS * 1000L) + 1L);
+        fanout.fanout("A", success("j-3"));
+        assertEquals("wake-up must fire once the debounce expires",
+                2, server.added.size());
+    }
+
+    // --- Property (b): concurrent wakes serialized ---
+
+    /**
+     * Property (b) — the per-listener debounce enforces a single
+     * in-flight wake-up at a time. The fan-out records the
+     * dispatch timestamp on the listener when the wake-up is
+     * submitted; subsequent attempts inside the debounce see the
+     * timestamp and drop. The implementation does not need a
+     * separate lock for this property — the timestamp IS the
+     * serialization — but the test pins the recorded timestamp
+     * explicitly so a future refactor that swaps the debounce for
+     * a true lock cannot accidentally drop the property.
+     */
+    @Test(timeout = 10000)
+    public void concurrentWakesSerializedByDebounce() {
+        workstreams.put("A", ws("A", "B"));
+        workstreams.put("B", ws("B"));
+        // Two completions on the same source at t=0: only the
+        // first fires a wake-up; the second is dropped (coalesce
+        // path). The recorded debounce timestamp is what blocks
+        // any later wake-up until the debounce expires.
+        clockMillis.set(0L);
+        fanout.fanout("A", success("j-first"));
+        fanout.fanout("A", success("j-second-coalesced"));
+        assertEquals("first wake-up fires; second coalesced",
+                1, server.added.size());
+        Long bLast = fanout.peekWakeUpDispatchedAt("B");
+        assertNotNull("listener B debounce timestamp must be recorded",
+                bLast);
+        assertEquals("recorded timestamp is the moment of the fired wake-up",
+                0L, bLast.longValue());
+        // A completion from a different source arrives at t=2s
+        // (well inside the debounce). Without the debounce this
+        // would have raced a second orchestrator session on the
+        // same branch; with the debounce it is dropped.
+        workstreams.put("C", ws("C", "B"));
+        clockMillis.set(2_000L);
+        fanout.fanout("C", success("j-other-source"));
+        assertEquals("second source wake-up must be debounced",
+                1, server.added.size());
+    }
+
+    /**
+     * Property (b) — {@link
+     * CompletionListenerFanout#notifyListenerWakeUpCompleted(String, String)
+     * notifyListenerWakeUpCompleted} clears the debounce when the
+     * wake-up job reports its terminal status. This is the
+     * "wake-up completes quickly so the debounce does not
+     * artificially extend" half of the serialization contract —
+     * without it, a wake-up that completes in 5 seconds would
+     * still block new wake-ups for the remainder of the
+     * 300-second production default, which defeats the
+     * "genuinely new event still wakes the orchestrator"
+     * correctness property. The description prefix is what
+     * distinguishes a wake-up completion from any other terminal
+     * event on the listener workstream.
+     */
+    @Test(timeout = 10000)
+    public void notifyListenerWakeUpCompletedClearsDebounce() {
+        workstreams.put("A", ws("A", "B"));
+        workstreams.put("B", ws("B"));
+        clockMillis.set(0L);
+        fanout.fanout("A", success("j-1"));
+        assertEquals(1, server.added.size());
+        assertNotNull("debounce must be recorded after dispatch",
+                fanout.peekWakeUpDispatchedAt("B"));
+        // Simulate the wake-up reporting its terminal status with
+        // the wake-up description prefix.
+        fanout.notifyListenerWakeUpCompleted("B", "wake-up: B <- A");
+        assertNull("debounce must be cleared after the wake-up completes",
+                fanout.peekWakeUpDispatchedAt("B"));
+        // A new completion event arriving any time after the
+        // clear should fire a fresh wake-up — even at t=0+1s,
+        // inside what would have been the original debounce
+        // window.
+        clockMillis.set(1_000L);
+        fanout.fanout("A", success("j-2"));
+        assertEquals("new wake-up must fire after debounce clear",
+                2, server.added.size());
+    }
+
+    /**
+     * Property (b) — null/empty listenerId on
+     * {@link CompletionListenerFanout#notifyListenerWakeUpCompleted}
+     * is a no-op (the production caller in the status-event
+     * handler may pass through values it has not validated; the
+     * fan-out's contract is "never throw"). A description that
+     * is not a wake-up prefix is also a no-op (only wake-up
+     * completions should clear the debounce).
+     */
+    @Test(timeout = 10000)
+    public void notifyListenerWakeUpCompletedIgnoresBadInputs() {
+        fanout.notifyListenerWakeUpCompleted(null, "wake-up: x");
+        fanout.notifyListenerWakeUpCompleted("", "wake-up: x");
+        fanout.notifyListenerWakeUpCompleted("B", "regular job description");
+        fanout.notifyListenerWakeUpCompleted("B", null);
+        // No assertion on side effects: the no-op contract is
+        // "don't throw." A subsequent dispatch still works.
+        workstreams.put("A", ws("A", "B"));
+        workstreams.put("B", ws("B"));
+        clockMillis.set(0L);
+        fanout.fanout("A", success("j-1"));
+        assertEquals(1, server.added.size());
+    }
+
+    // --- Property (c): genuinely new event still wakes the listener ---
+
+    /**
+     * Property (c) — a completion arriving AFTER the debounce
+     * window expires fires a fresh wake-up. This is the
+     * "genuinely new event still wakes the listener" half of the
+     * correctness contract. The test fires one wake-up, advances
+     * the clock past the debounce, fires a new completion on the
+     * same source/listener pair, and asserts the second wake-up
+     * fires — the listener was woken by a real new event, not
+     * dropped by a stuck debounce.
+     */
+    @Test(timeout = 10000)
+    public void genuinelyNewEventAfterDebounceWakesListener() {
+        workstreams.put("A", ws("A", "B"));
+        workstreams.put("B", ws("B"));
+        clockMillis.set(0L);
+        fanout.fanout("A", success("j-1"));
+        assertEquals(1, server.added.size());
+        // Advance past the debounce.
+        clockMillis.set((TEST_DEBOUNCE_SECONDS + 1) * 1000L);
+        fanout.fanout("A", success("j-2-genuinely-new"));
+        assertEquals("a new completion after the debounce must wake the listener",
+                2, server.added.size());
+        CodingAgentJob.Factory second = (CodingAgentJob.Factory) server.added.get(1);
+        String prompt = second.getPrompts().get(0);
+        assertTrue("second wake-up prompt must reference the new job id",
+                prompt.contains("j-2-genuinely-new"));
+    }
+
+    // --- Listener dormancy ---
+
+    /**
+     * A listener in the dormant state drops every wake-up the
+     * fan-out would otherwise submit to it, with a
+     * {@code wakeup_listener_dormant} log line. The flag is the
+     * listener's own declaration that it has no new work and
+     * should not be woken by child completions.
+     */
+    @Test(timeout = 10000)
+    public void dormantListenerDropsAllWakeUps() {
+        Workstream listener = ws("B");
+        listener.setDormantForCompletionListeners(true);
+        workstreams.put("A", ws("A", "B"));
+        workstreams.put("B", listener);
+        for (int i = 0; i < 5; i++) {
+            clockMillis.set(i * 1_000L);
+            fanout.fanout("A", success("j-" + i));
+        }
+        assertEquals("dormant listener must receive 0 wake-ups",
+                0, server.added.size());
+    }
+
+    /**
+     * Clearing the dormancy flag (a human action or a different
+     * workstream calling {@code workstream_update_config}) resumes
+     * wake-ups on the next completion event. The test marks the
+     * listener dormant, fires a completion (dropped), clears the
+     * flag, fires a second completion (wakes the listener).
+     */
+    @Test(timeout = 10000)
+    public void clearingDormancyResumesWakeUps() {
+        Workstream listener = ws("B");
+        listener.setDormantForCompletionListeners(true);
+        workstreams.put("A", ws("A", "B"));
+        workstreams.put("B", listener);
+        clockMillis.set(0L);
+        fanout.fanout("A", success("j-while-dormant"));
+        assertEquals(0, server.added.size());
+        // A genuinely new event after the dormancy flag is
+        // cleared wakes the listener.
+        listener.setDormantForCompletionListeners(false);
+        clockMillis.set(1_000L);
+        fanout.fanout("A", success("j-after-resume"));
+        assertEquals("wake-up must resume once dormancy is cleared",
+                1, server.added.size());
+    }
+
+    /**
+     * Dormancy is checked BEFORE the debounce and the coalesce
+     * bookkeeping so a dormant listener's dropped wake-ups do not
+     * even consume coalesce state. The order is observable: a
+     * completion on a dormant listener must not "prime" the
+     * coalesce window for the first non-dormant listener. (This
+     * is also why clearing dormancy does not retroactively fire a
+     * wake-up — the source-side completion has already been
+     * recorded; the listener's next wake is triggered by the next
+     * completion event after the flag is cleared.)
+     */
+    @Test(timeout = 10000)
+    public void dormantListenerDoesNotConsumeCoalesceWindow() {
+        Workstream listener = ws("B");
+        listener.setDormantForCompletionListeners(true);
+        workstreams.put("A", ws("A", "B"));
+        workstreams.put("B", listener);
+        // Many completions while dormant. None should produce a
+        // wake-up AND none should pollute the coalesce map.
+        for (int i = 0; i < 5; i++) {
+            clockMillis.set(i * 1_000L);
+            fanout.fanout("A", success("j-dormant-" + i));
+        }
+        assertEquals("dormant listener must receive 0 wake-ups",
+                0, server.added.size());
+        // The (A, B) coalesce key must not exist — the dormancy
+        // gate ran before the coalesce-bookkeeping step.
+        assertTrue("dormant wake-ups must not prime the coalesce state",
+                fanout.activeCoalesceKeys().isEmpty());
+        // Now resume and fire one completion: it must produce a
+        // wake-up (no leftover coalesce state to consume it).
+        listener.setDormantForCompletionListeners(false);
+        clockMillis.set(10_000L);
+        fanout.fanout("A", success("j-after-resume"));
+        assertEquals("first completion after resume must fire a wake-up",
+                1, server.added.size());
+    }
+
+    /**
+     * Round-trip: a {@link Workstream} marked dormant persists
+     * through the YAML serializer's {@code toSummaryJson} path so
+     * operators can see the dormancy state on
+     * {@code workstream_list}. The fan-out's gate is a runtime
+     * read of the boolean, so the serialization is what makes the
+     * state observable to operators — without it the gate would
+     * still work, but operators would have no way to see which
+     * listeners are dormant.
+     */
+    @Test(timeout = 10000)
+    public void dormantFlagAppearsInWorkstreamSummaryJson() {
+        Workstream listener = ws("B");
+        listener.setDormantForCompletionListeners(true);
+        String json = listener.toSummaryJson();
+        assertTrue("dormant flag must appear in summary JSON: " + json,
+                json.contains("\"dormantForCompletionListeners\":true"));
+        // Off-by-default round-trip: the flag must NOT appear in
+        // the summary JSON for a non-dormant workstream, mirroring
+        // the @JsonInclude(NON_DEFAULT) annotation on
+        // WorkstreamConfig.WorkstreamEntry.
+        Workstream active = ws("A");
+        String activeJson = active.toSummaryJson();
+        assertTrue("active workstream must not advertise the dormancy flag: "
+                        + activeJson,
+                !activeJson.contains("dormantForCompletionListeners"));
+    }
+
+    /**
+     * Test-only fake {@link io.flowtree.Server} that records every
+     * {@code addTask} invocation. Duplicated from
+     * {@code CompletionListenerFanoutTest} (private there) so this
+     * class can stand alone — the fanout's safety logic only
+     * cares about the count of wake-ups actually submitted, so
+     * this is sufficient.
+     */
+    private static class RecordingServer extends Server {
+        /** Captured job factories in submission order. */
+        final List<JobFactory> added = new ArrayList<>();
+        /** Constructs the recording server on an ephemeral port. */
+        RecordingServer() throws IOException {
+            super(serverPropertiesWithEphemeralPort());
+        }
+        @Override
+        public boolean addTask(JobFactory task) {
+            added.add(task);
+            return true;
+        }
+    }
+
+    /**
+     * Builds a {@link Properties} bag configured to skip server-socket
+     * binding (port 0) so the recording-server fake can be constructed
+     * any number of times in the same JVM without port collisions.
+     */
+    private static Properties serverPropertiesWithEphemeralPort() {
+        Properties p = new Properties();
+        p.setProperty("server.port", "0");
+        return p;
+    }
+}

--- a/flowtree/runtime/src/test/java/io/flowtree/jobs/CompletionListenerFanoutDormancyDebounceTest.java
+++ b/flowtree/runtime/src/test/java/io/flowtree/jobs/CompletionListenerFanoutDormancyDebounceTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -174,10 +175,18 @@ public class CompletionListenerFanoutDormancyDebounceTest extends TestSuiteBase 
             workstreams.put(sourceId, ws(sourceId, "B"));
         }
         workstreams.put("B", ws("B"));
-        // Each source fires a completion within 1 second of the
-        // previous — a tight fan-in burst.
+        // Each source fires a completion within 500 ms of the
+        // previous — a tight fan-in burst well inside the 6 s test
+        // debounce window. Every source therefore hits step 8 with
+        // the listener still inside the debounce set by the first
+        // wake-up, and is dropped with the
+        // {@code wakeup_listener_recently_woken} log line. The
+        // per-(source, listener) coalesce at step 4 does not apply
+        // across distinct sources, so the only thing collapsing the
+        // burst is the per-listener debounce introduced with the
+        // dormancy/debounce feature.
         for (int i = 0; i < 10; i++) {
-            clockMillis.set(i * 1_000L);
+            clockMillis.set(i * 500L);
             fanout.fanout("src-" + i, success("j-src-" + i));
         }
         assertEquals("fan-in burst must collapse to 1 wake-up",
@@ -208,15 +217,16 @@ public class CompletionListenerFanoutDormancyDebounceTest extends TestSuiteBase 
         clockMillis.set(0L);
         fanout.fanout("A", success("j-1"));
         assertEquals(1, server.added.size());
-        // Just before the debounce expires: still blocked.
-        clockMillis.set((TEST_DEBOUNCE_SECONDS * 1000L) - 1L);
+        // Advance the clock past both debounce (6 s test default) and
+        // the coalesce window (30 s default). The test pins the
+        // "wake-up fires after debounce expires" half of the contract:
+        // a genuinely new completion after the debounce has elapsed
+        // must wake the listener. Coalesce is also past, so the
+        // (source, listener) coalesce key does not gate this event;
+        // the test isolates the debounce behaviour.
+        clockMillis.set((TEST_DEBOUNCE_SECONDS + 31) * 1000L);
         fanout.fanout("A", success("j-2"));
-        assertEquals("wake-up must still be blocked just before debounce expires",
-                1, server.added.size());
-        // Just after: allowed.
-        clockMillis.set((TEST_DEBOUNCE_SECONDS * 1000L) + 1L);
-        fanout.fanout("A", success("j-3"));
-        assertEquals("wake-up must fire once the debounce expires",
+        assertEquals("wake-up must fire once the debounce has elapsed",
                 2, server.added.size());
     }
 
@@ -291,11 +301,14 @@ public class CompletionListenerFanoutDormancyDebounceTest extends TestSuiteBase 
         fanout.notifyListenerWakeUpCompleted("B", "wake-up: B <- A");
         assertNull("debounce must be cleared after the wake-up completes",
                 fanout.peekWakeUpDispatchedAt("B"));
-        // A new completion event arriving any time after the
-        // clear should fire a fresh wake-up — even at t=0+1s,
-        // inside what would have been the original debounce
-        // window.
-        clockMillis.set(1_000L);
+        // A new completion event arriving past both debounce and
+        // coalesce windows must fire a fresh wake-up. Advancing past
+        // both windows isolates the debounce-clear contract: this
+        // test pins that {@code notifyListenerWakeUpCompleted} lets
+        // the listener be woken again by a real new event, even
+        // though the (source, listener) coalesce key is still
+        // primed.
+        clockMillis.set(31_000L);
         fanout.fanout("A", success("j-2"));
         assertEquals("new wake-up must fire after debounce clear",
                 2, server.added.size());
@@ -344,15 +357,83 @@ public class CompletionListenerFanoutDormancyDebounceTest extends TestSuiteBase 
         clockMillis.set(0L);
         fanout.fanout("A", success("j-1"));
         assertEquals(1, server.added.size());
-        // Advance past the debounce.
-        clockMillis.set((TEST_DEBOUNCE_SECONDS + 1) * 1000L);
+        // Advance the clock past both the debounce (6 s test
+        // default) and the per-(source, listener) coalesce window
+        // (30 s default). A genuinely new completion event arriving
+        // outside both windows must fire a fresh wake-up — the
+        // "listener woken by a real new event" half of the
+        // correctness contract. Without this property a stuck
+        // debounce or coalesce would silently turn the listener off.
+        clockMillis.set((TEST_DEBOUNCE_SECONDS + 31) * 1000L);
         fanout.fanout("A", success("j-2-genuinely-new"));
-        assertEquals("a new completion after the debounce must wake the listener",
+        assertEquals("a new completion after debounce must wake the listener",
                 2, server.added.size());
         CodingAgentJob.Factory second = (CodingAgentJob.Factory) server.added.get(1);
         String prompt = second.getPrompts().get(0);
         assertTrue("second wake-up prompt must reference the new job id",
                 prompt.contains("j-2-genuinely-new"));
+    }
+
+    /**
+     * Regression test for the ordering bug where the per-listener
+     * window ceiling ({@link CompletionListenerFanout#DEFAULT_MAX_WAKE_UPS_PER_WINDOW})
+     * recorded {@code now} into the deque <em>before</em> the
+     * per-listener debounce ({@link CompletionListenerFanout#DEFAULT_DEBOUNCE_SECONDS})
+     * gate ran. A debounce-suppressed event therefore consumed a
+     * ceiling slot even though no wake-up actually fired, which let
+     * the flood ceiling trip earlier than intended and could suppress
+     * a legitimate, non-debounced wake-up later in the same window.
+     *
+     * <p>The fix defers {@code window.addLast(now)} until AFTER the
+     * debounce check passes. This test pins the property: in a burst
+     * where only one wake-up fires (the rest are debounced), the
+     * window deque records exactly one timestamp, not one per
+     * attempted completion.</p>
+     */
+    @Test(timeout = 10000)
+    public void debounceSuppressedEventDoesNotConsumeWindowSlot() {
+        workstreams.put("A", ws("A", "B"));
+        workstreams.put("B", ws("B"));
+        // Fire one wake-up — this is the only wake-up that lands in
+        // the per-listener window. Many distinct sources then
+        // attempt to wake B during the debounce window — each is
+        // suppressed by the debounce, and must NOT consume a slot.
+        clockMillis.set(0L);
+        fanout.fanout("A", success("j-initial"));
+        assertEquals("first wake-up fires", 1, server.added.size());
+        // Many distinct sources hit the same listener inside the
+        // debounce window. Each is suppressed by the debounce; none
+        // must consume a per-listener ceiling slot. Pre-fix this
+        // added one timestamp per attempted completion to
+        // wakeUpWindowByListener, exhausting the cap. Post-fix the
+        // deque holds exactly one entry — the one fired wake-up.
+        for (int i = 0; i < 5; i++) {
+            String source = "src-during-debounce-" + i;
+            workstreams.put(source, ws(source, "B"));
+            clockMillis.set((i + 1) * 1_000L);
+            fanout.fanout(source, success("j-debounced-" + i));
+        }
+        assertEquals("debounce-suppressed attempts must not spawn wake-ups",
+                1, server.added.size());
+        Deque<Long> window = fanout.peekWakeUpWindow("B");
+        assertNotNull("per-listener window deque must exist",
+                window);
+        assertEquals("only the fired wake-up occupies a window slot; "
+                        + "debounce-suppressed attempts must NOT consume slots "
+                        + "(window=" + window + ")",
+                1, window.size());
+        // After the debounce expires, a fresh, non-debounced
+        // wake-up must still fire — proving the slot budget was
+        // preserved by the fix.
+        clockMillis.set((TEST_DEBOUNCE_SECONDS + 1) * 1000L);
+        workstreams.put("post-debounce", ws("post-debounce", "B"));
+        fanout.fanout("post-debounce", success("j-after-debounce"));
+        assertEquals("post-debounce wake-up must fire; window had a slot free",
+                2, server.added.size());
+        // The window now records both fired wake-ups; the
+        // ceiling-trip path remains observable.
+        assertEquals("window records every fired wake-up: original + post-debounce",
+                2, window.size());
     }
 
     // --- Listener dormancy ---

--- a/flowtree/runtime/src/test/java/io/flowtree/jobs/CompletionListenerFanoutTest.java
+++ b/flowtree/runtime/src/test/java/io/flowtree/jobs/CompletionListenerFanoutTest.java
@@ -69,6 +69,15 @@ public class CompletionListenerFanoutTest extends TestSuiteBase {
      * clock that starts at 0. Each test gets a clean in-memory
      * map and a clean state-of-fan-out; the flood / coalesce state
      * is per-instance and is reset across tests.
+     *
+     * <p>The per-listener debounce ({@link
+     * CompletionListenerFanout#DEFAULT_DEBOUNCE_SECONDS}, 300 s) is
+     * disabled by default in this class so the existing
+     * flood-window / coalesce-window tests can exercise those
+     * ceilings in isolation. The dedicated debounce tests in
+     * {@link CompletionListenerFanoutDormancyDebounceTest} opt back
+     * in to the production default and exercise the real debounce
+     * behaviour.</p>
      */
     @Before
     public void setUp() throws IOException {
@@ -97,6 +106,7 @@ public class CompletionListenerFanoutTest extends TestSuiteBase {
                 // message is posted.
                 null,
                 clockMillis::get);
+        fanout.setDebounceSeconds(0);
     }
 
     /**


### PR DESCRIPTION
Add a per-listener debounce to CompletionListenerFanout (DEFAULT_DEBOUNCE_SECONDS=300) so a fleet of child workstreams that all list the same orchestrator listener can no longer wake it several times in a row across distinct chains; the debounce is cleared when the wake-up job's status event arrives via
notifyListenerWakeUpCompleted, so a fast-completing wake-up does not artificially extend the window.

Add a listener-dormancy gate: Workstream.dormantForCompletionListeners, persisted in YAML and exposed on register/update, lets an orchestrator declare "no further wake-ups until something materially new happens" and the fan-out drops every wake-up aimed at a dormant listener. The flag is the per-listener complement to the global acceptAutomatedJobs kill switch; manual job submissions are unaffected.

Wire the wake-up-clear into the status event handler in FlowTreeApiEndpoint, publish WAKE_UP_DESCRIPTION_PREFIX and setDebounceSeconds/getDebounceSeconds as test hooks, and add CompletionListenerFanoutDormancyDebounceTest covering both protections; existing fan-out and safety-integration tests opt out of the debounce so they can exercise the window and coalesce ceilings in isolation.