### PR TITLE
A random producer is a placeholder as far as the kernel is concerned

### DIFF
--- a/compute/algebra/src/main/java/org/almostrealism/collect/computations/Random.java
+++ b/compute/algebra/src/main/java/org/almostrealism/collect/computations/Random.java
@@ -22,6 +22,7 @@ import io.almostrealism.profile.OperationMetadata;
 import io.almostrealism.relation.Evaluable;
 import io.almostrealism.relation.Producer;
 import io.almostrealism.uml.Multiple;
+import io.almostrealism.uml.Signature;
 import org.almostrealism.collect.CollectionProducer;
 import org.almostrealism.collect.PackedCollection;
 import org.almostrealism.hardware.MemoryBank;
@@ -71,7 +72,7 @@ import java.util.stream.IntStream;
  * @see PackedCollection
  * @since 0.52
  */
-public class Random implements CollectionProducer, OperationInfo {
+public class Random implements CollectionProducer, OperationInfo, Signature {
 	/** Static seed used by the xorshift random number generator in {@link #nextInt()} and {@link #nextFloat()} */
 	private static long seed;
 
@@ -162,11 +163,40 @@ public class Random implements CollectionProducer, OperationInfo {
 
 	/**
 	 * Returns the metadata describing this random generation operation.
-	 * 
+	 *
 	 * @return the {@link OperationMetadata} containing operation details
 	 */
 	@Override
 	public OperationMetadata getMetadata() { return metadata; }
+
+	/**
+	 * Returns a signature covering the shape and distribution, but deliberately
+	 * not the generated values.
+	 *
+	 * <p>The values are <em>data</em>, not structure. They reach the device the
+	 * way any other argument does, so a kernel built over this producer has the
+	 * same body whatever the values happen to be — {@code rand(shape).multiply(2.0)}
+	 * compiles identically to {@code placeholder(shape).multiply(2.0)}. Excluding
+	 * the values is therefore what makes the signature correct, not a concession:
+	 * two generators of the same shape and distribution really do produce the same
+	 * program.</p>
+	 *
+	 * <p>Without a signature here every enclosing computation was uncacheable,
+	 * because {@code ProducerComputationBase.signature()} returns null as soon as
+	 * any input signature is null. That cost a fresh compilation each time a graph
+	 * over a random producer was constructed, which is ruinous in a loop.</p>
+	 *
+	 * <p>This does not merge distinct generators. Sharing a single instance
+	 * ({@code a.multiply(a)}, which squares) stays distinguishable from two
+	 * separate ones ({@code rand(s).multiply(rand(s))}, which multiplies
+	 * independent series) because distinct children are counted by identity.</p>
+	 *
+	 * @return the structural signature of this generator
+	 */
+	@Override
+	public String signature() {
+		return "rand(" + (normal ? "normal" : "uniform") + "{" + shape.toStringDetail() + "})";
+	}
 
 	/**
 	 * Initializes the random values array if it hasn't been created yet.

--- a/docs/plans/SETMEM_POLICY_ENFORCEMENT.md
+++ b/docs/plans/SETMEM_POLICY_ENFORCEMENT.md
@@ -165,34 +165,45 @@ sites illegal. Measured 2026-07-30 (textual scan, so counts are approximate):
 Sequenced correctly (migrate first, flip the rules second), the enforcement flip
 adds zero new baseline rows; flipped early it would add ~195.
 
-### Opportunity: let a Random producer participate in InstructionSet sharing
+### A Random producer participates in InstructionSet sharing
 
-Nothing containing a `Random` producer appears to be cached for instruction-set
-sharing today. It probably could be. `rand(shape).multiply(2.0)` has the same
-*structure* as `placeholder(shape).multiply(2.0)` — the random values are
-**data**, not structure, and they reach the device the same way any other
-argument does. If `Random` contributed a placeholder to the signature rather
-than anything value-dependent, every graph built over it would become
-signature-stable and the compiled kernel would be reused.
+Nothing containing a `Random` producer was cached for instruction-set sharing.
+The mechanism was total rather than partial: `ProducerComputationBase.signature()`
+collects `Signature.of(input)` for every input and returns null if *any* of them
+is null, and `Signature.of` returns null for anything not implementing
+`Signature`. `Random` implemented no signature, so every computation anywhere
+above a `rand()` or `randn()` had a null signature and was recompiled on each
+construction.
 
-The payoff is concrete and was measured during the fill-lambda migration: a
-statement like
+`Random` now carries a structural signature — shape and distribution, and
+deliberately neither the generated values nor the `java.util.Random` source.
+Excluding them is what makes the signature *correct* rather than a concession:
+the values are data that reach the device as an argument, so
+`rand(shape).multiply(2.0)` compiles to the same kernel body as
+`placeholder(shape).multiply(2.0)` whatever they are.
+`PassThroughProducer.signature()` is the precedent for this shape of answer.
+
+This does not merge generators that must stay apart. Sharing one instance
+(`a.multiply(a)`, which squares) stays distinguishable from two separate ones
+(`rand(s).multiply(rand(s))`, which multiplies independent series), because
+`Random` does not override `equals`/`hashCode` and the distinct-child count is
+identity-based.
+
+Measured on `TrainModelTest`, whose training loop runs `epochCount * 1000`
+iterations of
 
 ```java
 rand(input.getShape()).multiply(0.5).add(0.5).into(input.traverseEach()).evaluate();
 ```
 
-is fine at setup (a handful of iterations) but is the wrong shape inside a hot
-training loop running `epochCount * 1000` times, because the graph is rebuilt
-per iteration. Two sites — `TrainModelTest.train` and
-`MyNativeEnabledApplication` — were left on `fill(pos -> ...)` for exactly this
-reason and are still carried in the baseline. With sharing in place they become
-ordinary migrations, and the same applies to every remaining loop-resident
-random fill.
+the statement went from timing out at 240s per method to passing in 94s. The
+host `fill` it replaced took 63s, so the compile storm is gone while roughly
+0.3ms per iteration of graph *construction* remains — enough that a genuinely
+hot loop still deserves a hoisted evaluable, and the reason a
+loop-resident-producer check is worth keeping in review.
 
-This is a large win for something not especially complicated, and it is
-independent of the device-RNG work below — it makes the *enclosing* kernel
-cacheable regardless of how the random values themselves are produced.
+This is independent of the device-RNG work below: it makes the *enclosing*
+kernel cacheable regardless of how the random values themselves are produced.
 
 ### Use cases that do not fit the contract, and their resolutions
 

--- a/engine/utils/src/main/resources/org/almostrealism/util/setmem-violation-baseline.tsv
+++ b/engine/utils/src/main/resources/org/almostrealism/util/setmem-violation-baseline.tsv
@@ -45,7 +45,6 @@ FILL_PACK_BEYOND_SCALAR_ALLOWANCE	engine/utils/src/main/java/org/almostrealism/u
 FILL_PACK_BEYOND_SCALAR_ALLOWANCE	engine/utils/src/main/java/org/almostrealism/util/ModelTestFeatures.java	1	data.add(ValueTarget.of(input, new PackedCollection(outShape).fill(Math::random)));
 FILL_PACK_BEYOND_SCALAR_ALLOWANCE	engine/utils/src/test/java/org/almostrealism/MyNativeEnabledApplication.java	1	PackedCollection v = pack(IntStream.range(0, count * dim).boxed()
 FILL_PACK_BEYOND_SCALAR_ALLOWANCE	engine/utils/src/test/java/org/almostrealism/MyNativeEnabledApplication.java	1	a.fill(Math::random);
-FILL_PACK_BEYOND_SCALAR_ALLOWANCE	engine/utils/src/test/java/org/almostrealism/MyNativeEnabledApplication.java	1	input.fill(pos -> 0.5 + 0.5 * Math.random());
 FILL_PACK_BEYOND_SCALAR_ALLOWANCE	engine/utils/src/test/java/org/almostrealism/algebra/computations/test/MatrixDeltaComputationTests.java	2	PackedCollection b = new PackedCollection(shape(nodes)).fill(Math::random);
 FILL_PACK_BEYOND_SCALAR_ALLOWANCE	engine/utils/src/test/java/org/almostrealism/algebra/computations/test/MatrixDeltaComputationTests.java	1	PackedCollection g = new PackedCollection(shape(nodes)).fill(Math::random);
 FILL_PACK_BEYOND_SCALAR_ALLOWANCE	engine/utils/src/test/java/org/almostrealism/algebra/computations/test/MatrixDeltaComputationTests.java	3	PackedCollection v = new PackedCollection(shape(size)).fill(Math::random);
@@ -91,23 +90,10 @@ FILL_PACK_BEYOND_SCALAR_ALLOWANCE	engine/utils/src/test/java/org/almostrealism/g
 FILL_PACK_BEYOND_SCALAR_ALLOWANCE	engine/utils/src/test/java/org/almostrealism/graph/model/test/ConvolutionModelTrainingTest.java	1	data.add(ValueTarget.of(input, new PackedCollection(outShape).fill(pos -> pos[0] % 2 == 0 ? 1.0 : 0.0)));
 FILL_PACK_BEYOND_SCALAR_ALLOWANCE	engine/utils/src/test/java/org/almostrealism/graph/model/test/ConvolutionModelTrainingTest.java	2	input.fill(pos -> {
 FILL_PACK_BEYOND_SCALAR_ALLOWANCE	engine/utils/src/test/java/org/almostrealism/graph/model/test/ConvolutionModelTrainingTest.java	1	new PackedCollection(outShape).fill(pos -> pos[0] % 2 == v ? 1.0 : 0.0)));
-FILL_PACK_BEYOND_SCALAR_ALLOWANCE	engine/utils/src/test/java/org/almostrealism/graph/model/test/DenseLayerTests.java	1	.map(input -> input.fill(pos -> 4 + 3 * Math.random()))
-FILL_PACK_BEYOND_SCALAR_ALLOWANCE	engine/utils/src/test/java/org/almostrealism/graph/model/test/GradientDescentTests.java	1	.map(input -> input.fill(pos -> 2.0 + 3 * Math.random()))
-FILL_PACK_BEYOND_SCALAR_ALLOWANCE	engine/utils/src/test/java/org/almostrealism/graph/model/test/GradientDescentTests.java	2	.map(input -> input.fill(pos -> 4 + 3 * Math.random()))
-FILL_PACK_BEYOND_SCALAR_ALLOWANCE	engine/utils/src/test/java/org/almostrealism/graph/model/test/GradientDescentTests.java	1	.map(input -> input.fill(pos -> 5 + 2 * Math.random()))
-FILL_PACK_BEYOND_SCALAR_ALLOWANCE	engine/utils/src/test/java/org/almostrealism/graph/model/test/GradientDescentTests.java	1	.map(input -> input.fill(pos -> 5 + 4 * Math.random()))
 FILL_PACK_BEYOND_SCALAR_ALLOWANCE	engine/utils/src/test/java/org/almostrealism/graph/model/test/LayerTrackingTest.java	1	input.fill(pos -> 0.01 * pos[0]);
 FILL_PACK_BEYOND_SCALAR_ALLOWANCE	engine/utils/src/test/java/org/almostrealism/graph/model/test/LayerTrackingTest.java	1	w1.fill(pos -> 0.01 * (pos[0] + 1));
 FILL_PACK_BEYOND_SCALAR_ALLOWANCE	engine/utils/src/test/java/org/almostrealism/graph/model/test/LayerTrackingTest.java	1	w2.fill(pos -> 0.02 * (pos[0] + 1));
-FILL_PACK_BEYOND_SCALAR_ALLOWANCE	engine/utils/src/test/java/org/almostrealism/graph/model/test/StrictShapeEnforcementTest.java	1	.map(input -> input.fill(pos -> 4 + 3 * Math.random()))
-FILL_PACK_BEYOND_SCALAR_ALLOWANCE	engine/utils/src/test/java/org/almostrealism/graph/model/test/SyntheticActivationTrainingTest.java	3	.map(input -> input.fill(pos -> 4 + 3 * Math.random()))
-FILL_PACK_BEYOND_SCALAR_ALLOWANCE	engine/utils/src/test/java/org/almostrealism/graph/model/test/SyntheticCompositionTrainingTest.java	2	.map(input -> input.fill(pos -> 4 + 3 * Math.random()))
 FILL_PACK_BEYOND_SCALAR_ALLOWANCE	engine/utils/src/test/java/org/almostrealism/graph/model/test/SyntheticDenseTrainingTest.java	1	.fill(Math::random);
-FILL_PACK_BEYOND_SCALAR_ALLOWANCE	engine/utils/src/test/java/org/almostrealism/graph/model/test/SyntheticDenseTrainingTest.java	2	.map(input -> input.fill(pos -> 4 + 3 * Math.random()))
-FILL_PACK_BEYOND_SCALAR_ALLOWANCE	engine/utils/src/test/java/org/almostrealism/graph/model/test/SyntheticDenseTrainingTest.java	1	.map(input -> input.fill(pos -> 5 + 4 * Math.random()))
-FILL_PACK_BEYOND_SCALAR_ALLOWANCE	engine/utils/src/test/java/org/almostrealism/graph/model/test/SyntheticNormTrainingTest.java	2	.map(input -> input.fill(pos -> (1 + 10 * Math.random()) * (Math.random() - 0.5)))
-FILL_PACK_BEYOND_SCALAR_ALLOWANCE	engine/utils/src/test/java/org/almostrealism/graph/model/test/SyntheticNormTrainingTest.java	1	.map(input -> input.fill(pos -> 4 + 3 * Math.random()))
-FILL_PACK_BEYOND_SCALAR_ALLOWANCE	engine/utils/src/test/java/org/almostrealism/graph/model/test/TrainModelTest.java	1	input.fill(pos -> 0.5 + 0.5 * Math.random());
 FILL_PACK_BEYOND_SCALAR_ALLOWANCE	engine/utils/src/test/java/org/almostrealism/hardware/test/KernelOperationTests.java	1	PackedCollection a = new PackedCollection(shape(2048)).fill(Math::random);
 FILL_PACK_BEYOND_SCALAR_ALLOWANCE	engine/utils/src/test/java/org/almostrealism/hardware/test/KernelOperationTests.java	1	PackedCollection b = new PackedCollection(shape(2048)).fill(Math::random);
 FILL_PACK_BEYOND_SCALAR_ALLOWANCE	engine/utils/src/test/java/org/almostrealism/layers/test/Conv1dLayerTests.java	1	input.fill(pos -> (pos[0] - size / 2.0) * 0.2);
@@ -116,7 +102,6 @@ FILL_PACK_BEYOND_SCALAR_ALLOWANCE	engine/utils/src/test/java/org/almostrealism/l
 FILL_PACK_BEYOND_SCALAR_ALLOWANCE	engine/utils/src/test/java/org/almostrealism/layers/test/Conv1dLayerTests.java	1	weights.fill(pos -> 1.0 / (inputChannels * kernelSize));
 FILL_PACK_BEYOND_SCALAR_ALLOWANCE	engine/utils/src/test/java/org/almostrealism/layers/test/Conv1dLayerTests.java	1	weights.fill(pos -> weightVal);
 FILL_PACK_BEYOND_SCALAR_ALLOWANCE	engine/utils/src/test/java/org/almostrealism/layers/test/DenseLayerShapeInvestigationTest.java	1	weights.fill(pos -> (pos[0] + 1) * 0.1);
-FILL_PACK_BEYOND_SCALAR_ALLOWANCE	engine/utils/src/test/java/org/almostrealism/layers/test/LayersTests.java	2	.map(input -> input.fill(pos -> 1 + 2 * Math.random()))
 FILL_PACK_BEYOND_SCALAR_ALLOWANCE	engine/utils/src/test/java/org/almostrealism/layers/test/LoRALinearTests.java	2	loraLayer.getLoraA().fill(pos -> random.nextGaussian() * 0.1);
 FILL_PACK_BEYOND_SCALAR_ALLOWANCE	engine/utils/src/test/java/org/almostrealism/layers/test/LoRALinearTests.java	3	loraLayer.getLoraB().fill(pos -> random.nextGaussian() * 0.1);
 FILL_PACK_BEYOND_SCALAR_ALLOWANCE	engine/utils/src/test/java/org/almostrealism/layers/test/NormLayerShapeInvestigationTest.java	1	input.fill(pos -> 1.0 + pos[0]);

--- a/engine/utils/src/test/java/org/almostrealism/MyNativeEnabledApplication.java
+++ b/engine/utils/src/test/java/org/almostrealism/MyNativeEnabledApplication.java
@@ -367,7 +367,7 @@ public class MyNativeEnabledApplication extends TestSuiteBase implements CodeFea
 		int count = 100 * epochSize;
 
 		for (int i = 0; i < count; i++) {
-			input.fill(pos -> 0.5 + 0.5 * Math.random());
+			rand(input.getShape()).multiply(0.5).add(0.5).into(input.traverseEach()).evaluate();
 
 			compiled.forward(input);
 

--- a/engine/utils/src/test/java/org/almostrealism/graph/model/test/DenseLayerTests.java
+++ b/engine/utils/src/test/java/org/almostrealism/graph/model/test/DenseLayerTests.java
@@ -72,7 +72,10 @@ public class DenseLayerTests extends TestSuiteBase implements ModelTestFeatures 
 
 		Supplier<Dataset<?>> data = () -> Dataset.of(IntStream.range(0, steps)
 				.mapToObj(i -> new PackedCollection(shape(bs, 3)))
-				.map(input -> input.fill(pos -> 4 + 3 * Math.random()))
+				.map(input -> {
+					rand(input.getShape()).multiply(3.0).add(4.0).into(input.traverseEach()).evaluate();
+					return input;
+				})
 				.map(input -> ValueTarget.of(input, func3x3(input)))
 				.collect(Collectors.toList()));
 

--- a/engine/utils/src/test/java/org/almostrealism/graph/model/test/GradientDescentTests.java
+++ b/engine/utils/src/test/java/org/almostrealism/graph/model/test/GradientDescentTests.java
@@ -73,7 +73,10 @@ public class GradientDescentTests extends TestSuiteBase implements ModelTestFeat
 
 		Supplier<Dataset<?>> data = () -> Dataset.of(IntStream.range(0, steps)
 				.mapToObj(i -> new PackedCollection(shape(1)))
-				.map(input -> input.fill(pos -> 2.0 + 3 * Math.random()))
+				.map(input -> {
+					rand(input.getShape()).multiply(3.0).add(2.0).into(input.traverseEach()).evaluate();
+					return input;
+				})
 				.map(input -> ValueTarget.of(input, func1.apply(input)))
 				.collect(Collectors.toList()));
 
@@ -99,7 +102,10 @@ public class GradientDescentTests extends TestSuiteBase implements ModelTestFeat
 
 		Supplier<Dataset<?>> data = () -> Dataset.of(IntStream.range(0, steps)
 				.mapToObj(i -> new PackedCollection(shape(2)))
-				.map(input -> input.fill(pos -> 5 + 2 * Math.random()))
+				.map(input -> {
+					rand(input.getShape()).multiply(2.0).add(5.0).into(input.traverseEach()).evaluate();
+					return input;
+				})
 				.map(input -> ValueTarget.of(input, func2.apply(input)))
 				.collect(Collectors.toList()));
 
@@ -122,7 +128,10 @@ public class GradientDescentTests extends TestSuiteBase implements ModelTestFeat
 
 		Supplier<Dataset<?>> data = () -> Dataset.of(IntStream.range(0, steps)
 				.mapToObj(i -> new PackedCollection(shape(3)))
-				.map(input -> input.fill(pos -> 4 + 3 * Math.random()))
+				.map(input -> {
+					rand(input.getShape()).multiply(3.0).add(4.0).into(input.traverseEach()).evaluate();
+					return input;
+				})
 				.map(input -> ValueTarget.of(input, func3x3.apply(input)))
 				.collect(Collectors.toList()));
 
@@ -147,7 +156,10 @@ public class GradientDescentTests extends TestSuiteBase implements ModelTestFeat
 
 		Supplier<Dataset<?>> data = () -> Dataset.of(IntStream.range(0, steps)
 				.mapToObj(i -> new PackedCollection(shape(3)))
-				.map(input -> input.fill(pos -> 4 + 3 * Math.random()))
+				.map(input -> {
+					rand(input.getShape()).multiply(3.0).add(4.0).into(input.traverseEach()).evaluate();
+					return input;
+				})
 				.map(input -> ValueTarget.of(input, func3.apply(input)))
 				.collect(Collectors.toList()));
 
@@ -179,7 +191,10 @@ public class GradientDescentTests extends TestSuiteBase implements ModelTestFeat
 
 			Supplier<Dataset<?>> data = () -> Dataset.of(IntStream.range(0, steps)
 					.mapToObj(i -> new PackedCollection(shape(inChannels)))
-					.map(input -> input.fill(pos -> 5 + 4 * Math.random()))
+					.map(input -> {
+						rand(input.getShape()).multiply(4.0).add(5.0).into(input.traverseEach()).evaluate();
+						return input;
+					})
 					.map(input -> ValueTarget.of(input, func3.apply(input)))
 					.collect(Collectors.toList()));
 

--- a/engine/utils/src/test/java/org/almostrealism/graph/model/test/StrictShapeEnforcementTest.java
+++ b/engine/utils/src/test/java/org/almostrealism/graph/model/test/StrictShapeEnforcementTest.java
@@ -141,7 +141,10 @@ public class StrictShapeEnforcementTest extends TestSuiteBase implements ModelTe
 
 		Supplier<Dataset<?>> data = () -> Dataset.of(IntStream.range(0, steps)
 				.mapToObj(i -> new PackedCollection(shape(inputSize)))
-				.map(input -> input.fill(pos -> 4 + 3 * Math.random()))
+				.map(input -> {
+					rand(input.getShape()).multiply(3.0).add(4.0).into(input.traverseEach()).evaluate();
+					return input;
+				})
 				.map(input -> ValueTarget.of(input, linearFunc.apply(input)))
 				.collect(Collectors.toList()));
 

--- a/engine/utils/src/test/java/org/almostrealism/graph/model/test/SyntheticActivationTrainingTest.java
+++ b/engine/utils/src/test/java/org/almostrealism/graph/model/test/SyntheticActivationTrainingTest.java
@@ -99,7 +99,10 @@ public class SyntheticActivationTrainingTest extends TestSuiteBase implements Mo
 		// Generate dataset
 		Supplier<Dataset<?>> data = () -> Dataset.of(IntStream.range(0, steps)
 				.mapToObj(i -> new PackedCollection(shape(inputSize)))
-				.map(input -> input.fill(pos -> 4 + 3 * Math.random()))
+				.map(input -> {
+					rand(input.getShape()).multiply(3.0).add(4.0).into(input.traverseEach()).evaluate();
+					return input;
+				})
 				.map(input -> ValueTarget.of(input, nonLinearFunc.apply(input)))
 				.collect(Collectors.toList()));
 
@@ -141,7 +144,10 @@ public class SyntheticActivationTrainingTest extends TestSuiteBase implements Mo
 		// Generate dataset
 		Supplier<Dataset<?>> data = () -> Dataset.of(IntStream.range(0, steps)
 				.mapToObj(i -> new PackedCollection(shape(inputSize)))
-				.map(input -> input.fill(pos -> 4 + 3 * Math.random()))
+				.map(input -> {
+					rand(input.getShape()).multiply(3.0).add(4.0).into(input.traverseEach()).evaluate();
+					return input;
+				})
 				.map(input -> ValueTarget.of(input, nonLinearFunc.apply(input)))
 				.collect(Collectors.toList()));
 
@@ -182,7 +188,10 @@ public class SyntheticActivationTrainingTest extends TestSuiteBase implements Mo
 		// Generate dataset
 		Supplier<Dataset<?>> data = () -> Dataset.of(IntStream.range(0, steps)
 				.mapToObj(i -> new PackedCollection(shape(inputSize)))
-				.map(input -> input.fill(pos -> 4 + 3 * Math.random()))
+				.map(input -> {
+					rand(input.getShape()).multiply(3.0).add(4.0).into(input.traverseEach()).evaluate();
+					return input;
+				})
 				.map(input -> ValueTarget.of(input, nonLinearFunc.apply(input)))
 				.collect(Collectors.toList()));
 

--- a/engine/utils/src/test/java/org/almostrealism/graph/model/test/SyntheticCompositionTrainingTest.java
+++ b/engine/utils/src/test/java/org/almostrealism/graph/model/test/SyntheticCompositionTrainingTest.java
@@ -107,7 +107,10 @@ public class SyntheticCompositionTrainingTest extends TestSuiteBase implements M
 		// Generate dataset - identity-like function benefits from residual
 		Supplier<Dataset<?>> data = () -> Dataset.of(IntStream.range(0, steps)
 				.mapToObj(i -> new PackedCollection(shape(size)))
-				.map(input -> input.fill(pos -> 4 + 3 * Math.random()))
+				.map(input -> {
+					rand(input.getShape()).multiply(3.0).add(4.0).into(input.traverseEach()).evaluate();
+					return input;
+				})
 				.map(input -> ValueTarget.of(input, identityLikeFunc.apply(input)))
 				.collect(Collectors.toList()));
 
@@ -147,7 +150,10 @@ public class SyntheticCompositionTrainingTest extends TestSuiteBase implements M
 		// Generate dataset
 		Supplier<Dataset<?>> data = () -> Dataset.of(IntStream.range(0, steps)
 				.mapToObj(i -> new PackedCollection(shape(size)))
-				.map(input -> input.fill(pos -> 4 + 3 * Math.random()))
+				.map(input -> {
+					rand(input.getShape()).multiply(3.0).add(4.0).into(input.traverseEach()).evaluate();
+					return input;
+				})
 				.map(input -> ValueTarget.of(input, scaleFunc.apply(input)))
 				.collect(Collectors.toList()));
 

--- a/engine/utils/src/test/java/org/almostrealism/graph/model/test/SyntheticDenseTrainingTest.java
+++ b/engine/utils/src/test/java/org/almostrealism/graph/model/test/SyntheticDenseTrainingTest.java
@@ -114,7 +114,10 @@ public class SyntheticDenseTrainingTest extends TestSuiteBase implements ModelTe
 		// Generate dataset using same pattern as GradientDescentTests
 		Supplier<Dataset<?>> data = () -> Dataset.of(IntStream.range(0, steps)
 				.mapToObj(i -> new PackedCollection(shape(size)))
-				.map(input -> input.fill(pos -> 4 + 3 * Math.random()))
+				.map(input -> {
+					rand(input.getShape()).multiply(3.0).add(4.0).into(input.traverseEach()).evaluate();
+					return input;
+				})
 				.map(input -> ValueTarget.of(input, linearFunc.apply(input)))
 				.collect(Collectors.toList()));
 
@@ -157,7 +160,10 @@ public class SyntheticDenseTrainingTest extends TestSuiteBase implements ModelTe
 		// Generate dataset
 		Supplier<Dataset<?>> data = () -> Dataset.of(IntStream.range(0, steps)
 				.mapToObj(i -> new PackedCollection(shape(inputSize)))
-				.map(input -> input.fill(pos -> 5 + 4 * Math.random()))
+				.map(input -> {
+					rand(input.getShape()).multiply(4.0).add(5.0).into(input.traverseEach()).evaluate();
+					return input;
+				})
 				.map(input -> ValueTarget.of(input, weightedSumFunc.apply(input)))
 				.collect(Collectors.toList()));
 
@@ -291,7 +297,10 @@ public class SyntheticDenseTrainingTest extends TestSuiteBase implements ModelTe
 		// Generate batched dataset
 		Supplier<Dataset<?>> data = () -> Dataset.of(IntStream.range(0, steps)
 				.mapToObj(i -> new PackedCollection(shape(batchSize, size)))
-				.map(input -> input.fill(pos -> 4 + 3 * Math.random()))
+				.map(input -> {
+					rand(input.getShape()).multiply(3.0).add(4.0).into(input.traverseEach()).evaluate();
+					return input;
+				})
 				.map(input -> ValueTarget.of(input, batchFunc.apply(input)))
 				.collect(Collectors.toList()));
 

--- a/engine/utils/src/test/java/org/almostrealism/graph/model/test/SyntheticNormTrainingTest.java
+++ b/engine/utils/src/test/java/org/almostrealism/graph/model/test/SyntheticNormTrainingTest.java
@@ -98,7 +98,12 @@ public class SyntheticNormTrainingTest extends TestSuiteBase implements ModelTes
 		// Generate dataset with varied input magnitudes to test normalization
 		Supplier<Dataset<?>> data = () -> Dataset.of(IntStream.range(0, steps)
 				.mapToObj(i -> new PackedCollection(shape(inputSize)))
-				.map(input -> input.fill(pos -> (1 + 10 * Math.random()) * (Math.random() - 0.5)))
+				.map(input -> {
+					rand(input.getShape()).multiply(10.0).add(1.0)
+							.multiply(rand(input.getShape()).add(-0.5))
+							.into(input.traverseEach()).evaluate();
+					return input;
+				})
 				.map(input -> ValueTarget.of(input, linearFunc.apply(input)))
 				.collect(Collectors.toList()));
 
@@ -142,7 +147,12 @@ public class SyntheticNormTrainingTest extends TestSuiteBase implements ModelTes
 		// Generate dataset with varied input magnitudes
 		Supplier<Dataset<?>> data = () -> Dataset.of(IntStream.range(0, steps)
 				.mapToObj(i -> new PackedCollection(shape(inputSize)))
-				.map(input -> input.fill(pos -> (1 + 10 * Math.random()) * (Math.random() - 0.5)))
+				.map(input -> {
+					rand(input.getShape()).multiply(10.0).add(1.0)
+							.multiply(rand(input.getShape()).add(-0.5))
+							.into(input.traverseEach()).evaluate();
+					return input;
+				})
 				.map(input -> ValueTarget.of(input, linearFunc.apply(input)))
 				.collect(Collectors.toList()));
 
@@ -188,7 +198,10 @@ public class SyntheticNormTrainingTest extends TestSuiteBase implements ModelTes
 		// Generate dataset
 		Supplier<Dataset<?>> data = () -> Dataset.of(IntStream.range(0, steps)
 				.mapToObj(i -> new PackedCollection(shape(inputSize)))
-				.map(input -> input.fill(pos -> 4 + 3 * Math.random()))
+				.map(input -> {
+					rand(input.getShape()).multiply(3.0).add(4.0).into(input.traverseEach()).evaluate();
+					return input;
+				})
 				.map(input -> {
 					PackedCollection out = new PackedCollection(shape(outputSize));
 					cp(extCoeff).multiply(cp(input).valueAt(integers(0, outputSize).mod(inputSize)))

--- a/engine/utils/src/test/java/org/almostrealism/graph/model/test/TrainModelTest.java
+++ b/engine/utils/src/test/java/org/almostrealism/graph/model/test/TrainModelTest.java
@@ -375,7 +375,7 @@ public class TrainModelTest extends TestSuiteBase implements ModelFeatures, Kern
 			long start = 0;
 
 			for (int i = 0; i < count; i++) {
-				input.fill(pos -> 0.5 + 0.5 * Math.random());
+				rand(input.getShape()).multiply(0.5).add(0.5).into(input.traverseEach()).evaluate();
 
 				// Supply the input in the model's declared shape (e.g. batched/channeled).
 				compiled.forward(input.reshape(compiled.getInputShape()));

--- a/engine/utils/src/test/java/org/almostrealism/layers/test/LayersTests.java
+++ b/engine/utils/src/test/java/org/almostrealism/layers/test/LayersTests.java
@@ -168,7 +168,10 @@ public class LayersTests extends TestSuiteBase implements LayerFeatures, Distrib
 
 		Supplier<Dataset<?>> data = () -> Dataset.of(IntStream.range(0, steps)
 				.mapToObj(i -> new PackedCollection(shape(size)))
-				.map(input -> input.fill(pos -> 1 + 2 * Math.random()))
+				.map(input -> {
+					rand(input.getShape()).multiply(2.0).add(1.0).into(input.traverseEach()).evaluate();
+					return input;
+				})
 				.map(input -> ValueTarget.of(input, input))
 				.collect(Collectors.toList()));
 		ModelOptimizer train = new ModelOptimizer(model, profile, data);
@@ -198,7 +201,10 @@ public class LayersTests extends TestSuiteBase implements LayerFeatures, Distrib
 
 		Supplier<Dataset<?>> data = () -> Dataset.of(IntStream.range(0, steps)
 				.mapToObj(i -> new PackedCollection(shape(size)))
-				.map(input -> input.fill(pos -> 1 + 2 * Math.random()))
+				.map(input -> {
+					rand(input.getShape()).multiply(2.0).add(1.0).into(input.traverseEach()).evaluate();
+					return input;
+				})
 				.map(input -> ValueTarget.of(input, input))
 				.collect(Collectors.toList()));
 


### PR DESCRIPTION
Nothing containing a Random producer was ever cached for instruction-set sharing, and the mechanism was total rather than partial. Signature.of returns null for anything that does not implement Signature, and ProducerComputationBase.signature() returns null as soon as any one of its inputs is null. Random implemented no signature, so every computation anywhere above a rand() or randn() had a null signature and was recompiled on each construction.

Random now carries a structural signature: shape and distribution, and deliberately neither the generated values nor the source they came from. Excluding them is what makes the signature correct rather than a concession the change gets away with. The values are data; they reach the device as an argument like any other, so rand(shape).multiply(2.0) compiles to the same kernel body as placeholder(shape).multiply(2.0) whatever they happen to be. PassThroughProducer answers the same question the same way.

Generators that must stay apart still do. Sharing one instance — a.multiply(a), which squares — remains distinguishable from two separate ones, which multiply independent series, because Random does not override equals and the distinct child count is by identity. That distinction is the reason the values are cached in the first place, so it was the thing to preserve.

TrainModelTest is the measurement. Its loop runs epochCount * 1000 iterations of a producer chain over a random fill; it timed out at four minutes a method before and passes in ninety-four seconds now. The host fill it replaced took sixty-three, so the compile storm is gone while graph construction is not free. A hot enough loop still wants a hoisted evaluable.

That unblocks the twenty fill sites that were stranded in map pipelines, where the fill is a value in a stream and the producer form is a statement, so each lambda becomes a block. Two of them draw twice per element and now say so explicitly, with two generators rather than one reused. The ledger drops fifteen more entries.