### PR TITLE
A note from a prior session is not documentation

### DIFF
--- a/tools/mcp/common/inference.py
+++ b/tools/mcp/common/inference.py
@@ -51,6 +51,24 @@ completely irrelevant to the question.
 6. Be CONCISE — 2-4 sentences. Cite sources like "per file.md:line".
 7. NO hedging ("might be", "could be"). State what the documentation says.
 8. ALWAYS include a concrete code example if the documentation provides one.
+9. Notes from prior sessions are an agent's record of one past task, not \
+documentation. A note is evidence only about the classes and files it names. \
+Never attribute a note's details to anything it does not mention — that a note \
+describes one class holding a flat array says nothing about any other class. \
+A note that mentions a concept in passing does not establish the types, field \
+layout, or implementation of anything it does not spell out; if the detail \
+asked for is not written in the note, it is not known, and "likely" or \
+"probably" is not an answer.
+10. A question about what a particular source file contains cannot be answered \
+from documentation unless a chunk quotes or describes that file. Say the \
+documentation does not cover it rather than inferring from the name, the \
+module, or how the framework usually works.
+11. Cite "per file.md:line" only for a location that states the claim. Never \
+attach a line number to something you inferred.
+12. A question can take a fact for granted that the documentation never \
+establishes — "what does X use arrays for" assumes X uses them. Do not adopt \
+the assumption. Check whether the chunks establish it, and if they do not, say \
+so plainly instead of answering as though it held.
 
 EXAMPLES:
 Doc chunk: "## Entering the Graph\\nUse cp() to wrap a PackedCollection...\\n\

--- a/tools/mcp/consultant/server.py
+++ b/tools/mcp/consultant/server.py
@@ -106,7 +106,15 @@ def _build_consult_prompt(question: str, doc_context: str, memory_context: str,
         parts.append("## Relevant Documentation\n\n(No documentation found for this query)")
 
     if memory_context:
-        parts.append(f"## Relevant Memories from Prior Sessions\n\n{memory_context}")
+        parts.append(
+            "## Notes From Prior Sessions\n\n"
+            "These are notes agents wrote about particular past work. They are not "
+            "documentation and carry no authority beyond the classes and files they "
+            "name. Use a note only for the subject it explicitly names; never carry "
+            "its details across to a class, file or module it does not mention, and "
+            "never let its wording supply a fact the documentation does not state.\n\n"
+            f"{memory_context}"
+        )
 
     parts.append(
         "## Instructions\n\n"
@@ -197,13 +205,25 @@ def _keyword_guidance(keywords: Optional[list[str]]) -> str:
 
 
 def _format_memory_context(memories: list[dict], max_entries: int = 3) -> str:
-    """Format memory entries into a context string."""
+    """Format memory entries into a context string.
+
+    Each note is labelled with the work it was written about, so that a record of
+    one class's internals reads as what it is rather than as a statement about the
+    framework. Presented as bare text it reads with the same authority as
+    documentation, and its specifics get attached to whatever the question happens
+    to ask about — a note describing one class's flat scalar layout becomes, for a
+    question naming several unrelated classes, an assertion about the one whose
+    name sounds nearest.
+    """
     if not memories:
         return ""
     parts = []
-    for m in memories[:max_entries]:
-        parts.append(f"- {m['content']}")
-    return "\n".join(parts)
+    for i, m in enumerate(memories[:max_entries], 1):
+        source = m.get("source") or "unspecified"
+        parts.append(
+            f"### Note {i} — written by an agent about: {source}\n\n{m['content']}"
+        )
+    return "\n\n".join(parts)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The consultant was asked what several named classes use host arrays for. It answered that one loads its weights through them and that another marshals a flat array of thirty-seven scalars for MIDI encoding, citing files and lines for both. Neither is true, the line numbers were different on each asking, and the retrieved documentation contained no occurrence of the array types at all.

The thirty-seven scalars are real, but they belong to a different class in a different module, and they were in the answer because a note recording that design had been retrieved alongside the documentation and read as a statement about whichever class in the question sounded nearest. Asking the same question with the notes withheld produced the correct answer every time; asking it with them included produced the invention every time.

Notes were being passed as bare bullets under a heading that made them look like documentation. They are now labelled with the work they were written about, and the section says plainly what they are: one agent's record of one past task, carrying no authority beyond the classes and files it names, never to be carried across to something it does not mention. A note that mentions a concept in passing does not establish the types or the layout of anything it does not spell out, and a hedge is not a way around that.

Three further rules follow from the same failure. A question about what a particular source file contains cannot be answered from documentation unless something quotes or describes that file — the name, the module and the way the framework usually works are not evidence. A file and line may be cited only for a location that states the claim, never attached to an inference. And a question can take for granted something the documentation never establishes, as this one did in asking what these classes use arrays for; the assumption is to be checked rather than adopted.

The question that produced the invention now answers correctly every time. Questions the notes genuinely do answer still answer from them, in full, and questions the documentation answers are unchanged.