### PR TITLE
Degrade gracefully when no inference backend is reachable

### DIFF
--- a/tools/mcp/README.md
+++ b/tools/mcp/README.md
@@ -151,9 +151,31 @@ pip install -r tools/mcp/requirements.txt
 
 Individual servers also have their own `requirements.txt` files.
 
+## Running the Python Tests
+
+The whole suite runs in one command:
+
+```bash
+python3 -m pytest tools/mcp -q
+```
+
+These directories are not Python packages, so every module here shares one
+flat namespace. Two rules keep that workable, both asserted by
+`common/test_layout.py`:
+
+- **Test files need distinct basenames.** Two `test_x.py` files in two
+  non-package directories claim one module name, and collection of any run
+  spanning both aborts with "import file mismatch". Name a server's tests
+  after the server (`test_secrets_server.py`, not `test_server.py`).
+- **Only ar-manager imports `server` by bare name.** Nine directories define
+  a top-level `server.py`; a bare `import server` resolves by `sys.path`
+  order, so in a multi-directory run the others would silently exercise the
+  wrong module. Load the directory's own `server.py` by explicit path
+  instead — `test-runner/server_under_test.py` is the pattern to copy.
+
 ## LLM Backend Setup (ar-consultant)
 
-The `ar-consultant` server requires a local LLM for documentation synthesis. Without one, it falls back to passthrough mode (returning raw docs without synthesis).
+The `ar-consultant` server uses a local LLM to synthesize documentation into answers. It is not required to run: without one, documentation search, memory recall and history all keep working, and the tools return their retrieval results marked `degraded: true` instead of failing. Backend health is re-probed rather than fixed at startup, so starting or stopping a model takes effect without restarting the MCP server.
 
 **See [consultant/README.md](consultant/README.md) for detailed backend setup instructions.**
 

--- a/tools/mcp/common/__init__.py
+++ b/tools/mcp/common/__init__.py
@@ -6,7 +6,13 @@ and other MCP servers that interact with the ar-memory HTTP service.
 """
 
 from .memory_http_client import MemoryHTTPClient
-from .inference import InferenceBackend, create_backend, SYSTEM_PROMPT
+from .inference import (
+    InferenceBackend,
+    InferenceUnavailable,
+    Synthesis,
+    create_backend,
+    SYSTEM_PROMPT,
+)
 from .git_context import detect_git_context
 from .memory_text import (
     BETA_NOTICE,
@@ -24,6 +30,8 @@ from .memory_text import (
 __all__ = [
     "MemoryHTTPClient",
     "InferenceBackend",
+    "InferenceUnavailable",
+    "Synthesis",
     "create_backend",
     "SYSTEM_PROMPT",
     "detect_git_context",

--- a/tools/mcp/common/health.py
+++ b/tools/mcp/common/health.py
@@ -48,8 +48,7 @@ class HealthCache:
 
     Args:
         probe: Returns True when the dependency is reachable. Called at most
-            once per TTL, never on the request path.
-    """
+            once per TTL.
 
     def __init__(self, probe: Callable[[], bool]):
         self._probe = probe

--- a/tools/mcp/common/health.py
+++ b/tools/mcp/common/health.py
@@ -1,0 +1,79 @@
+"""Cached liveness tracking for services an MCP server depends on.
+
+Every AR MCP server fronts at least one thing that can be down independently
+of it — a llama.cpp server, Ollama, the ar-memory HTTP service. Each needs
+the same treatment: probe cheaply, remember the answer briefly so a status
+call is not a network round trip, and re-probe often enough that the answer
+still describes the present.
+
+Caching a probe for the life of the process, which is what these clients
+used to do, produces the worst possible failure: the health flag reports the
+state at first call forever. A dependency that dies still reads as up (so
+status output contradicts what requests actually do), and one that recovers
+stays marked down until every consumer restarts.
+"""
+
+import logging
+import os
+import time
+from typing import Callable, Optional
+
+log = logging.getLogger(__name__)
+
+# How long a probe result is trusted before the dependency is re-probed.
+DEFAULT_HEALTH_TTL_SECONDS = 30.0
+
+
+def health_ttl() -> float:
+    """Seconds a probe result stays valid.
+
+    Override with ``AR_INFERENCE_HEALTH_TTL``. A value of 0 forces a probe
+    on every read, which is what tests want.
+    """
+    raw = os.environ.get("AR_INFERENCE_HEALTH_TTL")
+    if not raw:
+        return DEFAULT_HEALTH_TTL_SECONDS
+    try:
+        return max(0.0, float(raw))
+    except ValueError:
+        log.warning(
+            "Ignoring non-numeric AR_INFERENCE_HEALTH_TTL=%r; using %.0fs",
+            raw, DEFAULT_HEALTH_TTL_SECONDS,
+        )
+        return DEFAULT_HEALTH_TTL_SECONDS
+
+
+class HealthCache:
+    """A dependency's liveness, re-probed once the cached answer goes stale.
+
+    Args:
+        probe: Returns True when the dependency is reachable. Called at most
+            once per TTL, never on the request path.
+    """
+
+    def __init__(self, probe: Callable[[], bool]):
+        self._probe = probe
+        self._healthy: Optional[bool] = None
+        self._checked_at: float = 0.0
+
+    @property
+    def healthy(self) -> bool:
+        """Whether the dependency is reachable, re-probing when stale."""
+        now = time.monotonic()
+        if (
+            self._healthy is not None
+            and (now - self._checked_at) < health_ttl()
+        ):
+            return self._healthy
+        self._healthy = self._probe()
+        self._checked_at = now
+        return self._healthy
+
+    def invalidate(self) -> None:
+        """Force the next :attr:`healthy` read to re-probe.
+
+        Called after a request fails, since a failure just observed is
+        stronger evidence than a probe that succeeded some seconds ago.
+        """
+        self._healthy = None
+        self._checked_at = 0.0

--- a/tools/mcp/common/inference.py
+++ b/tools/mcp/common/inference.py
@@ -17,12 +17,58 @@ ar-manager and other MCP servers can use the same inference pipeline.
 import json
 import logging
 import os
+import time
 import urllib.error
 import urllib.request
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from typing import Optional
 
+try:
+    from .health import HealthCache, health_ttl
+except ImportError:
+    # Loaded by path (see consultant/inference.py) rather than as a package.
+    from health import HealthCache, health_ttl
+
 log = logging.getLogger(__name__)
+
+
+class InferenceUnavailable(RuntimeError):
+    """Raised when a backend cannot reach the model it fronts.
+
+    Backends raise this instead of letting transport errors (``URLError``,
+    ``OSError``, ``TimeoutError``) escape, so callers can distinguish "the
+    model is down" from a genuine bug in the calling code.
+    """
+
+    def __init__(self, backend: str, detail: str):
+        super().__init__(f"{backend} unavailable: {detail}")
+        self.backend = backend
+        self.detail = detail
+
+
+@dataclass(frozen=True)
+class Synthesis:
+    """The outcome of a synthesis request.
+
+    ``text`` carries the model's output when synthesis succeeded and is
+    ``None`` when it did not, which is the single check a caller needs
+    (:attr:`degraded`). ``reason`` explains a failure in terms a caller can
+    show to its own caller without inspecting the backend.
+
+    This exists so degradation is a value a caller must handle rather than
+    a banner string it has to sniff for: retrieval results stay usable when
+    only the summarization step is lost.
+    """
+
+    text: Optional[str]
+    backend: str
+    reason: Optional[str] = None
+
+    @property
+    def degraded(self) -> bool:
+        """True when no model output is available."""
+        return self.text is None
 
 
 # ---------------------------------------------------------------------------
@@ -94,7 +140,17 @@ CollectionFeatures` to a class gives it 40+ factory methods like `cp()`, \
 # ---------------------------------------------------------------------------
 
 class InferenceBackend(ABC):
-    """Abstract interface for LLM inference."""
+    """Abstract interface for LLM inference.
+
+    Subclasses implement :meth:`generate` (raising :class:`InferenceUnavailable`
+    when the model cannot be reached) and :meth:`_probe` (a liveness check).
+    The base class turns those into the two things callers actually need: an
+    :attr:`available` flag that reflects the present, not process start, and
+    :meth:`synthesize`, which degrades instead of raising.
+    """
+
+    def __init__(self):
+        self._health = HealthCache(self._probe)
 
     @abstractmethod
     def generate(
@@ -114,6 +170,9 @@ class InferenceBackend(ABC):
 
         Returns:
             The generated text.
+
+        Raises:
+            InferenceUnavailable: The model could not be reached.
         """
 
     @property
@@ -121,10 +180,64 @@ class InferenceBackend(ABC):
     def name(self) -> str:
         """Human-readable backend name."""
 
+    def _probe(self) -> bool:
+        """Check whether the model is reachable right now.
+
+        Subclasses override this with a real liveness check. It is called
+        at most once per health TTL, never on the request path.
+        """
+        return True
+
     @property
     def available(self) -> bool:
-        """Whether this backend is ready to serve requests."""
-        return True
+        """Whether this backend is ready to serve requests.
+
+        Re-probed when the cached result is older than the health TTL, so a
+        backend that dies is reported as down and one that recovers is
+        reported as up. Caching the first probe forever (the previous
+        behaviour) made this property report process-start state and
+        contradict what ``generate`` actually did.
+        """
+        return self._health.healthy
+
+    def invalidate_availability(self) -> None:
+        """Force the next :attr:`available` read to re-probe.
+
+        Called after a failed request so the recorded health reflects the
+        failure immediately rather than at the next TTL expiry.
+        """
+        self._health.invalidate()
+
+    def synthesize(
+        self,
+        prompt: str,
+        system: Optional[str] = None,
+        max_tokens: int = 1024,
+        temperature: float = 0.3,
+    ) -> Synthesis:
+        """Generate text, reporting failure as a value rather than raising.
+
+        This is the entry point for callers that have useful results to
+        return even when the model is gone — the whole retrieval pipeline
+        of a consult or recall survives a dead backend, and only the
+        summary is lost.
+
+        Returns:
+            A :class:`Synthesis`; check :attr:`Synthesis.degraded`.
+        """
+        try:
+            text = self.generate(
+                prompt, system=system, max_tokens=max_tokens,
+                temperature=temperature,
+            )
+        except InferenceUnavailable as e:
+            self.invalidate_availability()
+            log.warning("Synthesis degraded: %s", e)
+            return Synthesis(None, self.name, e.detail)
+
+        if not text or not text.strip():
+            return Synthesis(None, self.name, "model returned an empty response")
+        return Synthesis(text, self.name)
 
 
 # ---------------------------------------------------------------------------
@@ -152,16 +265,13 @@ class OllamaBackend(InferenceBackend):
         self.base_url = base_url or os.environ.get(
             "AR_CONSULTANT_OLLAMA_URL", self.DEFAULT_BASE_URL
         )
-        self._available: Optional[bool] = None
+        super().__init__()
 
     @property
     def name(self) -> str:
         return f"ollama ({self.model})"
 
-    @property
-    def available(self) -> bool:
-        if self._available is not None:
-            return self._available
+    def _probe(self) -> bool:
         try:
             req = urllib.request.Request(
                 f"{self.base_url}/api/tags",
@@ -172,10 +282,8 @@ class OllamaBackend(InferenceBackend):
                 models = [m.get("name", "") for m in data.get("models", [])]
                 # Check if our model (or a prefix of it) is available
                 model_base = self.model.split(":")[0]
-                self._available = any(
-                    model_base in m for m in models
-                )
-                if not self._available:
+                found = any(model_base in m for m in models)
+                if not found:
                     log.warning(
                         "Ollama is running but model '%s' not found. "
                         "Available: %s. Pull it with: ollama pull %s",
@@ -183,10 +291,10 @@ class OllamaBackend(InferenceBackend):
                         ", ".join(models) or "(none)",
                         self.model,
                     )
-        except (urllib.error.URLError, OSError, TimeoutError):
+                return found
+        except (urllib.error.URLError, OSError, TimeoutError, ValueError):
             log.info("Ollama not reachable at %s", self.base_url)
-            self._available = False
-        return self._available
+            return False
 
     def generate(
         self,
@@ -217,10 +325,13 @@ class OllamaBackend(InferenceBackend):
             method="POST",
         )
 
-        # Allow generous timeout for large model generation
-        with urllib.request.urlopen(req, timeout=120) as resp:
-            data = json.loads(resp.read())
-            return data.get("message", {}).get("content", "")
+        try:
+            # Allow generous timeout for large model generation
+            with urllib.request.urlopen(req, timeout=120) as resp:
+                data = json.loads(resp.read())
+                return data.get("message", {}).get("content", "")
+        except (urllib.error.URLError, OSError, TimeoutError, ValueError) as e:
+            raise InferenceUnavailable(self.name, str(e)) from e
 
 
 # ---------------------------------------------------------------------------
@@ -266,8 +377,9 @@ class LlamaCppBackend(InferenceBackend):
             self.CONTAINER_BASE_URL if self._in_container else self.HOST_BASE_URL
         )
         self._explicit_url = base_url or os.environ.get("AR_CONSULTANT_LLAMACPP_URL")
+        self._default_url = default_url
         self.base_url = self._explicit_url or default_url
-        self._available: Optional[bool] = None
+        super().__init__()
 
     @property
     def name(self) -> str:
@@ -286,29 +398,30 @@ class LlamaCppBackend(InferenceBackend):
                     "llama.cpp server at %s returned status: %s", url, status,
                 )
                 return False
-        except (urllib.error.URLError, OSError, TimeoutError) as e:
+        except (urllib.error.URLError, OSError, TimeoutError, ValueError) as e:
             log.info("llama.cpp server not reachable at %s: %s", url, e)
             return False
 
-    @property
-    def available(self) -> bool:
-        if self._available is not None:
-            return self._available
-
+    def _probe(self) -> bool:
         if self._check_health(self.base_url):
-            self._available = True
             return True
 
         # When using the localhost default (no explicit URL, not in a container),
-        # try mac-studio as a fallback before giving up.
+        # try mac-studio as a fallback before giving up. Re-check the default
+        # first on every probe so a recovered local server reclaims priority
+        # instead of the process staying pinned to the remote host forever.
         if not self._explicit_url and not self._in_container:
+            if self.base_url != self._default_url and self._check_health(
+                self._default_url
+            ):
+                self.base_url = self._default_url
+                return True
+
             log.info("Trying fallback host mac-studio...")
             if self._check_health(self.REMOTE_HOST_BASE_URL):
                 self.base_url = self.REMOTE_HOST_BASE_URL
-                self._available = True
                 return True
 
-        self._available = False
         return False
 
     def generate(
@@ -337,12 +450,15 @@ class LlamaCppBackend(InferenceBackend):
             method="POST",
         )
 
-        with urllib.request.urlopen(req, timeout=180) as resp:
-            data = json.loads(resp.read())
-            choices = data.get("choices", [])
-            if choices:
-                return choices[0].get("message", {}).get("content", "")
-            return ""
+        try:
+            with urllib.request.urlopen(req, timeout=180) as resp:
+                data = json.loads(resp.read())
+                choices = data.get("choices", [])
+                if choices:
+                    return choices[0].get("message", {}).get("content", "")
+                return ""
+        except (urllib.error.URLError, OSError, TimeoutError, ValueError) as e:
+            raise InferenceUnavailable(self.name, str(e)) from e
 
 
 # ---------------------------------------------------------------------------
@@ -363,10 +479,14 @@ class MLXBackend(InferenceBackend):
         )
         self._model = None
         self._tokenizer = None
-        self._available: Optional[bool] = None
+        super().__init__()
 
     def _load(self):
-        """Lazy-load the model on first use."""
+        """Lazy-load the model on first use.
+
+        Raises:
+            InferenceUnavailable: The model could not be loaded.
+        """
         if self._model is not None:
             return
         try:
@@ -374,24 +494,19 @@ class MLXBackend(InferenceBackend):
             self._model, self._tokenizer = load(self._model_path)
         except Exception as e:
             log.error("Failed to load MLX model '%s': %s", self._model_path, e)
-            self._available = False
-            raise
+            raise InferenceUnavailable(self.name, f"model load failed: {e}") from e
 
     @property
     def name(self) -> str:
         return f"mlx ({self._model_path})"
 
-    @property
-    def available(self) -> bool:
-        if self._available is not None:
-            return self._available
+    def _probe(self) -> bool:
         try:
             import mlx_lm  # noqa: F401
-            self._available = True
+            return True
         except ImportError:
             log.info("mlx-lm not installed; MLX backend unavailable")
-            self._available = False
-        return self._available
+            return False
 
     def generate(
         self,
@@ -437,14 +552,27 @@ class MLXBackend(InferenceBackend):
 class PassthroughBackend(InferenceBackend):
     """Fallback when no model is available.
 
-    Returns the prompt content directly, prefixed with a notice that
-    no model is running. Useful for testing the retrieval pipeline
-    without a model.
+    :meth:`generate` returns the prompt content directly, prefixed with a
+    notice that no model is running, which is useful for exercising the
+    retrieval pipeline without a model.
+
+    That banner is *not* an answer, so :attr:`available` is False and
+    :meth:`synthesize` reports a degraded result. Callers that route
+    through ``synthesize`` therefore never mistake a raw context dump for
+    synthesized text — the failure mode that put 36 such dumps into the
+    memory corpus.
     """
+
+    #: Leader emitted by :meth:`generate`. ``tools/mcp/memory/store.py``
+    #: matches on this to reject dumps that predate structured degradation.
+    BANNER = "[Consultant model not available. Returning raw context.]"
 
     @property
     def name(self) -> str:
         return "passthrough (no model)"
+
+    def _probe(self) -> bool:
+        return False
 
     def generate(
         self,
@@ -453,10 +581,118 @@ class PassthroughBackend(InferenceBackend):
         max_tokens: int = 1024,
         temperature: float = 0.3,
     ) -> str:
-        return (
-            "[Consultant model not available. Returning raw context.]\n\n"
-            + prompt
+        return self.BANNER + "\n\n" + prompt
+
+    def synthesize(
+        self,
+        prompt: str,
+        system: Optional[str] = None,
+        max_tokens: int = 1024,
+        temperature: float = 0.3,
+    ) -> Synthesis:
+        return Synthesis(
+            None, self.name,
+            "no inference model is configured or reachable",
         )
+
+
+# ---------------------------------------------------------------------------
+# Auto-detecting backend
+# ---------------------------------------------------------------------------
+
+class AutoBackend(InferenceBackend):
+    """Delegates to the first reachable backend, re-resolving as health changes.
+
+    Auto-detection is not a one-time decision. A llama.cpp server that is
+    down when an MCP server starts and comes up minutes later has to be
+    picked up without restarting every process holding a backend handle,
+    and a server that dies mid-session has to stop being addressed. This
+    backend re-runs detection whenever its cached choice goes stale,
+    falling back to :class:`PassthroughBackend` only for as long as nothing
+    better answers a probe.
+    """
+
+    def __init__(self, candidates: Optional[list] = None):
+        self._candidates = (
+            candidates if candidates is not None
+            else [LlamaCppBackend(), OllamaBackend(), MLXBackend()]
+        )
+        self._fallback = PassthroughBackend()
+        self._delegate: InferenceBackend = self._fallback
+        self._resolved_at: float = 0.0
+        super().__init__()
+
+    @property
+    def delegate(self) -> InferenceBackend:
+        """The backend currently serving requests, re-resolved when stale."""
+        now = time.monotonic()
+        if self._resolved_at and (now - self._resolved_at) < health_ttl():
+            return self._delegate
+
+        for candidate in self._candidates:
+            if candidate.available:
+                if candidate is not self._delegate:
+                    log.info("Using %s backend", candidate.name)
+                self._delegate = candidate
+                self._resolved_at = now
+                return self._delegate
+
+        if self._delegate is not self._fallback:
+            log.warning(
+                "No LLM backend is reachable; degrading until one returns."
+            )
+        self._delegate = self._fallback
+        self._resolved_at = now
+        return self._delegate
+
+    @property
+    def name(self) -> str:
+        return self.delegate.name
+
+    def _probe(self) -> bool:
+        return not isinstance(self.delegate, PassthroughBackend)
+
+    def invalidate_availability(self) -> None:
+        """Drop both the resolved delegate and every candidate's health."""
+        super().invalidate_availability()
+        self._resolved_at = 0.0
+        for candidate in self._candidates:
+            candidate.invalidate_availability()
+
+    def generate(
+        self,
+        prompt: str,
+        system: Optional[str] = None,
+        max_tokens: int = 1024,
+        temperature: float = 0.3,
+    ) -> str:
+        return self.delegate.generate(
+            prompt, system=system, max_tokens=max_tokens,
+            temperature=temperature,
+        )
+
+    def synthesize(
+        self,
+        prompt: str,
+        system: Optional[str] = None,
+        max_tokens: int = 1024,
+        temperature: float = 0.3,
+    ) -> Synthesis:
+        delegate = self.delegate
+        result = delegate.synthesize(
+            prompt, system=system, max_tokens=max_tokens,
+            temperature=temperature,
+        )
+        if result.degraded and delegate is not self._fallback:
+            # A real backend just failed a real request, which is stronger
+            # evidence than its cached probe. Re-resolve so the next call
+            # can reach a different backend that is actually up.
+            #
+            # Not done when the fallback answered: nothing was attempted, so
+            # there is no new evidence, and invalidating would re-probe every
+            # candidate on every call for as long as the outage lasts.
+            self.invalidate_availability()
+        return result
 
 
 # ---------------------------------------------------------------------------
@@ -471,6 +707,11 @@ def create_backend(backend_name: Optional[str] = None) -> InferenceBackend:
       2. Ollama
       3. MLX (Apple Silicon, native macOS only)
       4. Passthrough (no model)
+
+    A backend is always returned. Detection failure is not an error here —
+    it is reported per-request through :meth:`InferenceBackend.synthesize`,
+    so a consumer that starts while every model is down still serves
+    retrieval and starts synthesizing again once one comes up.
 
     Args:
         backend_name: One of "llamacpp", "ollama", "mlx", "passthrough",
@@ -490,29 +731,10 @@ def create_backend(backend_name: Optional[str] = None) -> InferenceBackend:
     elif name == "passthrough":
         return PassthroughBackend()
     elif name == "auto":
-        # Try llamacpp first (Linux container -> Mac host is the primary setup)
-        llamacpp = LlamaCppBackend()
-        if llamacpp.available:
-            log.info("Using llama.cpp backend: %s", llamacpp.name)
-            return llamacpp
-
-        ollama = OllamaBackend()
-        if ollama.available:
-            log.info("Using Ollama backend: %s", ollama.name)
-            return ollama
-
-        mlx = MLXBackend()
-        if mlx.available:
-            log.info("Using MLX backend: %s", mlx.name)
-            return mlx
-
-        log.warning(
-            "No LLM backend available. Start a llama.cpp server on the "
-            "host (llama-server -m model.gguf --host 0.0.0.0 --port 8080) "
-            "or set AR_CONSULTANT_BACKEND=passthrough. "
-            "Falling back to passthrough mode."
-        )
-        return PassthroughBackend()
+        # Ordered llamacpp first (Linux container -> Mac host is the primary
+        # setup), then Ollama, then MLX. AutoBackend re-runs this selection
+        # whenever its choice goes stale.
+        return AutoBackend()
     else:
         raise ValueError(
             f"Unknown backend: {name!r}. "

--- a/tools/mcp/common/memory_http_client.py
+++ b/tools/mcp/common/memory_http_client.py
@@ -15,6 +15,12 @@ from urllib.error import HTTPError, URLError
 from urllib.parse import quote, urlencode
 from urllib.request import Request, urlopen
 
+try:
+    from .health import HealthCache
+except ImportError:
+    # Loaded by path rather than as a package (see consultant/inference.py).
+    from health import HealthCache
+
 log = logging.getLogger(__name__)
 
 # Default port for the ar-memory HTTP service
@@ -47,24 +53,30 @@ class MemoryHTTPClient:
 
     def __init__(self, base_url: Optional[str] = None):
         self._base_url = base_url or _discover_memory_server()
-        self._available: Optional[bool] = None
+        self._health = HealthCache(self._probe)
 
     @property
     def base_url(self) -> str:
         """The resolved base URL of the ar-memory server."""
         return self._base_url
 
-    @property
-    def available(self) -> bool:
-        """Whether the ar-memory server is reachable."""
-        if self._available is not None:
-            return self._available
+    def _probe(self) -> bool:
         try:
             self.health()
-            self._available = True
+            return True
         except (ConnectionError, OSError):
-            self._available = False
-        return self._available
+            return False
+
+    @property
+    def available(self) -> bool:
+        """Whether the ar-memory server is reachable.
+
+        Re-checked once the cached result goes stale. A result cached for
+        the life of the process would report the state at first call
+        forever: a server that died would still read as up, and one that
+        came back would stay marked down until every consumer restarted.
+        """
+        return self._health.healthy
 
     def store(
         self,

--- a/tools/mcp/common/test_inference.py
+++ b/tools/mcp/common/test_inference.py
@@ -1,0 +1,409 @@
+"""Tests for graceful degradation in the shared inference layer.
+
+These cover the four ways the layer used to fail when no model was
+reachable: a health flag frozen at process start, transport errors escaping
+``generate()`` as tool errors, a passthrough fallback that an explicitly
+pinned backend could never reach, and a raw context dump being presented as
+synthesized text.
+"""
+
+import json
+import os
+import socketserver
+import sys
+import threading
+import unittest
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from inference import (  # noqa: E402
+    AutoBackend,
+    InferenceBackend,
+    InferenceUnavailable,
+    LlamaCppBackend,
+    OllamaBackend,
+    PassthroughBackend,
+    Synthesis,
+    create_backend,
+)
+
+
+class FakeBackend(InferenceBackend):
+    """Backend whose health and generate outcome are controlled by the test."""
+
+    def __init__(self, healthy=True, text="synthesized"):
+        self.healthy = healthy
+        self.text = text
+        self.probe_count = 0
+        self.generate_count = 0
+        super().__init__()
+
+    @property
+    def name(self):
+        return f"fake (healthy={self.healthy})"
+
+    def _probe(self):
+        self.probe_count += 1
+        return self.healthy
+
+    def generate(self, prompt, system=None, max_tokens=1024, temperature=0.3):
+        self.generate_count += 1
+        if not self.healthy:
+            raise InferenceUnavailable(self.name, "fake backend is down")
+        return self.text
+
+
+class HealthCacheTest(unittest.TestCase):
+    """``available`` must track the present, not the state at construction."""
+
+    def setUp(self):
+        os.environ["AR_INFERENCE_HEALTH_TTL"] = "0"
+        self.addCleanup(os.environ.pop, "AR_INFERENCE_HEALTH_TTL", None)
+
+    def test_available_reflects_a_backend_that_went_down(self):
+        backend = FakeBackend(healthy=True)
+        self.assertTrue(backend.available)
+
+        backend.healthy = False
+
+        self.assertFalse(
+            backend.available,
+            "a backend that died must stop reporting itself as available; "
+            "the old code memoized the first probe forever",
+        )
+
+    def test_available_reflects_a_backend_that_came_back(self):
+        backend = FakeBackend(healthy=False)
+        self.assertFalse(backend.available)
+
+        backend.healthy = True
+
+        self.assertTrue(
+            backend.available,
+            "a recovered backend must be usable without a process restart",
+        )
+
+    def test_probe_result_is_cached_within_the_ttl(self):
+        os.environ["AR_INFERENCE_HEALTH_TTL"] = "3600"
+        backend = FakeBackend(healthy=True)
+
+        for _ in range(5):
+            self.assertTrue(backend.available)
+
+        self.assertEqual(
+            backend.probe_count, 1,
+            "health probes must not run on every read, or status checks "
+            "would issue a network call per request",
+        )
+
+    def test_invalidate_forces_a_reprobe(self):
+        os.environ["AR_INFERENCE_HEALTH_TTL"] = "3600"
+        backend = FakeBackend(healthy=True)
+        self.assertTrue(backend.available)
+
+        backend.healthy = False
+        backend.invalidate_availability()
+
+        self.assertFalse(backend.available)
+        self.assertEqual(backend.probe_count, 2)
+
+
+class SynthesizeDegradationTest(unittest.TestCase):
+    """``synthesize`` reports failure as a value instead of raising."""
+
+    def test_degrades_instead_of_raising(self):
+        result = FakeBackend(healthy=False).synthesize("prompt")
+
+        self.assertTrue(result.degraded)
+        self.assertIsNone(result.text)
+        self.assertIn("fake backend is down", result.reason)
+
+    def test_returns_text_when_healthy(self):
+        result = FakeBackend(healthy=True, text="an answer").synthesize("prompt")
+
+        self.assertFalse(result.degraded)
+        self.assertEqual(result.text, "an answer")
+        self.assertIsNone(result.reason)
+
+    def test_empty_response_counts_as_degraded(self):
+        result = FakeBackend(healthy=True, text="   ").synthesize("prompt")
+
+        self.assertTrue(
+            result.degraded,
+            "whitespace is not an answer; returning it as one would put an "
+            "empty summary in front of the caller",
+        )
+
+    def test_failed_request_invalidates_health(self):
+        os.environ["AR_INFERENCE_HEALTH_TTL"] = "3600"
+        self.addCleanup(os.environ.pop, "AR_INFERENCE_HEALTH_TTL", None)
+
+        backend = FakeBackend(healthy=True)
+        self.assertTrue(backend.available)
+        backend.healthy = False
+
+        backend.synthesize("prompt")
+
+        self.assertFalse(
+            backend.available,
+            "a request that just failed is stronger evidence than a stale "
+            "probe, so health must be re-evaluated after it",
+        )
+
+    def test_generate_still_raises_for_direct_callers(self):
+        with self.assertRaises(InferenceUnavailable):
+            FakeBackend(healthy=False).generate("prompt")
+
+
+class PassthroughTest(unittest.TestCase):
+    """The passthrough banner is a context dump, not an answer."""
+
+    def test_reports_itself_unavailable(self):
+        self.assertFalse(PassthroughBackend().available)
+
+    def test_synthesize_is_degraded(self):
+        result = PassthroughBackend().synthesize("the prompt")
+
+        self.assertTrue(result.degraded)
+        self.assertIsNone(
+            result.text,
+            "returning the banner as text is what let raw context dumps be "
+            "stored as memories",
+        )
+
+    def test_generate_keeps_the_banner_for_the_memory_store_guard(self):
+        text = PassthroughBackend().generate("the prompt")
+
+        self.assertTrue(text.startswith(PassthroughBackend.BANNER))
+        self.assertIn("the prompt", text)
+
+
+class AutoBackendTest(unittest.TestCase):
+    """Auto-detection re-resolves rather than deciding once at startup."""
+
+    def setUp(self):
+        os.environ["AR_INFERENCE_HEALTH_TTL"] = "0"
+        self.addCleanup(os.environ.pop, "AR_INFERENCE_HEALTH_TTL", None)
+
+    def test_prefers_the_first_healthy_candidate(self):
+        first, second = FakeBackend(healthy=True), FakeBackend(healthy=True)
+        auto = AutoBackend(candidates=[first, second])
+
+        self.assertIs(auto.delegate, first)
+
+    def test_skips_unhealthy_candidates(self):
+        down, up = FakeBackend(healthy=False), FakeBackend(healthy=True, text="ok")
+        auto = AutoBackend(candidates=[down, up])
+
+        self.assertIs(auto.delegate, up)
+        self.assertEqual(auto.synthesize("prompt").text, "ok")
+
+    def test_degrades_when_every_candidate_is_down(self):
+        auto = AutoBackend(candidates=[FakeBackend(healthy=False)])
+
+        result = auto.synthesize("prompt")
+
+        self.assertTrue(result.degraded)
+        self.assertFalse(auto.available)
+
+    def test_recovers_when_a_candidate_returns(self):
+        candidate = FakeBackend(healthy=False)
+        auto = AutoBackend(candidates=[candidate])
+        self.assertTrue(auto.synthesize("prompt").degraded)
+
+        candidate.healthy = True
+
+        self.assertFalse(
+            auto.synthesize("prompt").degraded,
+            "a model that comes back must be picked up without restarting "
+            "every MCP server holding this backend",
+        )
+        self.assertTrue(auto.available)
+
+    def test_outage_does_not_reprobe_on_every_call(self):
+        os.environ["AR_INFERENCE_HEALTH_TTL"] = "3600"
+        candidate = FakeBackend(healthy=False)
+        auto = AutoBackend(candidates=[candidate])
+
+        for _ in range(5):
+            self.assertTrue(auto.synthesize("prompt").degraded)
+
+        self.assertEqual(
+            candidate.probe_count, 1,
+            "while everything is down the fallback answers without "
+            "attempting a request, so there is no new evidence to act on; "
+            "re-probing anyway put a full scan (including a DNS lookup for "
+            "the remote host) in front of every single tool call",
+        )
+
+    def test_a_real_failure_still_forces_a_reprobe(self):
+        os.environ["AR_INFERENCE_HEALTH_TTL"] = "3600"
+        candidate = FakeBackend(healthy=True)
+        auto = AutoBackend(candidates=[candidate])
+        self.assertFalse(auto.synthesize("prompt").degraded)
+        probes_before = candidate.probe_count
+
+        candidate.healthy = False
+        self.assertTrue(auto.synthesize("prompt").degraded)
+
+        # Invalidation is lazy: the failure clears the cached health and the
+        # next resolution pays for the re-probe.
+        auto.synthesize("prompt")
+
+        self.assertGreater(
+            candidate.probe_count, probes_before,
+            "a backend that failed an actual request must be re-probed even "
+            "inside the TTL, so a healthier candidate can take over",
+        )
+
+    def test_falls_back_to_a_second_candidate_when_the_first_dies(self):
+        first = FakeBackend(healthy=True, text="from first")
+        second = FakeBackend(healthy=True, text="from second")
+        auto = AutoBackend(candidates=[first, second])
+        self.assertEqual(auto.synthesize("prompt").text, "from first")
+
+        first.healthy = False
+
+        self.assertEqual(auto.synthesize("prompt").text, "from second")
+
+
+class CreateBackendTest(unittest.TestCase):
+    """Every configuration produces a backend that degrades rather than raises."""
+
+    def setUp(self):
+        self._saved = os.environ.pop("AR_CONSULTANT_BACKEND", None)
+        if self._saved is not None:
+            self.addCleanup(
+                os.environ.__setitem__, "AR_CONSULTANT_BACKEND", self._saved,
+            )
+
+    def test_auto_returns_a_reresolving_backend(self):
+        self.assertIsInstance(create_backend("auto"), AutoBackend)
+
+    def test_explicit_names_are_honoured(self):
+        self.assertIsInstance(create_backend("llamacpp"), LlamaCppBackend)
+        self.assertIsInstance(create_backend("ollama"), OllamaBackend)
+        self.assertIsInstance(create_backend("passthrough"), PassthroughBackend)
+
+    def test_unknown_name_is_rejected(self):
+        with self.assertRaises(ValueError):
+            create_backend("no-such-backend")
+
+    def test_pinned_backend_degrades_when_unreachable(self):
+        backend = create_backend("llamacpp")
+        backend.base_url = "http://127.0.0.1:1"  # nothing listens here
+
+        result = backend.synthesize("prompt")
+
+        self.assertTrue(
+            result.degraded,
+            "pinning a backend used to bypass every availability check, so "
+            "a dead server surfaced as a hard tool error",
+        )
+        self.assertIsNotNone(result.reason)
+
+
+class _LlamaCppHandler(BaseHTTPRequestHandler):
+    """Minimal stand-in for llama-server's health and completions endpoints."""
+
+    healthy = True
+
+    def log_message(self, fmt, *args):
+        pass
+
+    def _respond(self, payload):
+        body = json.dumps(payload).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        if not _LlamaCppHandler.healthy:
+            self.send_error(503)
+            return
+        self._respond({"status": "ok"})
+
+    def do_POST(self):
+        if not _LlamaCppHandler.healthy:
+            self.send_error(503)
+            return
+        self._respond(
+            {"choices": [{"message": {"content": "a real summary"}}]}
+        )
+
+
+class _LocalHTTPServer(HTTPServer):
+    """HTTPServer that skips the reverse-DNS lookup when binding.
+
+    ``HTTPServer.server_bind`` resolves the bound address with
+    ``socket.getfqdn()``, which stalls for ~35s on a host with no reverse
+    DNS for 127.0.0.1. Only the human-readable ``server_name`` depends on
+    it, and no test reads that.
+    """
+
+    def server_bind(self):
+        socketserver.TCPServer.server_bind(self)
+        self.server_name, self.server_port = self.server_address[:2]
+
+
+class LlamaCppLiveTest(unittest.TestCase):
+    """End-to-end against a real socket, covering the outage the user hit."""
+
+    def setUp(self):
+        os.environ["AR_INFERENCE_HEALTH_TTL"] = "0"
+        self.addCleanup(os.environ.pop, "AR_INFERENCE_HEALTH_TTL", None)
+
+        _LlamaCppHandler.healthy = True
+        self.server = _LocalHTTPServer(("127.0.0.1", 0), _LlamaCppHandler)
+        thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        thread.start()
+        self.addCleanup(self.server.shutdown)
+
+        port = self.server.server_address[1]
+        self.backend = LlamaCppBackend(base_url=f"http://127.0.0.1:{port}")
+
+    def test_synthesizes_while_the_server_is_up(self):
+        self.assertTrue(self.backend.available)
+        result = self.backend.synthesize("prompt")
+
+        self.assertFalse(result.degraded)
+        self.assertEqual(result.text, "a real summary")
+
+    def test_degrades_when_the_server_starts_failing(self):
+        self.assertTrue(self.backend.available)
+
+        _LlamaCppHandler.healthy = False
+
+        result = self.backend.synthesize("prompt")
+        self.assertTrue(result.degraded)
+        self.assertFalse(
+            self.backend.available,
+            "status must agree with what synthesize just did, rather than "
+            "reporting the health recorded at startup",
+        )
+
+    def test_recovers_without_reconstruction(self):
+        _LlamaCppHandler.healthy = False
+        self.assertTrue(self.backend.synthesize("prompt").degraded)
+
+        _LlamaCppHandler.healthy = True
+
+        result = self.backend.synthesize("prompt")
+        self.assertFalse(result.degraded)
+        self.assertEqual(result.text, "a real summary")
+
+    def test_connection_refused_does_not_escape(self):
+        self.server.shutdown()
+        self.server.server_close()
+
+        result = self.backend.synthesize("prompt")
+
+        self.assertTrue(result.degraded)
+        self.assertIsInstance(result, Synthesis)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/mcp/common/test_layout.py
+++ b/tools/mcp/common/test_layout.py
@@ -1,0 +1,120 @@
+"""Guards the module names under ``tools/mcp`` against collisions.
+
+These directories are not packages, so everything here lands in one flat
+module namespace, and two files that claim the same name break any run
+spanning both. Two separate collisions did exactly that, and both are
+asserted here because each is invisible until someone runs the
+directories together:
+
+1. **Test files.** For a directory with no ``__init__.py``, pytest and
+   ``unittest discover`` name the module after the basename alone. Three
+   separate ``test_server.py`` files (ar-manager, ar-secrets,
+   ar-test-runner) therefore claimed one name, and collection aborted
+   with "import file mismatch" — not a skip, an error that took the whole
+   run with it.
+
+2. **The modules under test.** Nine directories define a top-level
+   ``server.py``, and their tests imported it as bare ``server``. That
+   resolves by ``sys.path`` order, so once collection spanned several
+   directories the losing ones exercised the wrong module — surfacing as
+   ``AttributeError: module 'server' has no attribute 'runner'`` rather
+   than as a name clash. Fixed by loading ``server.py`` from an explicit
+   path under a directory-specific name (see
+   ``test-runner/server_under_test.py``).
+
+A shared basename is fine when a package disambiguates it, so the first
+check compares the module names collection actually derives, not
+filenames.
+"""
+
+import os
+import re
+import unittest
+
+_MCP_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_SKIP_DIRS = {"__pycache__", ".pytest_cache", "node_modules", "target", ".git"}
+
+
+def _module_name(path: str) -> str:
+    """The module name collection will import ``path`` as.
+
+    Walks up while each directory is a package, mirroring how pytest
+    derives a module name: the basename, prefixed by every ancestor
+    package directory, stopping at the first one without ``__init__.py``.
+    """
+    parts = [os.path.splitext(os.path.basename(path))[0]]
+    directory = os.path.dirname(os.path.abspath(path))
+    while os.path.exists(os.path.join(directory, "__init__.py")):
+        parts.insert(0, os.path.basename(directory))
+        directory = os.path.dirname(directory)
+    return ".".join(parts)
+
+
+def _test_files() -> list:
+    """Every ``test_*.py`` under ``tools/mcp``."""
+    found = []
+    for root, dirs, files in os.walk(_MCP_DIR):
+        dirs[:] = [d for d in dirs if d not in _SKIP_DIRS]
+        for name in files:
+            if name.startswith("test_") and name.endswith(".py"):
+                found.append(os.path.join(root, name))
+    return found
+
+
+class TestModuleNamesAreUnique(unittest.TestCase):
+    """Two test modules must never claim the same import name."""
+
+    def test_no_two_test_files_share_a_module_name(self):
+        by_name = {}
+        for path in _test_files():
+            by_name.setdefault(_module_name(path), []).append(
+                os.path.relpath(path, _MCP_DIR)
+            )
+
+        collisions = {n: p for n, p in by_name.items() if len(p) > 1}
+
+        self.assertEqual(
+            {}, collisions,
+            "these test files resolve to the same module name, so any run "
+            "covering both aborts during collection with 'import file "
+            "mismatch'. Rename one after the server it tests (as "
+            "test_secrets_server.py and test_runner_server.py were), or add "
+            "an __init__.py so the package disambiguates them: "
+            f"{collisions}",
+        )
+
+    def test_the_walk_actually_found_the_test_files(self):
+        """A guard that silently matches nothing would assert nothing."""
+        self.assertGreater(
+            len(_test_files()), 10,
+            f"expected to find the tools/mcp test suite under {_MCP_DIR}; "
+            "finding almost nothing means the walk is misrooted and the "
+            "collision check above is vacuous",
+        )
+
+
+class TestBareServerImportIsClaimedOnce(unittest.TestCase):
+    """At most one directory may import its ``server.py`` by bare name."""
+
+    _BARE_IMPORT = re.compile(r"^\s*(?:import\s+server\b|from\s+server\s+import)", re.M)
+
+    def test_only_one_directory_imports_bare_server(self):
+        claimants = set()
+        for path in _test_files():
+            with open(path, errors="ignore") as handle:
+                if self._BARE_IMPORT.search(handle.read()):
+                    claimants.add(os.path.relpath(os.path.dirname(path), _MCP_DIR))
+
+        # ar-manager keeps the bare name; every other directory loads its
+        # own server.py by path. A second claimant means whichever imports
+        # second silently gets ar-manager's module.
+        allowed = {"manager", os.path.join("manager", "tests")}
+
+        self.assertEqual(
+            set(), claimants - allowed,
+            "these directories' tests import the bare module name `server`, "
+            "which only ar-manager may claim. In a run covering both, one of "
+            "them exercises ar-manager's server.py instead of its own. Load "
+            "this directory's server.py by explicit path under its own "
+            "module name — test-runner/server_under_test.py is the pattern.",
+        )

--- a/tools/mcp/consultant/README.md
+++ b/tools/mcp/consultant/README.md
@@ -10,7 +10,7 @@ The consultant wraps three subsystems:
 - **MemoryClient** -- reads/writes the centralized ar-memory HTTP service via `MemoryHTTPClient` (from `tools/mcp/common/`)
 - **InferenceBackend** -- a local LLM that synthesizes retrieved context into concise answers
 
-When no LLM is available, the server falls back to **passthrough mode**, returning raw retrieved documentation without synthesis.
+Only the third of these needs a model. When no LLM is reachable, retrieval keeps working and every tool returns what it retrieved, marked `degraded: true` with a `note` naming the fields that are still complete — so a consult still yields the matching documentation and memories, and a recall still yields the memories themselves. The one exception is `remember`, which refuses to store rather than write an unreformulated note into the corpus.
 
 Memory operations require the ar-memory HTTP server to be running (see `tools/mcp/memory/README.md`). When ar-memory is unavailable, memory tools degrade gracefully — returning empty results rather than errors.
 
@@ -18,7 +18,7 @@ Git context (repo_url, branch) is auto-detected from the working directory when 
 
 ## Inference Backends
 
-The consultant supports four inference backends. The backend is selected at server startup via auto-detection or the `AR_CONSULTANT_BACKEND` environment variable.
+The consultant supports four inference backends, selected by auto-detection or the `AR_CONSULTANT_BACKEND` environment variable.
 
 ### Auto-Detection Order
 
@@ -27,9 +27,16 @@ When `AR_CONSULTANT_BACKEND` is unset or `"auto"` (the default), the server trie
 1. **llama.cpp** -- checks `localhost:8084`, then `mac-studio:8084` as fallback
 2. **Ollama** -- checks `localhost:11434`
 3. **MLX** -- checks if `mlx-lm` is importable (Apple Silicon only)
-4. **Passthrough** -- always available, no model needed
+4. **Degraded** -- no model; retrieval-only responses marked `degraded: true`
 
-The backend is created once at startup. If the LLM server becomes available after the consultant starts, **you must restart the MCP server** (toggle it off/on in `/mcp` or restart Claude Code).
+Detection is re-run whenever the current choice goes stale, so **no restart is
+needed** when a model comes up or goes away. Start `llama-server` mid-session and
+the next consult synthesizes; kill it and the next consult degrades to retrieval.
+Health is cached for `AR_INFERENCE_HEALTH_TTL` seconds (default 30) so a status
+check is not a network round trip; set it to `0` in tests to probe every time.
+
+Because health is re-probed rather than fixed at startup, `consultant_status`
+always agrees with what the other tools will actually do.
 
 ### llama.cpp (Recommended)
 
@@ -148,11 +155,16 @@ The model is downloaded on first use from Hugging Face.
 
 ### Passthrough (No Model)
 
-Returns retrieved documentation context directly without LLM synthesis. Useful for testing the retrieval pipeline or when no GPU is available.
+Skips LLM synthesis entirely. Every tool returns its retrieval results marked
+`degraded: true`. Useful for exercising the retrieval pipeline or when no GPU is
+available.
 
 ```bash
 export AR_CONSULTANT_BACKEND=passthrough
 ```
+
+Note that pinning any backend by name disables auto-detection, so a pinned
+backend that is unreachable degrades rather than falling back to another one.
 
 ## Environment Variables
 
@@ -164,6 +176,7 @@ export AR_CONSULTANT_BACKEND=passthrough
 | `AR_CONSULTANT_MODEL` | `qwen2.5-coder:32b-instruct-q4_K_M` | Ollama model name |
 | `AR_CONSULTANT_MLX_MODEL` | `mlx-community/Qwen2.5-Coder-32B-Instruct-4bit` | MLX model path |
 | `AR_CONSULTANT_HISTORY_DIR` | `tools/mcp/consultant/data` | Directory for `history.db` |
+| `AR_INFERENCE_HEALTH_TTL` | `30` | Seconds a backend health probe is trusted before re-probing; `0` probes every time |
 | `AR_MEMORY_URL` | (auto-discovered) | ar-memory HTTP server URL |
 | `AR_MEMORY_REFORMULATED` | unset (off) | Show reformulated memory text by default instead of the original (beta) |
 
@@ -215,12 +228,23 @@ servers.
 
 ### "passthrough (no model)" in consultant_status
 
-The consultant could not find any LLM backend at startup. Check:
+No LLM backend is reachable right now. Documentation search, memory recall and
+history are unaffected; only synthesized answers are missing, and responses say
+so with `degraded: true`. Check:
 
 1. Is llama-server / Ollama actually running? (`curl http://localhost:8084/health`)
 2. If running on a remote host, is it reachable? (`curl http://mac-studio:8084/health`)
 3. If reachable via `nc` but not `curl`, check the [macOS firewall](#macos-firewall-common-issue) section
-4. After fixing, **restart the MCP server** -- the backend is cached at startup
+
+No restart is needed after fixing it — the consultant re-probes and picks the
+backend up within `AR_INFERENCE_HEALTH_TTL` seconds.
+
+### `remember` returns `stored: false`
+
+Reformulation needs a model, and storing an unreformulated note would put a raw
+context dump into the corpus, where it leads recall for large queries. The tool
+refuses instead, returning the note as `original` so it can be re-sent once a
+backend is up. This is the only tool that fails closed on a backend outage.
 
 ### "memory_available: false" in consultant_status
 

--- a/tools/mcp/consultant/history.py
+++ b/tools/mcp/consultant/history.py
@@ -88,7 +88,12 @@ class RequestRecord:
         """Finalize timing and extract a result summary."""
         self.latency_ms = int((time.monotonic() - self.start_time) * 1000)
         if isinstance(result, dict):
-            summary = result.get("answer") or result.get("summary") or result.get("response")
+            # "note" last: it is what degraded results carry in place of
+            # synthesized text, so an outage still records what was returned.
+            summary = (
+                result.get("answer") or result.get("summary")
+                or result.get("response") or result.get("note")
+            )
             if summary:
                 self.result_summary = str(summary)[:500]
 
@@ -387,31 +392,45 @@ def tracked_tool(history: HistoryStore, tool_name: str) -> Callable:
 # Tracked LLM generation helper
 # ---------------------------------------------------------------------------
 
-def tracked_generate(
+def tracked_synthesize(
     llm: Any,
     prompt: str,
     system: Optional[str] = None,
     max_tokens: int = 1024,
     temperature: float = 0.3,
-) -> str:
-    """Call ``llm.generate()`` while recording prompt, response, and timing.
+) -> Any:
+    """Call ``llm.synthesize()`` while recording prompt, response, and timing.
 
     If there is an active ``RequestRecord`` in ``_current_request``, the
     prompt text, LLM response, backend name, and LLM latency are written
     to it.  If there is no active record (e.g. called outside of a
     tracked tool), the function behaves identically to a direct
-    ``llm.generate()`` call.
+    ``llm.synthesize()`` call.
+
+    A degraded result is recorded too, with the failure reason in place of
+    the response, so history analysis can tell a backend outage apart from
+    a poor answer.
+
+    Returns:
+        The ``Synthesis`` produced by the backend.
     """
     record = _current_request.get()
 
     t0 = time.monotonic()
-    response = llm.generate(prompt, system=system, max_tokens=max_tokens, temperature=temperature)
+    result = llm.synthesize(
+        prompt, system=system, max_tokens=max_tokens, temperature=temperature,
+    )
     elapsed_ms = int((time.monotonic() - t0) * 1000)
 
     if record is not None:
         record.prompt_text = prompt
-        record.llm_response = response
-        record.backend = llm.name
+        record.llm_response = (
+            result.text if not result.degraded
+            else f"(degraded: {result.reason})"
+        )
+        record.backend = result.backend
         record.llm_latency_ms = elapsed_ms
+        if result.degraded:
+            record.status = "degraded"
 
-    return response
+    return result

--- a/tools/mcp/consultant/inference.py
+++ b/tools/mcp/consultant/inference.py
@@ -25,8 +25,11 @@ _spec.loader.exec_module(_mod)
 # Re-export everything
 SYSTEM_PROMPT = _mod.SYSTEM_PROMPT
 InferenceBackend = _mod.InferenceBackend
+InferenceUnavailable = _mod.InferenceUnavailable
+Synthesis = _mod.Synthesis
 LlamaCppBackend = _mod.LlamaCppBackend
 OllamaBackend = _mod.OllamaBackend
 MLXBackend = _mod.MLXBackend
 PassthroughBackend = _mod.PassthroughBackend
+AutoBackend = _mod.AutoBackend
 create_backend = _mod.create_backend

--- a/tools/mcp/consultant/server.py
+++ b/tools/mcp/consultant/server.py
@@ -49,8 +49,8 @@ if _COMMON_DIR not in sys.path:
 from mcp.server.fastmcp import FastMCP
 
 from docs_retriever import DocsRetriever
-from history import HistoryStore, _current_request, tracked_generate, tracked_tool
-from inference import SYSTEM_PROMPT, create_backend
+from history import HistoryStore, _current_request, tracked_synthesize, tracked_tool
+from inference import SYSTEM_PROMPT, Synthesis, create_backend
 from memory_client import MemoryClient
 from memory_text import (
     BETA_NOTICE, prefers_reformulated, present, presented_entries, projected,
@@ -251,11 +251,46 @@ def _log_session_id(session_id: str) -> None:
         record.session_id = session_id
 
 
-def _generate(prompt: str, system: Optional[str] = None, max_tokens: int = 1024,
-              temperature: float = 0.3) -> str:
-    """Tracked wrapper around ``llm.generate()``."""
-    return tracked_generate(llm, prompt, system=system, max_tokens=max_tokens,
-                            temperature=temperature)
+def _synthesize(prompt: str, system: Optional[str] = None, max_tokens: int = 1024,
+                temperature: float = 0.3) -> Synthesis:
+    """Tracked wrapper around ``llm.synthesize()``.
+
+    Never raises when the model is unreachable — the caller inspects
+    :attr:`Synthesis.degraded` and returns its retrieval results anyway.
+    """
+    return tracked_synthesize(llm, prompt, system=system, max_tokens=max_tokens,
+                              temperature=temperature)
+
+
+def _degraded_note(result: Synthesis, retained: str) -> str:
+    """Explain a lost synthesis and point the caller at what did survive.
+
+    Retrieval runs before synthesis and is unaffected by a dead model, so
+    the caller is told exactly which fields are still trustworthy rather
+    than being handed an error.
+
+    Args:
+        result: The degraded synthesis.
+        retained: Description of the fields still populated in the response.
+    """
+    return (
+        "No summary was synthesized because the inference backend is "
+        f"unavailable ({result.reason}). {retained} Retrieval is unaffected, "
+        "so these results are complete and safe to use. To restore "
+        "synthesis, start a llama.cpp server (llama-server -m model.gguf "
+        "--host 0.0.0.0 --port 8084); the Consultant reconnects on its own."
+    )
+
+
+def _degrade(result: Synthesis, payload: dict, retained: str) -> dict:
+    """Mark a response as degraded and attach an explanatory note.
+
+    Used in place of a synthesized ``answer``/``summary`` so no caller can
+    mistake a backend outage for a substantive reply.
+    """
+    payload["degraded"] = True
+    payload["note"] = _degraded_note(result, retained)
+    return payload
 
 
 # ---------------------------------------------------------------------------
@@ -313,7 +348,7 @@ def consult(
 
     # Build prompt and generate
     prompt = _build_consult_prompt(question, doc_context, mem_context, context)
-    answer = _generate(prompt, system=SYSTEM_PROMPT)
+    synthesis = _synthesize(prompt, system=SYSTEM_PROMPT)
 
     # Source references: markdown files used in context + HTML for exploration
     sources = list({r["file"] for r in doc_results})
@@ -327,6 +362,20 @@ def consult(
         ],
         "backend": llm.name,
     }
+
+    # A dead model costs the synthesized answer, not the search that
+    # preceded it: return the documentation and memories that were found.
+    if synthesis.degraded:
+        _degrade(
+            synthesis, result,
+            "The sources, html_refs and related_memories fields below were "
+            "retrieved successfully and contain the documentation matching "
+            "this question — read them directly.",
+        )
+        result["note"] += _keyword_guidance(keywords)
+        return result
+
+    answer = synthesis.text
 
     # When the LLM could not synthesize an answer, replace "answer" with
     # a "note" that encourages the caller to explore the listed sources.
@@ -421,13 +470,12 @@ def recall(
 
     # Summarize with the model
     prompt = _build_recall_prompt(query, memories, doc_context)
-    summary = _generate(prompt, system=SYSTEM_PROMPT)
+    synthesis = _synthesize(prompt, system=SYSTEM_PROMPT)
 
     doc_refs = list({r["file"] for r in doc_results})
     doc_refs.extend(doc_retrieval["html_refs"])  # Include HTML refs too
 
     result = {
-        "summary": summary,
         "memories": [
             projected(m, ("id", "content", "score", "tags", "created_at"))
             for m in memories
@@ -435,6 +483,17 @@ def recall(
         "doc_references": doc_refs,
         "backend": llm.name,
     }
+
+    # The memories themselves are the substance of a recall; the summary is
+    # a convenience over them. Losing the model must not lose the memories.
+    if synthesis.degraded:
+        _degrade(
+            synthesis, result,
+            "The memories field below holds the full text of every match, "
+            "unsummarized and in the order retrieved.",
+        )
+    else:
+        result["summary"] = synthesis.text
 
     if notice:
         result["notice"] = notice
@@ -544,25 +603,27 @@ def remember(
 
     # Reformulate with the model
     prompt = _build_reformulate_prompt(content, doc_context)
-    reformulated = _generate(prompt, system=SYSTEM_PROMPT, max_tokens=512)
+    synthesis = _synthesize(prompt, system=SYSTEM_PROMPT, max_tokens=512)
 
-    # Strip any wrapping the model might add
-    reformulated = reformulated.strip().strip('"').strip("'")
-
-    # When no model is reachable, _generate returns the passthrough banner
-    # plus the raw prompt. Storing that as a memory pollutes recall (a census
-    # found 36 such dumps already in the corpus). Refuse early — before
-    # embedding — with a clear message. The ar-memory store guards this too,
-    # but catching it here avoids a wasted embed and a round trip.
-    if reformulated.lstrip().startswith("[Consultant model not available"):
+    # Reformulation is the one path that must NOT degrade to storing
+    # something: a context dump written into the corpus pollutes every
+    # later recall (a census found 36 such dumps already). Refuse before
+    # embedding. The ar-memory store guards this too, but catching it here
+    # avoids a wasted embed and a round trip.
+    if synthesis.degraded:
         return {
             "stored": False,
-            "error": "inference backend unavailable; memory not stored. "
-                     "Retry once a model is reachable.",
+            "degraded": True,
+            "error": "inference backend unavailable; memory not stored "
+                     f"({synthesis.reason}). Retry once a model is reachable — "
+                     "the note below is returned unchanged so it is not lost.",
             "original": content,
             "namespace": namespace,
             "backend": llm.name,
         }
+
+    # Strip any wrapping the model might add
+    reformulated = synthesis.text.strip().strip('"').strip("'")
 
     # Store both versions
     entry = memory.store_dual(
@@ -632,16 +693,27 @@ def search_docs(query: str, module: Optional[str] = None) -> dict:
         "Provide a brief summary of what the documentation says about this "
         "topic. Reference specific files, classes, or methods. Be concise."
     )
-    summary = _generate(prompt, system=SYSTEM_PROMPT)
+    synthesis = _synthesize(prompt, system=SYSTEM_PROMPT)
 
-    return {
-        "summary": summary,
+    result = {
         "results": [
             {"file": r["file"], "line": r["line"], "context": r["context"]}
             for r in results
         ],
         "backend": llm.name,
     }
+
+    if synthesis.degraded:
+        _degrade(
+            synthesis, result,
+            "The results field below carries every matching chunk with its "
+            "file and line number, which is the searchable substance of this "
+            "response.",
+        )
+    else:
+        result["summary"] = synthesis.text
+
+    return result
 
 
 @mcp.tool()
@@ -680,23 +752,40 @@ def start_consultation(topic: str) -> dict:
     _log_memory_results(topic, memories)
 
     prompt = _build_consult_prompt(topic, doc_context, mem_context)
-    response = _generate(prompt, system=SYSTEM_PROMPT)
+    synthesis = _synthesize(prompt, system=SYSTEM_PROMPT)
+
+    # A degraded turn is not part of the conversation. Recording the
+    # failure as an assistant message would feed it back as context on
+    # every later turn, so only the user's opening is kept. The retrieved
+    # doc context is kept, so the session is usable the moment a model
+    # returns.
+    messages = [{"role": "user", "content": topic}]
+    if not synthesis.degraded:
+        messages.append({"role": "assistant", "content": synthesis.text})
 
     _sessions[session_id] = {
         "topic": topic,
-        "messages": [
-            {"role": "user", "content": topic},
-            {"role": "assistant", "content": response},
-        ],
+        "messages": messages,
         "doc_context": doc_context,
         "created": time.time(),
     }
 
-    return {
+    result = {
         "session_id": session_id,
-        "response": response,
         "backend": llm.name,
     }
+
+    if synthesis.degraded:
+        _degrade(
+            synthesis, result,
+            f"Session '{session_id}' was opened and its documentation context "
+            "retrieved, so continue_consultation will work once a model is "
+            "reachable.",
+        )
+    else:
+        result["response"] = synthesis.text
+
+    return result
 
 
 @mcp.tool()
@@ -751,17 +840,31 @@ def continue_consultation(session_id: str, message: str) -> dict:
                         "conversation history.")
 
     prompt = "\n\n".join(prompt_parts)
-    response = _generate(prompt, system=SYSTEM_PROMPT)
+    synthesis = _synthesize(prompt, system=SYSTEM_PROMPT)
 
-    session["messages"].append({"role": "user", "content": message})
-    session["messages"].append({"role": "assistant", "content": response})
+    # Leave the transcript untouched on a degraded turn: appending the user
+    # message without a reply would strand it, and appending the failure as
+    # a reply would poison every subsequent turn's context.
+    if not synthesis.degraded:
+        session["messages"].append({"role": "user", "content": message})
+        session["messages"].append({"role": "assistant", "content": synthesis.text})
 
-    return {
-        "response": response,
+    result = {
         "session_id": session_id,
         "turn": len(session["messages"]) // 2,
         "backend": llm.name,
     }
+
+    if synthesis.degraded:
+        _degrade(
+            synthesis, result,
+            "This turn was not recorded, so the session is unchanged and the "
+            "same message can be sent again once a model is reachable.",
+        )
+    else:
+        result["response"] = synthesis.text
+
+    return result
 
 
 @mcp.tool()
@@ -808,24 +911,44 @@ def end_consultation(
         "recommendations made. This summary will be stored as a memory "
         "entry for future reference."
     )
-    summary = _generate(prompt, system=SYSTEM_PROMPT, max_tokens=512)
+    synthesis = _synthesize(prompt, system=SYSTEM_PROMPT, max_tokens=512)
 
     result = {
-        "summary": summary,
         "session_id": session_id,
         "topic": session["topic"],
         "turns": len(session["messages"]) // 2,
         "backend": llm.name,
     }
 
+    # Without a summary there is nothing worth storing, and storing the
+    # failure text would put a non-memory into the corpus. Return the
+    # transcript instead so the caller keeps what the session produced.
+    if synthesis.degraded:
+        _degrade(
+            synthesis, result,
+            "No summary was stored. The full transcript is returned in the "
+            "messages field so nothing from the session is lost.",
+        )
+        result["messages"] = session["messages"]
+        return result
+
+    result["summary"] = synthesis.text
+
     if store_summary:
         entry = memory.store(
-            content=summary,
+            content=synthesis.text,
             namespace=namespace,
             tags=["consultation", "summary"],
             source=f"consultation:{session_id}",
         )
-        result["memory_entry_id"] = entry["id"]
+        # The memory service degrades to an error dict rather than raising,
+        # so the id is not guaranteed to be present.
+        if "id" in entry:
+            result["memory_entry_id"] = entry["id"]
+        else:
+            result["storage_error"] = entry.get(
+                "error", "memory service unavailable; summary not stored",
+            )
 
     return result
 
@@ -967,10 +1090,9 @@ def branch_catchup(
     ]
 
     prompt = "\n".join(prompt_parts)
-    briefing = _generate(prompt, system=SYSTEM_PROMPT, max_tokens=2048)
+    synthesis = _synthesize(prompt, system=SYSTEM_PROMPT, max_tokens=2048)
 
     result = {
-        "briefing": briefing,
         "branch": branch,
         "repo_url": repo_url,
         "memory_count": len(branch_memories),
@@ -981,6 +1103,19 @@ def branch_catchup(
         "commit_log": commit_log,
         "backend": llm.name,
     }
+
+    # The briefing is a synthesis of the memories and commit log, both of
+    # which are already in the response. A dead model costs the narrative,
+    # not the underlying material.
+    if synthesis.degraded:
+        _degrade(
+            synthesis, result,
+            "The memories and commit_log fields below hold the raw material "
+            "the briefing would have summarized — read them in order to catch "
+            "up on this branch.",
+        )
+    else:
+        result["briefing"] = synthesis.text
 
     if notice:
         result["notice"] = notice
@@ -993,18 +1128,38 @@ def branch_catchup(
 def consultant_status() -> dict:
     """Check the Consultant's status and backend configuration.
 
+    ``backend_available`` reflects a live health probe (re-checked at most
+    once per health TTL), not the state at process start, so it can be
+    trusted to agree with what the other tools will actually do.
+
     Returns:
         Dictionary with backend info, active sessions, and health status.
     """
-    return {
+    backend_available = llm.available
+
+    status = {
         "backend": llm.name,
-        "backend_available": llm.available,
+        "backend_available": backend_available,
         "memory_available": memory.available,
         "active_sessions": len(_sessions),
         "session_ttl_seconds": _SESSION_TTL,
         "docs_modules_available": len(docs._all_doc_files()),
         "history_db": str(history._db_path),
     }
+
+    if not backend_available:
+        status["degraded"] = True
+        status["note"] = (
+            "No inference model is reachable. Documentation search, memory "
+            "recall and history remain fully functional; only synthesized "
+            "answers and summaries are unavailable, and every tool reports "
+            "degraded=true while that is so. remember is the exception: it "
+            "refuses to store rather than write an unreformulated note. "
+            "Start a llama.cpp server (llama-server -m model.gguf --host "
+            "0.0.0.0 --port 8084) to restore synthesis; no restart is needed."
+        )
+
+    return status
 
 
 # ---------------------------------------------------------------------------

--- a/tools/mcp/manager/server.py
+++ b/tools/mcp/manager/server.py
@@ -2868,10 +2868,14 @@ def memory_recall(
         memories, reformulated=reformulated or prefers_reformulated(),
     )
 
-    # Attempt LLM synthesis
+    # Attempt LLM synthesis. The memories are the substance of the response
+    # and are returned either way; synthesis is a convenience over them.
     summary = None
+    degraded_reason = None
     llm = _get_llm()
-    if llm and llm.available:
+    if llm is None:
+        degraded_reason = "no inference backend could be constructed"
+    else:
         try:
             from inference import SYSTEM_PROMPT
 
@@ -2886,9 +2890,16 @@ def memory_recall(
                 "Summarize the retrieved memories. Highlight key findings and "
                 "any decisions or progress notes. Be concise (2-4 sentences)."
             )
-            summary = llm.generate(prompt, system=SYSTEM_PROMPT)
+            # synthesize() reports an unreachable model as a value rather
+            # than raising, and re-probes health so a recovered backend is
+            # picked up without restarting this server.
+            synthesis = llm.synthesize(prompt, system=SYSTEM_PROMPT)
+            if synthesis.degraded:
+                degraded_reason = synthesis.reason
+            else:
+                summary = synthesis.text
         except Exception as e:
-            summary = f"(LLM synthesis failed: {e})"
+            degraded_reason = f"LLM synthesis failed: {e}"
 
     result = {
         "ok": True,
@@ -2908,6 +2919,13 @@ def memory_recall(
 
     if summary:
         result["summary"] = summary
+    elif degraded_reason:
+        result["degraded"] = True
+        result["note"] = (
+            f"No summary was synthesized ({degraded_reason}). The memories "
+            "field is complete and unaffected — memory retrieval does not "
+            "depend on the inference backend."
+        )
     if notice:
         result["notice"] = notice
 

--- a/tools/mcp/manager/test_server.py
+++ b/tools/mcp/manager/test_server.py
@@ -20,6 +20,12 @@ _MANAGER_DIR = os.path.dirname(os.path.abspath(__file__))
 if _MANAGER_DIR not in sys.path:
     sys.path.insert(0, _MANAGER_DIR)
 
+_COMMON_DIR = os.path.join(os.path.dirname(_MANAGER_DIR), "common")
+if _COMMON_DIR not in sys.path:
+    sys.path.insert(0, _COMMON_DIR)
+
+from inference import Synthesis  # noqa: E402
+
 # Suppress startup prints during import
 with patch.dict(os.environ, {"AR_CONTROLLER_URL": "http://test:7780"}):
     import server
@@ -2672,12 +2678,36 @@ class TestMemoryReformulatedText(unittest.TestCase):
         mock_client_fn.return_value = client
         llm = MagicMock()
         llm.available = True
-        llm.generate.return_value = "summary"
+        llm.synthesize.return_value = Synthesis("summary", "fake")
         mock_llm.return_value = llm
         server.memory_recall(query="test", scope="all")
-        prompt = llm.generate.call_args[0][0]
+        prompt = llm.synthesize.call_args[0][0]
         self.assertIn("what the agent actually wrote", prompt)
         self.assertNotIn("rewritten by the consultant", prompt)
+
+    @patch.object(server, "_get_llm")
+    @patch.object(server, "_get_memory_client")
+    def test_recall_returns_memories_when_synthesis_degrades(
+        self, mock_client_fn, mock_llm,
+    ):
+        """An unreachable model costs the summary, not the memories."""
+        _grant_all_scopes()
+        client = MagicMock()
+        client.search.return_value = [self._reformulated_memory()]
+        mock_client_fn.return_value = client
+        llm = MagicMock()
+        llm.synthesize.return_value = Synthesis(None, "fake", "backend is down")
+        mock_llm.return_value = llm
+
+        result = server.memory_recall(query="test", scope="all")
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(
+            "what the agent actually wrote", result["memories"][0]["content"],
+        )
+        self.assertNotIn("summary", result)
+        self.assertTrue(result["degraded"])
+        self.assertIn("backend is down", result["note"])
 
     @patch.object(server, "_github_request", return_value={"ok": False, "error": "off"})
     @patch.object(server, "_get_memory_client")

--- a/tools/mcp/secrets/test_secrets_server.py
+++ b/tools/mcp/secrets/test_secrets_server.py
@@ -10,7 +10,7 @@ required environment variables.
 
 import base64
 import hmac
-import importlib
+import importlib.util
 import io
 import json
 import os
@@ -59,9 +59,20 @@ def _import_server(env: dict = None):
     # Drop unset markers
     effective = {k: v for k, v in effective.items() if v is not None}
     with patch.dict(os.environ, effective, clear=False):
-        if "server" in sys.modules:
-            del sys.modules["server"]
-        import server as srv  # type: ignore
+        # Loaded by explicit path under a name only this directory uses.
+        # `import server` resolves by sys.path order, and several MCP
+        # server directories define a top-level server.py, so in a run
+        # spanning more than one of them this picked up whichever
+        # directory pytest had inserted most recently — the tests then
+        # failed against the wrong module. Re-executed on every call
+        # because each caller needs the module's import-time reads of
+        # the environment patched above.
+        spec = importlib.util.spec_from_file_location(
+            "ar_secrets_server", os.path.join(_SECRETS_DIR, "server.py"),
+        )
+        srv = importlib.util.module_from_spec(spec)
+        sys.modules["ar_secrets_server"] = srv
+        spec.loader.exec_module(srv)
         return srv
 
 

--- a/tools/mcp/test-runner/server_under_test.py
+++ b/tools/mcp/test-runner/server_under_test.py
@@ -33,6 +33,8 @@ def _load():
         return cached
 
     spec = importlib.util.spec_from_file_location(MODULE_NAME, _SERVER_PATH)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Could not load {MODULE_NAME} from {_SERVER_PATH}")
     module = importlib.util.module_from_spec(spec)
     # Registered before execution so a circular import inside server.py
     # resolves to the partially initialised module rather than re-entering.

--- a/tools/mcp/test-runner/server_under_test.py
+++ b/tools/mcp/test-runner/server_under_test.py
@@ -1,0 +1,44 @@
+"""Loads this directory's ``server.py`` under an unambiguous module name.
+
+Nine MCP server directories each define a top-level ``server.py``. A test
+run spanning more than one of them shares a single interpreter and a single
+``sys.modules``, so a plain ``import server`` resolves to whichever
+directory got there first — and the losing directory's tests then exercise
+the wrong module. The symptom does not read as a name clash: ar-manager's
+``server`` has no ``runner``, so these tests failed with ``AttributeError:
+module 'server' has no attribute 'runner'``.
+
+Adjusting ``sys.path`` cannot fix it, because the stale binding is already
+cached under the name ``server``. Loading by explicit path under a name
+only this directory uses removes the ambiguity outright, independent of
+``sys.path`` order and of the order pytest happens to collect in. The
+module is cached under that name so every test file here shares one
+instance, exactly as ``import server`` used to give them.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+#: Distinct from the bare ``server`` that other directories also claim.
+MODULE_NAME = "ar_test_runner_server"
+
+_SERVER_PATH = Path(__file__).resolve().parent / "server.py"
+
+
+def _load():
+    """Return the cached module, importing it from disk on first use."""
+    cached = sys.modules.get(MODULE_NAME)
+    if cached is not None:
+        return cached
+
+    spec = importlib.util.spec_from_file_location(MODULE_NAME, _SERVER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    # Registered before execution so a circular import inside server.py
+    # resolves to the partially initialised module rather than re-entering.
+    sys.modules[MODULE_NAME] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+server = _load()

--- a/tools/mcp/test-runner/test_group_resolution.py
+++ b/tools/mcp/test-runner/test_group_resolution.py
@@ -10,7 +10,9 @@ import pathlib
 import tempfile
 import unittest
 
-import server
+# Not `import server`: that name is claimed by several MCP server
+# directories at once. See server_under_test for why.
+from server_under_test import server
 
 FIXTURE = """\
       - name: Run Utils Tests (Group ${{ matrix.group }})

--- a/tools/mcp/test-runner/test_preflight_integration.py
+++ b/tools/mcp/test-runner/test_preflight_integration.py
@@ -39,7 +39,9 @@ if str(_COMMON_DIR) not in sys.path:
     sys.path.insert(0, str(_COMMON_DIR))
 
 import preflight  # noqa: E402
-import server  # noqa: E402
+# Not `import server`: that name is claimed by several MCP server
+# directories at once. See server_under_test for why.
+from server_under_test import server  # noqa: E402
 
 
 def _write_root_pom(project_root: Path, version: str = "0.74") -> None:

--- a/tools/mcp/test-runner/test_runner_server.py
+++ b/tools/mcp/test-runner/test_runner_server.py
@@ -27,7 +27,9 @@ _SERVER_DIR = Path(__file__).resolve().parent
 if str(_SERVER_DIR) not in sys.path:
     sys.path.insert(0, str(_SERVER_DIR))
 
-import server  # noqa: E402
+# Not `import server`: that name is claimed by several MCP server
+# directories at once. See server_under_test for why.
+from server_under_test import server  # noqa: E402
 import watcher  # noqa: E402
 
 


### PR DESCRIPTION
An unreachable LLM turned every ar-consultant tool into a hard error, even though the documentation search and memory search that precede synthesis had already succeeded. Health was probed once and memoized for the life of the process, so `consultant_status` reported a backend as available while every call to it failed, and a backend that came back was ignored until each MCP server restarted.

Inference (tools/mcp/common/):

- Backends raise a typed `InferenceUnavailable` instead of letting transport errors escape, and `synthesize()` reports failure as a `Synthesis` value (`text` / `degraded` / `reason`) rather than raising. This replaces sniffing for a banner string in the returned text.
- `health.py` holds `HealthCache`: a probe result trusted for `AR_INFERENCE_HEALTH_TTL` seconds (default 30), re-probed once stale and invalidated after an observed failure. Both the inference backends and `MemoryHTTPClient` had the same permanent-cache bug and now share it.
- `AutoBackend` re-runs detection when its choice goes stale, so starting or stopping a model takes effect without restarting anything. It deliberately does not re-probe while the no-model fallback is answering: nothing was attempted, so there is no new evidence, and probing anyway put a full candidate scan in front of every call for the duration of an outage.
- `PassthroughBackend` reports itself unavailable and degrades. It still emits its banner from `generate()`, which the memory store's guard matches to reject dumps written before degradation was structured.

Callers:

- Each consultant tool returns its retrieval results with `degraded: true` and a note naming the fields that are still complete: `consult` keeps sources and related memories, `recall` and `branch_catchup` keep memories, `search_docs` keeps results, `end_consultation` returns the transcript. ar-manager's `memory_recall` matches.
- `remember` is the exception and fails closed, since storing an unreformulated note puts a context dump into the corpus where it leads recall.
- A degraded consultation turn is not written to the session transcript; recording it would feed the failure back as context on every later turn.
- `end_consultation` no longer raises `KeyError` when the memory service declines to store the summary.

Test layout (tools/mcp/):

Three directories each contained a `test_server.py`, and since these directories are not packages, all three claimed one module name — collection of any run spanning them aborted with "import file mismatch". Renaming two after the servers they test exposed a second collision underneath: nine directories define a top-level `server.py`, and a bare `import server` resolves by `sys.path` order, so the losing directories were exercising ar-manager's module (`AttributeError: module 'server' has no attribute 'runner'`). ar-secrets and ar-test-runner now load their own `server.py` from an explicit path under a directory-specific name. `python3 -m pytest tools/mcp` runs the whole suite in one command for the first time; `common/test_layout.py` asserts both invariants so a new server directory cannot reintroduce either silently.

Documentation in both READMEs told users to restart the MCP server after starting a model, which is no longer true.