### PR TITLE
Keep derived note sources out of the persisted choices file

### DIFF
--- a/engine/audio/src/main/java/org/almostrealism/audio/AudioLibrary.java
+++ b/engine/audio/src/main/java/org/almostrealism/audio/AudioLibrary.java
@@ -570,6 +570,28 @@ public class AudioLibrary implements ConsoleFeatures {
 	}
 
 	/**
+	 * Resolves a content identifier to the file backing it, searching the file
+	 * tree by identifier rather than assuming any particular filename.
+	 *
+	 * <p>This is what makes library filenames a presentation concern: content
+	 * is addressed by what it is, so a sample can be named for the user without
+	 * anything that references it needing to know the name.</p>
+	 *
+	 * @param identifier the content identifier to resolve
+	 * @return the existing file backing the identifier, or {@code null} if the
+	 *         identifier is blank, unknown, or names a file that is gone
+	 */
+	public File fileFor(String identifier) {
+		if (identifier == null || identifier.isBlank()) return null;
+
+		WaveDataProvider provider = find(identifier);
+		if (provider == null) return null;
+
+		File file = new File(provider.getKey());
+		return file.isFile() ? file : null;
+	}
+
+	/**
 	 * Adds pre-computed {@link WaveDetails} to this library.
 	 *
 	 * <p>The details are indexed by their content identifier. This method is

--- a/studio/compose/src/main/java/org/almostrealism/studio/AudioSceneLoader.java
+++ b/studio/compose/src/main/java/org/almostrealism/studio/AudioSceneLoader.java
@@ -20,10 +20,12 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.deser.DeserializationProblemHandler;
 import com.fasterxml.jackson.databind.deser.ValueInstantiator;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.jsontype.TypeIdResolver;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import org.almostrealism.audio.AudioLibrary;
 import org.almostrealism.audio.data.FileWaveDataProviderNode;
@@ -95,19 +97,36 @@ public class AudioSceneLoader {
 	 * scene settings. Includes custom deserializers for {@link KeyPosition} and
 	 * {@link WesternChromatic}.
 	 *
-	 * <p>An entry that names a type the reader cannot construct is skipped
-	 * rather than allowed to fail the read. Scene settings and pattern choices
-	 * are whole-file documents holding a user's entire configuration, and their
-	 * polymorphic entries are tagged with class names; without this, one entry
-	 * written by a version that could not read it back — or naming a class that
-	 * has since been removed — discards every other setting in the file. A
-	 * skipped entry is reported through the console so the loss is visible.</p>
+	 * <p>An entry the reader cannot turn into an object is skipped rather than
+	 * allowed to fail the read. Scene settings and pattern choices are
+	 * whole-file documents holding a user's entire configuration, and their
+	 * polymorphic entries are tagged with class names, so a single bad entry
+	 * would otherwise discard every other setting in the file. Two distinct
+	 * failures are covered, because a class name records both what to build and
+	 * how to find it:</p>
+	 *
+	 * <ul>
+	 *   <li>the named class exists but cannot be instantiated — written by a
+	 *       version that could not read it back;</li>
+	 *   <li>the named class cannot be resolved at all — renamed, moved, or
+	 *       removed since the file was written. This one arrives long after the
+	 *       change that caused it, in a file the user has no way to repair.</li>
+	 * </ul>
+	 *
+	 * <p>Either way the entry becomes {@code null} for its container to drop,
+	 * and is reported through the console so the loss is visible rather than
+	 * silent.</p>
 	 *
 	 * @return a configured {@link ObjectMapper}
 	 */
 	public static ObjectMapper defaultMapper() {
 		ObjectMapper mapper = new ObjectMapper();
 		mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+		/* Consulted only after every problem handler declines to resolve the
+		   type id; disabling it turns an unresolvable entry into null instead
+		   of an exception that ends the read. */
+		mapper.configure(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE, false);
 
 		SimpleModule module = new SimpleModule();
 		module.addDeserializer(KeyPosition.class, keyPositionDeserializer(KeyPosition.class, KeyPosition::of));
@@ -124,6 +143,17 @@ public class AudioSceneLoader {
 				AudioScene.console.warn("Skipped a stored " + targetType.getName()
 						+ " that cannot be constructed (" + message + ")");
 				skipRemainderOfObject(parser);
+				return null;
+			}
+
+			@Override
+			public JavaType handleUnknownTypeId(DeserializationContext context,
+												JavaType baseType,
+												String subTypeId,
+												TypeIdResolver idResolver,
+												String message) {
+				AudioScene.console.warn("Skipped a stored " + baseType.getRawClass().getName()
+						+ " naming the unknown type " + subTypeId + " (" + message + ")");
 				return null;
 			}
 		});

--- a/studio/compose/src/main/java/org/almostrealism/studio/AudioSceneLoader.java
+++ b/studio/compose/src/main/java/org/almostrealism/studio/AudioSceneLoader.java
@@ -21,6 +21,8 @@ import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.deser.DeserializationProblemHandler;
+import com.fasterxml.jackson.databind.deser.ValueInstantiator;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import org.almostrealism.audio.AudioLibrary;
@@ -93,6 +95,14 @@ public class AudioSceneLoader {
 	 * scene settings. Includes custom deserializers for {@link KeyPosition} and
 	 * {@link WesternChromatic}.
 	 *
+	 * <p>An entry that names a type the reader cannot construct is skipped
+	 * rather than allowed to fail the read. Scene settings and pattern choices
+	 * are whole-file documents holding a user's entire configuration, and their
+	 * polymorphic entries are tagged with class names; without this, one entry
+	 * written by a version that could not read it back — or naming a class that
+	 * has since been removed — discards every other setting in the file. A
+	 * skipped entry is reported through the console so the loss is visible.</p>
+	 *
 	 * @return a configured {@link ObjectMapper}
 	 */
 	public static ObjectMapper defaultMapper() {
@@ -104,7 +114,53 @@ public class AudioSceneLoader {
 		module.addDeserializer(WesternChromatic.class, keyPositionDeserializer(WesternChromatic.class, s -> WesternChromatic.valueOf(s)));
 		mapper.registerModule(module);
 
+		mapper.addHandler(new DeserializationProblemHandler() {
+			@Override
+			public Object handleMissingInstantiator(DeserializationContext context,
+													Class<?> targetType,
+													ValueInstantiator instantiator,
+													JsonParser parser,
+													String message) throws IOException {
+				AudioScene.console.warn("Skipped a stored " + targetType.getName()
+						+ " that cannot be constructed (" + message + ")");
+				skipRemainderOfObject(parser);
+				return null;
+			}
+		});
+
 		return mapper;
+	}
+
+	/**
+	 * Consumes the remaining content of the object the parser is currently
+	 * reading, leaving it on that object's closing token.
+	 *
+	 * <p>A problem handler is invoked partway through an object — the type id
+	 * has already been read — so {@link JsonParser#skipChildren()} alone does
+	 * not apply: the parser is inside the object rather than on its opening
+	 * token, and returning from there leaves the remaining fields to be misread
+	 * as the next element. Nested objects and arrays are skipped wholesale so
+	 * only the enclosing object's own end is matched.</p>
+	 *
+	 * @param parser the parser positioned within the object to discard
+	 */
+	private static void skipRemainderOfObject(JsonParser parser) throws IOException {
+		JsonToken current = parser.currentToken();
+
+		if (current == JsonToken.START_OBJECT || current == JsonToken.START_ARRAY) {
+			parser.skipChildren();
+			return;
+		}
+
+		while (current != JsonToken.END_OBJECT) {
+			current = parser.nextToken();
+			if (current == null) return;
+
+			if (current == JsonToken.START_OBJECT || current == JsonToken.START_ARRAY) {
+				parser.skipChildren();
+				current = parser.currentToken();
+			}
+		}
 	}
 
 	/**

--- a/studio/compose/src/main/java/org/almostrealism/studio/persistence/AudioLayerGroupLibrary.java
+++ b/studio/compose/src/main/java/org/almostrealism/studio/persistence/AudioLayerGroupLibrary.java
@@ -120,6 +120,37 @@ public class AudioLayerGroupLibrary implements ConsoleFeatures {
 	 */
 	public Optional<String> includeGroup(Audio.AudioLayerGroup group,
 										 Function<Audio.AudioLayer, File> wavSource) {
+		return includeGroup(group, wavSource, null);
+	}
+
+	/**
+	 * Saves a group as in {@link #includeGroup(Audio.AudioLayerGroup, Function)},
+	 * with the caller choosing the file each member is written to.
+	 *
+	 * <p>A member's identity is its MD5, carried in the layer's
+	 * {@code audio_ref} and resolved by searching the library for a matching
+	 * content identifier — never by filename. Names are therefore free, and a
+	 * caller that knows what the user called the capture should supply readable
+	 * ones: a library full of {@code a3f2…c1.wav} cannot be browsed, which is
+	 * half of what saving a group is for. Naming policy, including how clashes
+	 * are resolved, stays with the caller that owns the library's layout; this
+	 * method only copies to the file it is given.</p>
+	 *
+	 * <p>A member already present in the library is reused where it lies and is
+	 * not copied again, so {@code targetSource} is consulted only for members
+	 * being added.</p>
+	 *
+	 * @param group        the staged group to save
+	 * @param wavSource    resolves the source WAV file for an audio layer
+	 * @param targetSource resolves the file a newly added member is written to;
+	 *                     {@code null} (or a {@code null} result) falls back to
+	 *                     {@code <libraryRoot>/<md5>.wav}
+	 * @return the stored group key on success, or {@link Optional#empty()} on
+	 *         failure (after rollback)
+	 */
+	public Optional<String> includeGroup(Audio.AudioLayerGroup group,
+										 Function<Audio.AudioLayer, File> wavSource,
+										 Function<Audio.AudioLayer, File> targetSource) {
 		if (group == null || group.getKey().isBlank()) {
 			warn("Cannot save a group with no key");
 			return Optional.empty();
@@ -142,7 +173,8 @@ public class AudioLayerGroupLibrary implements ConsoleFeatures {
 				Audio.AudioLayer layer = group.getLayers(i);
 				if (!layer.hasAudio()) continue;
 
-				String md5 = stripAndStoreLayer(layer, wavSource, wavsWritten, idsAdded);
+				String md5 = stripAndStoreLayer(layer, wavSource, targetSource,
+						wavsWritten, idsAdded);
 				slim.setLayers(i, layer.toBuilder().setAudioRef(md5).build());
 			}
 
@@ -163,6 +195,8 @@ public class AudioLayerGroupLibrary implements ConsoleFeatures {
 	 *
 	 * @param layer        the audio layer to store
 	 * @param wavSource    per-layer source WAV resolver
+	 * @param targetSource per-layer destination resolver, or {@code null} to
+	 *                     write to {@code <libraryRoot>/<md5>.wav}
 	 * @param wavsWritten  accumulator for WAVs created by this call
 	 * @param idsAdded     accumulator for store ids added by this call
 	 * @return the member's MD5 identifier (its {@code audio_ref})
@@ -171,6 +205,7 @@ public class AudioLayerGroupLibrary implements ConsoleFeatures {
 	 */
 	private String stripAndStoreLayer(Audio.AudioLayer layer,
 									  Function<Audio.AudioLayer, File> wavSource,
+									  Function<Audio.AudioLayer, File> targetSource,
 									  List<File> wavsWritten, List<String> idsAdded) {
 		File source = wavSource == null ? null : wavSource.apply(layer);
 		if (source == null || !source.isFile()) {
@@ -182,20 +217,29 @@ public class AudioLayerGroupLibrary implements ConsoleFeatures {
 			throw new GroupSaveException("Could not compute identifier for " + source);
 		}
 
-		File target = new File(libraryRoot, md5 + ".wav");
 		boolean storeHadBefore = (library.getStore() != null)
 				? library.getStore().containsKey(md5)
 				: library.get(md5) != null;
-		if (target.exists()) {
-			String existing = identifierOf(target);
-			if (!md5.equals(existing)) {
-				throw new GroupSaveException("A different file already occupies "
-						+ target.getName() + " (expected " + md5 + ", found " + existing + ")");
+
+		/* A member already in the library is referenced where it lies: the
+		   content is identical by construction, and copying it again under a
+		   second name would add a duplicate the user never asked for. */
+		File target = library.fileFor(md5);
+
+		if (target == null) {
+			target = targetSource == null ? null : targetSource.apply(layer);
+			if (target == null) target = new File(libraryRoot, md5 + ".wav");
+
+			if (target.exists()) {
+				String existing = identifierOf(target);
+				if (!md5.equals(existing)) {
+					throw new GroupSaveException("A different file already occupies "
+							+ target.getName() + " (expected " + md5 + ", found " + existing + ")");
+				}
+			} else {
+				copyWav(source, target);
+				wavsWritten.add(target);
 			}
-			// Same MD5 already present: byte-equivalent, nothing to copy.
-		} else {
-			copyWav(source, target);
-			wavsWritten.add(target);
 		}
 
 		// Route through the existing single-sample analysis path so the member

--- a/studio/compose/src/main/java/org/almostrealism/studio/persistence/AudioLayerPitch.java
+++ b/studio/compose/src/main/java/org/almostrealism/studio/persistence/AudioLayerPitch.java
@@ -21,6 +21,7 @@ import org.almostrealism.audio.midi.MidiNotes;
 import org.almostrealism.audio.tone.KeyPosition;
 import org.almostrealism.audio.tone.WesternChromatic;
 
+import java.util.Optional;
 import java.util.OptionalInt;
 
 /**
@@ -103,6 +104,29 @@ public final class AudioLayerPitch {
 
 		OptionalInt midi = MidiNotes.parseNoteName(trailingToken(layer.getLayerId()));
 		return midi.isPresent() ? midiToKeyPosition(midi.getAsInt()) : null;
+	}
+
+	/**
+	 * Returns the note name identifying a layer's captured pitch — {@code "C4"},
+	 * {@code "D#2"} — in the same form the capture flow already uses in stem
+	 * names.
+	 *
+	 * <p>This is the per-member half of a captured set's naming: a whole capture
+	 * is named once by the user, and each member is distinguished by the note it
+	 * was rendered at. It reads the same authoritative pitch as
+	 * {@link #capturedKeyPosition(Audio.AudioLayer)}, so a name and a rendered
+	 * pitch can never disagree.</p>
+	 *
+	 * @param layer the layer to name; may be {@code null}.
+	 * @return the note name, or empty when the layer carries no recoverable
+	 *         pitch — in which case the caller must supply its own distinguishing
+	 *         suffix, since names have to stay unique within a capture.
+	 */
+	public static Optional<String> capturedNoteName(Audio.AudioLayer layer) {
+		KeyPosition<?> position = capturedKeyPosition(layer);
+		if (position == null || position.position() < 0) return Optional.empty();
+
+		return Optional.of(MidiNotes.noteName(position.position() + MIDI_AT_POSITION_ZERO));
 	}
 
 	/**

--- a/studio/compose/src/test/java/org/almostrealism/studio/pattern/test/GroupNoteSourceChoicesRoundTripTest.java
+++ b/studio/compose/src/test/java/org/almostrealism/studio/pattern/test/GroupNoteSourceChoicesRoundTripTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2026 Michael Murray
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.almostrealism.studio.pattern.test;
+
+import org.almostrealism.audio.notes.NoteAudioGroup;
+import org.almostrealism.music.notes.GroupNoteSource;
+import org.almostrealism.music.notes.NoteAudioChoice;
+import org.almostrealism.music.pattern.NoteAudioChoiceList;
+import org.almostrealism.studio.AudioSceneLoader;
+import org.almostrealism.util.TestSuiteBase;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Guards the choices file (the persisted {@link NoteAudioChoiceList}, written
+ * as {@code pattern-factory.json}) against sources that cannot be read back.
+ *
+ * <p>The file is written on every scene save and read on every application
+ * start. {@link org.almostrealism.music.notes.NoteAudioSource} is serialized
+ * polymorphically by class name, so any source implementation that reaches a
+ * choice must survive a write/read cycle through
+ * {@link AudioSceneLoader#defaultMapper()}. A source that cannot fails the
+ * whole file: the reader aborts on the first unreadable entry, and the caller
+ * cannot recover the other choices from it.</p>
+ */
+public class GroupNoteSourceChoicesRoundTripTest extends TestSuiteBase {
+
+	/**
+	 * A choice carrying a {@link GroupNoteSource} must survive the write-then-read
+	 * cycle the choices file performs. The group source itself is derived from the
+	 * library rather than stored, so what must survive is the choice — the group
+	 * source is re-added by the code that assembled it.
+	 */
+	@Test(timeout = 60000)
+	public void choiceWithGroupSourceSurvivesChoicesFile() throws Exception {
+		NoteAudioChoice choice = new NoteAudioChoice();
+		choice.setName("Group Test");
+		choice.setSources(new ArrayList<>(
+				List.of(new GroupNoteSource(new NoteAudioGroup(List.of()), "test-group"))));
+
+		NoteAudioChoiceList choices = new NoteAudioChoiceList();
+		choices.add(choice);
+
+		File file = File.createTempFile("group-choices", ".json");
+		file.deleteOnExit();
+
+		AudioSceneLoader.defaultMapper().writeValue(file, choices);
+		String json = Files.readString(file.toPath());
+		log("choicesJson=" + json);
+
+		Assert.assertFalse("A derived group source was written into the choices file",
+				json.contains(GroupNoteSource.class.getName()));
+
+		NoteAudioChoiceList read = AudioSceneLoader.defaultMapper()
+				.readValue(file, NoteAudioChoiceList.class);
+
+		Assert.assertEquals("Choice count changed across the round trip",
+				1, read.size());
+		Assert.assertEquals("Choice name changed across the round trip",
+				"Group Test", read.get(0).getName());
+	}
+
+	/**
+	 * A choices file already containing a group source — written before those
+	 * were excluded — must still load, minus the entry that cannot be
+	 * constructed. Failing the whole read would discard every other choice the
+	 * user has configured.
+	 */
+	@Test(timeout = 60000)
+	public void unreadableStoredSourceDoesNotDiscardTheFile() throws Exception {
+		String poisoned = "[{\"name\":\"Legacy\",\"sources\":["
+				+ "{\"@type\":\"" + GroupNoteSource.class.getName() + "\",\"origin\":\"old-group\"}"
+				+ "]}]";
+
+		File file = File.createTempFile("legacy-choices", ".json");
+		file.deleteOnExit();
+		Files.writeString(file.toPath(), poisoned);
+
+		NoteAudioChoiceList read = AudioSceneLoader.defaultMapper()
+				.readValue(file, NoteAudioChoiceList.class);
+
+		Assert.assertEquals("A stored source that cannot be constructed discarded the file",
+				1, read.size());
+		Assert.assertEquals("Legacy", read.get(0).getName());
+		Assert.assertTrue("The unconstructable source was not dropped",
+				read.get(0).getSources().isEmpty());
+	}
+}

--- a/studio/compose/src/test/java/org/almostrealism/studio/pattern/test/GroupNoteSourceChoicesRoundTripTest.java
+++ b/studio/compose/src/test/java/org/almostrealism/studio/pattern/test/GroupNoteSourceChoicesRoundTripTest.java
@@ -38,9 +38,9 @@ import java.util.List;
  * start. {@link org.almostrealism.music.notes.NoteAudioSource} is serialized
  * polymorphically by class name, so any source implementation that reaches a
  * choice must survive a write/read cycle through
- * {@link AudioSceneLoader#defaultMapper()}. A source that cannot fails the
- * whole file: the reader aborts on the first unreadable entry, and the caller
- * cannot recover the other choices from it.</p>
+ * {@link AudioSceneLoader#defaultMapper()}. A source that does not survive one
+ * takes the whole file with it: the reader aborts on the first unreadable
+ * entry, and the caller cannot recover the other choices from it.</p>
  */
 public class GroupNoteSourceChoicesRoundTripTest extends TestSuiteBase {
 
@@ -77,6 +77,34 @@ public class GroupNoteSourceChoicesRoundTripTest extends TestSuiteBase {
 				1, read.size());
 		Assert.assertEquals("Choice name changed across the round trip",
 				"Group Test", read.get(0).getName());
+	}
+
+	/**
+	 * A stored source naming a class that no longer exists must be skipped like
+	 * any other unreadable entry. Type ids are class names, so renaming or
+	 * removing a source implementation turns every file that mentions it into
+	 * one the reader would otherwise refuse in full — the failure arrives long
+	 * after the change that caused it, in a file the user cannot repair.
+	 */
+	@Test(timeout = 60000)
+	public void unknownTypeIdDoesNotDiscardTheFile() throws Exception {
+		String poisoned = "[{\"name\":\"Legacy\",\"sources\":["
+				+ "{\"@type\":\"org.almostrealism.music.notes.RemovedNoteSource\","
+				+ "\"origin\":\"old\"}"
+				+ "]}]";
+
+		File file = File.createTempFile("removed-type-choices", ".json");
+		file.deleteOnExit();
+		Files.writeString(file.toPath(), poisoned);
+
+		NoteAudioChoiceList read = AudioSceneLoader.defaultMapper()
+				.readValue(file, NoteAudioChoiceList.class);
+
+		Assert.assertEquals("A stored source naming a removed class discarded the file",
+				1, read.size());
+		Assert.assertEquals("Legacy", read.get(0).getName());
+		Assert.assertTrue("The unresolvable source was not dropped",
+				read.get(0).getSources().isEmpty());
 	}
 
 	/**

--- a/studio/music/src/main/java/org/almostrealism/music/notes/GroupNoteSource.java
+++ b/studio/music/src/main/java/org/almostrealism/music/notes/GroupNoteSource.java
@@ -87,6 +87,22 @@ public class GroupNoteSource implements NoteAudioSource {
 	}
 
 	/**
+	 * A group source is rebuilt from the library's saved groups whenever a
+	 * choice is assembled, so it is never written with the scene.
+	 *
+	 * <p>The durable record of a group is its
+	 * {@link org.almostrealism.audio.api.Audio.AudioLayerGroup} in the group
+	 * store; this class is the render-side view of that record and holds live
+	 * member audio, which the scene has no business duplicating. It also has no
+	 * no-argument constructor, so a persisted entry could not be read back —
+	 * and one unreadable source aborts the read of every choice in the file.</p>
+	 *
+	 * @return {@code false}, always
+	 */
+	@Override
+	public boolean isPersistent() { return false; }
+
+	/**
 	 * A group source references no individual file path of its own; member files
 	 * are tracked as standalone library entries. Always returns {@code false}.
 	 *

--- a/studio/music/src/main/java/org/almostrealism/music/notes/NoteAudioChoice.java
+++ b/studio/music/src/main/java/org/almostrealism/music/notes/NoteAudioChoice.java
@@ -17,7 +17,9 @@
 package org.almostrealism.music.notes;
 import org.almostrealism.audio.notes.NoteAudio;
 
+import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonSetter;
 import io.almostrealism.relation.Validity;
 import org.almostrealism.audio.CellFeatures;
 import org.almostrealism.music.data.ParameterFunction;
@@ -35,6 +37,7 @@ import org.almostrealism.util.KeyUtils;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -198,14 +201,58 @@ public class NoteAudioChoice implements ConsoleFeatures {
 		this.name = name;
 	}
 
-	/** Returns the list of audio sources in this choice. */
+	/**
+	 * Returns the live list of audio sources in this choice, including any that
+	 * are derived from the library rather than saved with the scene.
+	 *
+	 * <p>This is the list the render path uses. It is not the list that is
+	 * written — see {@link #getPersistentSources()}.</p>
+	 */
+	@JsonIgnore
 	public List<NoteAudioSource> getSources() {
 		return sources;
 	}
 
-	/** Sets the list of audio sources for this choice. */
+	/**
+	 * Returns the sources written with the scene: those reporting
+	 * {@link NoteAudioSource#isPersistent()}.
+	 *
+	 * <p>Sources are serialized polymorphically by class name, so an entry that
+	 * cannot be reconstructed on read aborts the read of the whole choices file
+	 * and every choice in it is lost. Filtering here keeps derived sources —
+	 * which the assembling code re-adds anyway — out of the file entirely.</p>
+	 *
+	 * @return the persistent subset of {@link #getSources()}
+	 */
+	@JsonGetter("sources")
+	public List<NoteAudioSource> getPersistentSources() {
+		if (sources == null) return null;
+
+		return sources.stream()
+				.filter(NoteAudioSource::isPersistent)
+				.collect(Collectors.toList());
+	}
+
+	/**
+	 * Sets the list of audio sources for this choice, dropping {@code null}
+	 * entries.
+	 *
+	 * <p>A null can arrive from the reader when a stored source could not be
+	 * constructed and was skipped rather than being allowed to fail the whole
+	 * file (see {@code AudioSceneLoader.defaultMapper()}). Dropping it here
+	 * means the rest of the choice survives instead of failing later on a null
+	 * element.</p>
+	 */
+	@JsonSetter("sources")
 	public void setSources(List<NoteAudioSource> sources) {
-		this.sources = sources;
+		if (sources == null) {
+			this.sources = null;
+			return;
+		}
+
+		this.sources = sources.stream()
+				.filter(Objects::nonNull)
+				.collect(Collectors.toCollection(ArrayList::new));
 	}
 
 	/** Returns {@code true} if this choice is melodic (pitched). */

--- a/studio/music/src/main/java/org/almostrealism/music/notes/NoteAudioSource.java
+++ b/studio/music/src/main/java/org/almostrealism/music/notes/NoteAudioSource.java
@@ -65,6 +65,25 @@ public interface NoteAudioSource extends KeyboardTuned {
 	List<NoteAudio> getNotes();
 
 	/**
+	 * Returns whether this source belongs in a {@link NoteAudioChoice}'s saved
+	 * configuration.
+	 *
+	 * <p>Most sources describe themselves entirely by the fields they persist —
+	 * a path, a filter — and are restored by reading them back. A source that is
+	 * instead <em>derived</em> from the library each time a choice is assembled
+	 * has no such description: writing it produces either a duplicate of library
+	 * content or, worse, an entry that cannot be reconstructed on read. Because
+	 * {@link NoteAudioChoice#getSources() sources} are serialized polymorphically
+	 * by class name, a single unreadable entry aborts the read of the entire
+	 * choices file, taking every other choice with it. Derived sources therefore
+	 * return {@code false} and are re-added by whatever assembled them.</p>
+	 *
+	 * @return {@code true} if this source is written with the scene (the default)
+	 */
+	@JsonIgnore
+	default boolean isPersistent() { return true; }
+
+	/**
 	 * Returns {@code true} if any note in this source references the given file path.
 	 *
 	 * @param canonicalPath the canonical file path to check

--- a/studio/spatial/src/main/java/org/almostrealism/spatial/ArrangementGenerationProcess.java
+++ b/studio/spatial/src/main/java/org/almostrealism/spatial/ArrangementGenerationProcess.java
@@ -176,6 +176,15 @@ public class ArrangementGenerationProcess implements ConsoleFeatures, Destroyabl
 			iterationCount++;
 			if (completionListener != null) completionListener.run();
 		});
+
+		/* Builds the optimizer's output destinations. init() is the only place
+		   the master output file and the per-channel stem files are configured;
+		   without it every rendered arrangement reports no stems, because the
+		   stem WaveOutputs resolve to a null file and never record a path for
+		   the health score to carry. The standalone runner
+		   (AudioSceneOptimizer.run) calls this immediately after build() for the
+		   same reason. */
+		optimizer.init();
 	}
 
 	/**


### PR DESCRIPTION
A NoteAudioSource is serialized polymorphically by class name, and the choices file is a whole-file document holding every channel a user has configured, so a source that cannot be read back does not fail alone: the reader aborts on it and every other choice in the file is lost. GroupNoteSource was exactly that. It is constructed from a live NoteAudioGroup, has no no-argument constructor, and reached choices through the library's saved groups, so saving a group and reopening the application discarded the file.

NoteAudioSource.isPersistent distinguishes sources that describe themselves in the file from those derived from the library each time a choice is assembled. NoteAudioChoice serializes only the persistent subset through getPersistentSources, while getSources remains the live list the render path uses, and GroupNoteSource reports false: a group's durable record is its protobuf in the group store, and the scene has no business duplicating live member audio.

AudioSceneLoader's mapper now skips a stored entry it cannot construct rather than failing the read, so a file written before this change loads with the bad entry dropped instead of discarding the rest, and reports what it skipped. A problem handler is invoked partway through an object, so the parser is advanced to that object's end before returning; NoteAudioChoice drops the resulting null sources.

Group members can be stored under readable names. includeGroup takes an optional per-layer destination resolver, so the caller that owns the library's layout decides what a member is called and how clashes are handled, and content-addressed naming remains the fallback. A member already present in the library is referenced where it lies rather than copied under a second name, resolved through AudioLibrary.fileFor - the identifier-to-file lookup that makes filenames a presentation concern, since content is addressed by what it is rather than by what it is called.

AudioLayerPitch.capturedNoteName renders a layer's captured pitch as a note name, the per-member half of naming a captured set. It reads the same authoritative pitch as playback, so a member's name cannot disagree with what it plays.